### PR TITLE
Remove stray reference to deleted `coln-do` package

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,7 +7,6 @@ packages:
 if !os(wasi)
   packages:
     packages/coln-manual-dev
-    packages/coln-do
     packages/coln-repl
     packages/coln-ls
     packages/coln-cli


### PR DESCRIPTION
Noticed this causing a (seemingly harmless) warning. Was missed in #90. cc @patrickaldis