### PR TITLE
Fix haskell justfile

### DIFF
--- a/build-support/haskell.just
+++ b/build-support/haskell.just
@@ -3,12 +3,12 @@ test:
 
 check-format:
     git ls-files -z '*.hs' | xargs -P 12 -0 fourmolu --mode check
-    cabal-gild --mode=check $(ls *.cabal)
+    cabal-gild --mode=check --input=$(ls *.cabal)
 
 check: check-format test
 
 format:
     git ls-files -z '*.hs' | xargs -P 12 -0 fourmolu --mode inplace
-    cabal-gild --mode=format $(ls *.cabal)
+    cabal-gild --io=$(ls *.cabal)
 
 fix: format


### PR DESCRIPTION
Currently the `build-support/haskell.just` file's `check` target fails because cabal-gild is used improperly. Owen fixed this in commit 6ad2925c8797, however this was then lost in a merge.