### PR TITLE
Coln query/tuple support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 .vscode/
 .cursor/
 .idea/
+.zed/
 **/*.iml
 
 ## Bibliography auxiliary files (bibtex/biblatex/biber):

--- a/flake.nix
+++ b/flake.nix
@@ -25,6 +25,7 @@
 
         inherit (pkgs) colnHaskellPackages;
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [ "rust-src" "rust-analyzer" ];
           targets = [ "wasm32-unknown-unknown" ];
         };
 

--- a/flake.nix
+++ b/flake.nix
@@ -217,7 +217,6 @@
             cabal-install
             cabal2nix
             cargo-llvm-cov
-            clippy
             coln-manual-dev
             forester
             fourmolu

--- a/packages/coln-query/src/api/deltas.rs
+++ b/packages/coln-query/src/api/deltas.rs
@@ -15,7 +15,7 @@ pub type ZWeight = i64;
 /// see [`z_weight`](`Self::z_weight`) documentation.
 pub struct RowDelta {
     /// A ZWeight value ...
-    /// - `== 0` behaves as if there was no insertion happening at all.
+    /// - `== 0` behaves as if there was no change happening at all.
     /// - `n if n > 0` represents an insertion. If `n > 1` it is a duplicated
     ///   insertion, that is, the row is inserted n-times.
     /// - `n if n < 0` represents a deletion. If `n < 1` we remove the row

--- a/packages/coln-query/src/api/schema.rs
+++ b/packages/coln-query/src/api/schema.rs
@@ -19,7 +19,7 @@ pub struct TableSchema {
     /// All fields of the table in their physical order.
     columns: Vec<Column>,
     /// The list of (possibly compound) primary keys into the table, specified
-    /// as indices into the [`header`](Self::header).
+    /// as indices into the [`columns`](Self::columns).
     primary_keys: Vec<Vec<usize>>,
 }
 

--- a/packages/coln-query/src/dbsp/playground.rs
+++ b/packages/coln-query/src/dbsp/playground.rs
@@ -756,10 +756,7 @@ type WeightedEdge = Tup3<NodeId, NodeId, Weight>;
 type Path = Tup4<NodeId, NodeId, CumWeight, Hopcnt>;
 
 #[allow(clippy::type_complexity)]
-fn trans_closure_data() -> (
-    Vec<Vec<Tup2<WeightedEdge, ZWeight>>>,
-    Vec<OrdZSet<Path>>,
-) {
+fn trans_closure_data() -> (Vec<Vec<Tup2<WeightedEdge, ZWeight>>>, Vec<OrdZSet<Path>>) {
     let edges_input = vec![
         // The first clock cycle adds a graph of four nodes:
         // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
@@ -819,34 +816,32 @@ fn test_self_rec_trans_closure_recursive() -> Result<(), anyhow::Error> {
             let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
 
             let closure = root_circuit.recursive(
-            |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Path>>| {
-                // Import the `edges` and `len_1` relation from the parent circuit.
-                let edges = edges.delta0(child_circuit);
-                let len_1 = len_1.delta0(child_circuit);
+                |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Path>>| {
+                    // Import the `edges` and `len_1` relation from the parent circuit.
+                    let edges = edges.delta0(child_circuit);
+                    let len_1 = len_1.delta0(child_circuit);
 
-                // Perform an iterative step (n-1 to n) through joining the
-                // paths of length n-1 with the edges.
-                let len_n = len_n_minus_1
-                    .map_index(|Tup4(start, end, cum_weight, hopcnt)| {
-                        (
-                            *end,
-                            Tup4(*start, *end, *cum_weight, *hopcnt),
+                    // Perform an iterative step (n-1 to n) through joining the
+                    // paths of length n-1 with the edges.
+                    let len_n = len_n_minus_1
+                        .map_index(|Tup4(start, end, cum_weight, hopcnt)| {
+                            (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                        })
+                        .join(
+                            &edges.map_index(|Tup3(from, to, weight)| {
+                                (*from, Tup3(*from, *to, *weight))
+                            }),
+                            |_end_from,
+                             Tup4(start, _end, cum_weight, hopcnt),
+                             Tup3(_from, to, weight)| {
+                                Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
+                            },
                         )
-                    })
-                    .join(
-                        &edges.map_index(|Tup3(from, to, weight)| {
-                            (*from, Tup3(*from, *to, *weight))
-                        }),
-                        |_end_from,
-                         Tup4(start, _end, cum_weight, hopcnt),
-                         Tup3(_from, to, weight)| {
-                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
-                        },
-                    ).plus(&len_1);
+                        .plus(&len_1);
 
-                Ok(len_n)
-            },
-        )?;
+                    Ok(len_n)
+                },
+            )?;
 
             Ok((edges_input, closure.accumulate_output()))
         })?;
@@ -887,10 +882,8 @@ fn test_self_rec_trans_closure_iterate() -> Result<(), anyhow::Error> {
 
             let closure = root_circuit.iterate_with_condition(|child_circuit| {
                 // Feedback carries only the frontier (the delta from the last step).
-                let (frontier, frontier_feedback) = child_circuit
-                    .add_feedback(Z1::new(
-                        OrdZSet::<Path>::default(),
-                    ));
+                let (frontier, frontier_feedback) =
+                    child_circuit.add_feedback(Z1::new(OrdZSet::<Path>::default()));
 
                 // delta0 fires only at inner step 0, injecting the base case exactly once.
                 let edges_inner = edges.delta0(child_circuit);

--- a/packages/coln-query/src/dbsp/playground.rs
+++ b/packages/coln-query/src/dbsp/playground.rs
@@ -748,16 +748,23 @@ fn test_factorial_with_iterate() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+type NodeId = u64;
+type Weight = u64;
+type CumWeight = u64;
+type Hopcnt = u64;
+type WeightedEdge = Tup3<NodeId, NodeId, Weight>;
+type Path = Tup4<NodeId, NodeId, CumWeight, Hopcnt>;
+
 #[allow(clippy::type_complexity)]
 fn trans_closure_data() -> (
-    Vec<Vec<Tup2<Tup3<usize, usize, usize>, ZWeight>>>,
-    Vec<OrdZSet<Tup4<usize, usize, usize, usize>>>,
+    Vec<Vec<Tup2<WeightedEdge, ZWeight>>>,
+    Vec<OrdZSet<Path>>,
 ) {
     let edges_input = vec![
         // The first clock cycle adds a graph of four nodes:
         // |0| -1-> |1| -1-> |2| -2-> |3| -2-> |4|
         vec![
-            Tup2(Tup3(0_usize, 1_usize, 1_usize), 1_i64),
+            Tup2(Tup3(0, 1, 1), 1),
             Tup2(Tup3(1, 2, 1), 1),
             Tup2(Tup3(2, 3, 2), 1),
             Tup2(Tup3(3, 4, 2), 1),
@@ -775,7 +782,7 @@ fn trans_closure_data() -> (
     ];
     let expected_output = vec![
         zset! {
-            Tup4(0_usize, 1_usize, 1_usize, 1_usize) => 1,
+            Tup4(0, 1, 1, 1) => 1,
             Tup4(0, 2, 2, 2) => 1,
             Tup4(0, 3, 4, 3) => 1,
             Tup4(0, 4, 6, 4) => 1,
@@ -812,7 +819,7 @@ fn test_self_rec_trans_closure_recursive() -> Result<(), anyhow::Error> {
             let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
 
             let closure = root_circuit.recursive(
-            |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Tup4<usize, usize, usize, usize>>>| {
+            |child_circuit, len_n_minus_1: Stream<_, OrdZSet<Path>>| {
                 // Import the `edges` and `len_1` relation from the parent circuit.
                 let edges = edges.delta0(child_circuit);
                 let len_1 = len_1.delta0(child_circuit);
@@ -874,7 +881,7 @@ fn test_self_rec_trans_closure_iterate() -> Result<(), anyhow::Error> {
             // Create a base relation with all paths of length 1.
             let len_1 = edges.map(|Tup3(from, to, weight)| Tup4(*from, *to, *weight, 1));
 
-            // Safety measure to prevent infinite iterations.
+            // Maximum recursion/iteration depth.
             const MAX_ITERATIONS: usize = 128;
             let iteration_count = Rc::new(RefCell::new(0));
 
@@ -882,7 +889,7 @@ fn test_self_rec_trans_closure_iterate() -> Result<(), anyhow::Error> {
                 // Feedback carries only the frontier (the delta from the last step).
                 let (frontier, frontier_feedback) = child_circuit
                     .add_feedback(Z1::new(
-                        OrdZSet::<Tup4<usize, usize, usize, usize>>::default(),
+                        OrdZSet::<Path>::default(),
                     ));
 
                 // delta0 fires only at inner step 0, injecting the base case exactly once.
@@ -892,20 +899,22 @@ fn test_self_rec_trans_closure_iterate() -> Result<(), anyhow::Error> {
                 // Extend the frontier by one hop.
                 // At step 0: frontier={}, so the result is just len_1_inner, the base case.
                 // At step n with n > 0: len_1_inner={}, so it's purely frontier ⋈ edges.
-                let new_frontier = frontier
-                    .map_index(move |Tup4(start, end, cum_weight, hopcnt)| {
-                        (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
-                    })
-                    .join(
-                        &edges_inner
-                            .map_index(|Tup3(from, to, weight)| (*from, Tup3(*from, *to, *weight))),
-                        |_end_from,
-                         Tup4(start, _end, cum_weight, hopcnt),
-                         Tup3(_from, to, weight)| {
-                            Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
-                        },
-                    )
-                    .plus(&len_1_inner);
+                let new_frontier = len_1_inner.plus(
+                    &frontier
+                        .map_index(move |Tup4(start, end, cum_weight, hopcnt)| {
+                            (*end, Tup4(*start, *end, *cum_weight, *hopcnt))
+                        })
+                        .join(
+                            &edges_inner.map_index(|Tup3(from, to, weight)| {
+                                (*from, Tup3(*from, *to, *weight))
+                            }),
+                            |_end_from,
+                             Tup4(start, _end, cum_weight, hopcnt),
+                             Tup3(_from, to, weight)| {
+                                Tup4(*start, *to, cum_weight + weight, hopcnt + 1)
+                            },
+                        ),
+                );
 
                 frontier_feedback.connect(&new_frontier);
 
@@ -951,17 +960,20 @@ fn test_self_rec_trans_closure_iterate() -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+type Edge = Tup2<usize, usize>;
+type Node = usize;
+
 #[allow(clippy::type_complexity)]
 fn graph_color_data() -> (
-    Vec<Vec<Tup2<usize, ZWeight>>>,
-    Vec<Vec<Tup2<Tup2<usize, usize>, ZWeight>>>,
-    Vec<OrdZSet<usize>>,
-    Vec<OrdZSet<usize>>,
+    Vec<Vec<Tup2<Node, ZWeight>>>,
+    Vec<Vec<Tup2<Edge, ZWeight>>>,
+    Vec<OrdZSet<Node>>,
+    Vec<OrdZSet<Node>>,
 ) {
     let init_data = vec![vec![Tup2(0, 1)], vec![], vec![]];
 
     let edges_data = vec![
-        // The first clock cycle adds a graph of four nodes:
+        // The first step adds a graph of four nodes:
         // |0| --> |1| --> |2| --> |3| --> |4|
         vec![
             Tup2(Tup2(0, 1), 1),
@@ -969,13 +981,14 @@ fn graph_color_data() -> (
             Tup2(Tup2(2, 3), 1),
             Tup2(Tup2(3, 4), 1),
         ],
-        // In total, we have the following graph:
+        // Now, we have the following graph in total:
         // |0| --> |1| --> |2| --> |3| --> |4|
         //  ^               |
         //  |               |
         //  ------ |5| <-----
         vec![Tup2(Tup2(2, 5), 1), Tup2(Tup2(5, 0), 1)],
-        // TODO: Odd-length cycle, destroying bipartite property.
+        // And we introduce an odd-length cycle, rendering the graph
+        // non-biparite anymore (all nodes are red _and_ blue):
         // |0| --> |1| --> |2| --> |3| --> |4|
         //  ^               |               |
         //  |               |               |
@@ -1025,27 +1038,21 @@ fn graph_color_data() -> (
 /// This does mutual recursion of graph coloring using the recursive() method.
 // TODO and open questions:
 // - How to add a recursion/iteration depth limit with recursive()?
-// - How can the second arg to recursive() be variadic in the amount of recursive streams?
-//   I think it requires `impl RecursiveStreams for Vec<Stream>` which is
-//   marked as TODO in the DBSP source (see `recursive.rs`).
+// - Rewrite using `recursive_dynamic` once your PR got merged
 #[test]
 fn test_mutual_rec_graph_color_recursive() -> Result<(), anyhow::Error> {
     const STEPS: usize = 3;
 
     let (mut circuit_handle, ((init_input, edges_input), (red_output, blue_output))) =
         Runtime::init_circuit(worker_threads(), move |root_circuit| {
-            let (edges, edges_input) = root_circuit.add_input_zset::<Tup2<usize, usize>>();
-            let (init, init_input) = root_circuit.add_input_zset::<usize>();
-
-            // Safety measure to prevent infinite iterations.
-            const MAX_ITERATIONS: usize = 128;
-            let iteration_count = Rc::new(RefCell::new(0));
+            let (edges, edges_input) = root_circuit.add_input_zset::<Edge>();
+            let (init, init_input) = root_circuit.add_input_zset::<Node>();
 
             let (red, blue) = root_circuit.recursive(
                 |child_circuit,
                  (red, blue): (
-                    Stream<NestedCircuit, OrdZSet<usize>>,
-                    Stream<NestedCircuit, OrdZSet<usize>>,
+                    Stream<NestedCircuit, OrdZSet<Node>>,
+                    Stream<NestedCircuit, OrdZSet<Node>>,
                 )| {
                     // delta0 fires only at inner step 0, injecting the base case exactly once.
                     let edges = edges.delta0(child_circuit);
@@ -1114,8 +1121,8 @@ fn test_mutual_rec_graph_color_iterate() {
 
     let (mut circuit_handle, ((init_input, edges_input), (red_output, blue_output))) =
         Runtime::init_circuit(1, move |root_circuit| {
-            let (edges, edges_input) = root_circuit.add_input_zset::<Tup2<usize, usize>>();
-            let (init, init_input) = root_circuit.add_input_zset::<usize>();
+            let (edges, edges_input) = root_circuit.add_input_zset::<Edge>();
+            let (init, init_input) = root_circuit.add_input_zset::<Node>();
 
             // Safety measure to prevent infinite iterations.
             const MAX_ITERATIONS: usize = 128;

--- a/packages/coln-query/src/dbsp/wrapper.rs
+++ b/packages/coln-query/src/dbsp/wrapper.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     expr::{Literal, LiteralExpr},
-    relation::{Relation, RelationSchema, SchemaTuple, TupleKey, TupleValue},
+    relation::{Relation, RelationRef, RelationSchema, SchemaTuple, TupleKey, TupleValue},
 };
 use cli_table::{Cell, Style, Table, format::Justify};
 pub use dbsp::{
@@ -223,6 +223,21 @@ impl DbspInput {
     pub fn handle(&self) -> &OrdIndexedStreamInputHandle {
         &self.handle
     }
+    pub fn insert_consume<T: Into<TupleKey> + Into<TupleValue> + Clone>(
+        &self,
+        tuples: impl IntoIterator<Item = (T, ZWeight)>,
+    ) {
+        let mut delta_batch = tuples
+            .into_iter()
+            .map(|(data, zweight)| {
+                Tup2(
+                    Into::<TupleKey>::into(data.clone()),
+                    Tup2(Into::<TupleValue>::into(data), zweight),
+                )
+            })
+            .collect();
+        self.handle.append(&mut delta_batch);
+    }
     pub fn insert<'a, T: Into<TupleKey> + Into<TupleValue> + Clone + 'a>(
         &self,
         tuples: impl IntoIterator<Item = (&'a T, ZWeight)>,
@@ -264,6 +279,15 @@ impl DbspOutput {
             schema: &self.schema,
             inner,
         }
+    }
+}
+
+impl From<RelationRef> for DbspOutput {
+    fn from(relation: RelationRef) -> Self {
+        let relation = relation.borrow();
+        let schema = relation.schema.clone();
+        let handle = relation.inner.output();
+        Self { schema, handle }
     }
 }
 

--- a/packages/coln-query/src/error.rs
+++ b/packages/coln-query/src/error.rs
@@ -8,12 +8,18 @@ use thiserror::Error;
 #[derive(Error, Debug, Clone, PartialEq, Eq)]
 /// Public error type for any Incremental Datalog error.
 pub enum IncLogError {
+    /// An error that occurs during parsing or static analysis at compile time.
     #[error(transparent)]
     Syntax(#[from] SyntaxError),
+    /// An error that occurs during an optimization pass prior to runtime.
     #[error(transparent)]
     Optimization(#[from] OptimizationError),
+    /// An error which occurs during runtime of the circuit constructing,
+    /// tree-walk interpreter.
     #[error(transparent)]
     Engine(#[from] EngineError),
+    /// An error that occurs during runtime of the underlying (incremental)
+    /// query execution engine (currently only DBSP).
     #[error(transparent)]
     Runtime(#[from] RuntimeError),
 }
@@ -53,9 +59,10 @@ impl OptimizationError {
 #[error("{message}")]
 /// An error which occurs during runtime of the circuit constructing,
 /// tree-walk interpreter.
-// TODO: Instead of being generic, we could introduce:
+// TODO: Instead of being general, we could introduce:
 // - a type error
 // - a reference error
+// - ... ?
 pub struct EngineError {
     message: String,
 }

--- a/packages/coln-query/src/expr.rs
+++ b/packages/coln-query/src/expr.rs
@@ -14,12 +14,13 @@ use std::fmt::{self, Debug, Display};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Expr {
+    Literal(Box<LiteralExpr>),
+    Tuple(Box<TupleExpr>),
+    Grouping(Box<GroupingExpr>),
     Binary(Box<BinaryExpr>),
     Unary(Box<UnaryExpr>),
-    Grouping(Box<GroupingExpr>),
     Var(Box<VarExpr>),
     Assign(Box<AssignExpr>),
-    Literal(Box<LiteralExpr>),
     Call(Box<CallExpr>),
     Function(Box<FunctionExpr>),
     Alias(Box<AliasExpr>),
@@ -36,12 +37,13 @@ pub enum Expr {
 
 impl_from_auto_box! {
     Expr,
+    (Expr::Literal, LiteralExpr),
+    (Expr::Tuple, TupleExpr),
+    (Expr::Grouping, GroupingExpr),
     (Expr::Binary, BinaryExpr),
     (Expr::Unary, UnaryExpr),
-    (Expr::Grouping, GroupingExpr),
     (Expr::Var, VarExpr),
     (Expr::Assign, AssignExpr),
-    (Expr::Literal, LiteralExpr),
     (Expr::Call, CallExpr),
     (Expr::Function, FunctionExpr),
     (Expr::Alias, AliasExpr),
@@ -57,6 +59,29 @@ impl_from_auto_box! {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LiteralExpr {
+    pub value: Literal,
+}
+
+impl<T: Into<Literal>> From<T> for LiteralExpr {
+    fn from(value: T) -> Self {
+        Self {
+            value: value.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TupleExpr {
+    pub elements: Vec<Expr>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GroupingExpr {
+    pub expr: Expr,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct BinaryExpr {
     pub operator: Operator,
     pub left: Expr,
@@ -67,11 +92,6 @@ pub struct BinaryExpr {
 pub struct UnaryExpr {
     pub operator: Operator,
     pub operand: Expr,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct GroupingExpr {
-    pub expr: Expr,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -127,19 +147,6 @@ impl Resolvable for AssignExpr {
 impl Named for AssignExpr {
     fn name(&self) -> &str {
         &self.name
-    }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LiteralExpr {
-    pub value: Literal,
-}
-
-impl<T: Into<Literal>> From<T> for LiteralExpr {
-    fn from(value: T) -> Self {
-        Self {
-            value: value.into(),
-        }
     }
 }
 
@@ -386,12 +393,13 @@ impl Display for Literal {
 pub trait ExprVisitor<T, C> {
     fn visit_expr(&mut self, expr: &Expr, ctx: C) -> T {
         match expr {
+            Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
+            Expr::Tuple(expr) => self.visit_tuple_expr(expr, ctx),
+            Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(expr, ctx),
-            Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Var(expr) => self.visit_var_expr(expr, ctx),
             Expr::Assign(expr) => self.visit_assign_expr(expr, ctx),
-            Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
             Expr::Function(expr) => self.visit_function_expr(expr, ctx),
             Expr::Call(expr) => self.visit_call_expr(expr, ctx),
             Expr::Alias(expr) => self.visit_alias_expr(expr, ctx),
@@ -406,12 +414,13 @@ pub trait ExprVisitor<T, C> {
             Expr::FixedPointIter(expr) => self.visit_fixed_point_iter_expr(expr, ctx),
         }
     }
+    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: C) -> T;
+    fn visit_tuple_expr(&mut self, expr: &TupleExpr, ctx: C) -> T;
+    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: &BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: &UnaryExpr, ctx: C) -> T;
-    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: C) -> T;
     fn visit_var_expr(&mut self, expr: &VarExpr, ctx: C) -> T;
     fn visit_assign_expr(&mut self, expr: &AssignExpr, ctx: C) -> T;
-    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: C) -> T;
     fn visit_function_expr(&mut self, expr: &FunctionExpr, ctx: C) -> T;
     fn visit_call_expr(&mut self, expr: &CallExpr, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: &AliasExpr, ctx: C) -> T;
@@ -429,12 +438,13 @@ pub trait ExprVisitor<T, C> {
 pub trait ExprVisitorMut<T, C> {
     fn visit_expr(&mut self, expr: &mut Expr, ctx: C) -> T {
         match expr {
+            Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
+            Expr::Tuple(expr) => self.visit_tuple_expr(expr, ctx),
+            Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(expr, ctx),
-            Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Var(expr) => self.visit_var_expr(expr, ctx),
             Expr::Assign(expr) => self.visit_assign_expr(expr, ctx),
-            Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
             Expr::Function(expr) => self.visit_function_expr(expr, ctx),
             Expr::Call(expr) => self.visit_call_expr(expr, ctx),
             Expr::Alias(expr) => self.visit_alias_expr(expr, ctx),
@@ -449,12 +459,13 @@ pub trait ExprVisitorMut<T, C> {
             Expr::FixedPointIter(expr) => self.visit_fixed_point_iter_expr(expr, ctx),
         }
     }
+    fn visit_literal_expr(&mut self, expr: &mut LiteralExpr, ctx: C) -> T;
+    fn visit_tuple_expr(&mut self, expr: &mut TupleExpr, ctx: C) -> T;
+    fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: &mut BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: &mut UnaryExpr, ctx: C) -> T;
-    fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: C) -> T;
     fn visit_var_expr(&mut self, expr: &mut VarExpr, ctx: C) -> T;
     fn visit_assign_expr(&mut self, expr: &mut AssignExpr, ctx: C) -> T;
-    fn visit_literal_expr(&mut self, expr: &mut LiteralExpr, ctx: C) -> T;
     fn visit_function_expr(&mut self, expr: &mut FunctionExpr, ctx: C) -> T;
     fn visit_call_expr(&mut self, expr: &mut CallExpr, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: &mut AliasExpr, ctx: C) -> T;
@@ -472,12 +483,13 @@ pub trait ExprVisitorMut<T, C> {
 pub trait ExprVisitorOwn<T, C> {
     fn visit_expr(&mut self, expr: Expr, ctx: C) -> T {
         match expr {
+            Expr::Literal(expr) => self.visit_literal_expr(*expr, ctx),
+            Expr::Tuple(expr) => self.visit_tuple_expr(*expr, ctx),
+            Expr::Grouping(expr) => self.visit_grouping_expr(*expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(*expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(*expr, ctx),
-            Expr::Grouping(expr) => self.visit_grouping_expr(*expr, ctx),
             Expr::Var(expr) => self.visit_var_expr(*expr, ctx),
             Expr::Assign(expr) => self.visit_assign_expr(*expr, ctx),
-            Expr::Literal(expr) => self.visit_literal_expr(*expr, ctx),
             Expr::Function(expr) => self.visit_function_expr(*expr, ctx),
             Expr::Call(expr) => self.visit_call_expr(*expr, ctx),
             Expr::Alias(expr) => self.visit_alias_expr(*expr, ctx),
@@ -492,12 +504,13 @@ pub trait ExprVisitorOwn<T, C> {
             Expr::FixedPointIter(expr) => self.visit_fixed_point_iter_expr(*expr, ctx),
         }
     }
+    fn visit_literal_expr(&mut self, expr: LiteralExpr, ctx: C) -> T;
+    fn visit_tuple_expr(&mut self, expr: TupleExpr, ctx: C) -> T;
+    fn visit_grouping_expr(&mut self, expr: GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: UnaryExpr, ctx: C) -> T;
-    fn visit_grouping_expr(&mut self, expr: GroupingExpr, ctx: C) -> T;
     fn visit_var_expr(&mut self, expr: VarExpr, ctx: C) -> T;
     fn visit_assign_expr(&mut self, expr: AssignExpr, ctx: C) -> T;
-    fn visit_literal_expr(&mut self, expr: LiteralExpr, ctx: C) -> T;
     fn visit_function_expr(&mut self, expr: FunctionExpr, ctx: C) -> T;
     fn visit_call_expr(&mut self, expr: CallExpr, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: AliasExpr, ctx: C) -> T;
@@ -513,12 +526,13 @@ pub trait ExprVisitorOwn<T, C> {
 }
 
 impl MemAddr for Expr {}
+impl MemAddr for LiteralExpr {}
+impl MemAddr for TupleExpr {}
+impl MemAddr for GroupingExpr {}
 impl MemAddr for BinaryExpr {}
 impl MemAddr for UnaryExpr {}
-impl MemAddr for GroupingExpr {}
 impl MemAddr for VarExpr {}
 impl MemAddr for AssignExpr {}
-impl MemAddr for LiteralExpr {}
 impl MemAddr for FunctionExpr {}
 impl MemAddr for CallExpr {}
 impl MemAddr for AliasExpr {}

--- a/packages/coln-query/src/expr.rs
+++ b/packages/coln-query/src/expr.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Debug, Display};
 pub enum Expr {
     Literal(Box<LiteralExpr>),
     Tuple(Box<TupleExpr>),
+    GetIndex(Box<GetIndexExpr>),
     Grouping(Box<GroupingExpr>),
     Binary(Box<BinaryExpr>),
     Unary(Box<UnaryExpr>),
@@ -39,6 +40,7 @@ impl_from_auto_box! {
     Expr,
     (Expr::Literal, LiteralExpr),
     (Expr::Tuple, TupleExpr),
+    (Expr::GetIndex, GetIndexExpr),
     (Expr::Grouping, GroupingExpr),
     (Expr::Binary, BinaryExpr),
     (Expr::Unary, UnaryExpr),
@@ -74,6 +76,12 @@ impl<T: Into<Literal>> From<T> for LiteralExpr {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TupleExpr {
     pub elements: Vec<Expr>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct GetIndexExpr {
+    pub target: Expr,
+    pub index: Expr,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -395,6 +403,7 @@ pub trait ExprVisitor<T, C> {
         match expr {
             Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
             Expr::Tuple(expr) => self.visit_tuple_expr(expr, ctx),
+            Expr::GetIndex(expr) => self.visit_get_index_expr(expr, ctx),
             Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(expr, ctx),
@@ -416,6 +425,7 @@ pub trait ExprVisitor<T, C> {
     }
     fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: C) -> T;
     fn visit_tuple_expr(&mut self, expr: &TupleExpr, ctx: C) -> T;
+    fn visit_get_index_expr(&mut self, expr: &GetIndexExpr, ctx: C) -> T;
     fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: &BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: &UnaryExpr, ctx: C) -> T;
@@ -440,6 +450,7 @@ pub trait ExprVisitorMut<T, C> {
         match expr {
             Expr::Literal(expr) => self.visit_literal_expr(expr, ctx),
             Expr::Tuple(expr) => self.visit_tuple_expr(expr, ctx),
+            Expr::GetIndex(expr) => self.visit_get_index_expr(expr, ctx),
             Expr::Grouping(expr) => self.visit_grouping_expr(expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(expr, ctx),
@@ -461,6 +472,7 @@ pub trait ExprVisitorMut<T, C> {
     }
     fn visit_literal_expr(&mut self, expr: &mut LiteralExpr, ctx: C) -> T;
     fn visit_tuple_expr(&mut self, expr: &mut TupleExpr, ctx: C) -> T;
+    fn visit_get_index_expr(&mut self, expr: &mut GetIndexExpr, ctx: C) -> T;
     fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: &mut BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: &mut UnaryExpr, ctx: C) -> T;
@@ -485,6 +497,7 @@ pub trait ExprVisitorOwn<T, C> {
         match expr {
             Expr::Literal(expr) => self.visit_literal_expr(*expr, ctx),
             Expr::Tuple(expr) => self.visit_tuple_expr(*expr, ctx),
+            Expr::GetIndex(expr) => self.visit_get_index_expr(*expr, ctx),
             Expr::Grouping(expr) => self.visit_grouping_expr(*expr, ctx),
             Expr::Binary(expr) => self.visit_binary_expr(*expr, ctx),
             Expr::Unary(expr) => self.visit_unary_expr(*expr, ctx),
@@ -506,6 +519,7 @@ pub trait ExprVisitorOwn<T, C> {
     }
     fn visit_literal_expr(&mut self, expr: LiteralExpr, ctx: C) -> T;
     fn visit_tuple_expr(&mut self, expr: TupleExpr, ctx: C) -> T;
+    fn visit_get_index_expr(&mut self, expr: GetIndexExpr, ctx: C) -> T;
     fn visit_grouping_expr(&mut self, expr: GroupingExpr, ctx: C) -> T;
     fn visit_binary_expr(&mut self, expr: BinaryExpr, ctx: C) -> T;
     fn visit_unary_expr(&mut self, expr: UnaryExpr, ctx: C) -> T;

--- a/packages/coln-query/src/function.rs
+++ b/packages/coln-query/src/function.rs
@@ -69,3 +69,9 @@ pub struct FunctionType {
     // TODO: parameters' type
     pub return_type: Box<ExprType>,
 }
+
+impl Display for FunctionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "<fn -> {}>", self.return_type)
+    }
+}

--- a/packages/coln-query/src/interpreter.rs
+++ b/packages/coln-query/src/interpreter.rs
@@ -9,8 +9,8 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitor, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, UnaryExpr,
-        UnionExpr, VarExpr,
+        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
+        UnaryExpr, UnionExpr, VarExpr,
     },
     function::new_function,
     operator::Operator,
@@ -21,6 +21,7 @@ use crate::{
     },
     relation::{Relation, RelationRef, SchemaTuple, TupleKey, TupleValue, new_relation},
     stmt::{BlockStmt, ExprStmt, Stmt, StmtVisitor, VarStmt},
+    tuple::Tuple,
     variable::{Environment, Value},
 };
 use std::{cell::Ref, rc::Rc};
@@ -183,6 +184,26 @@ type VisitorCtx<'a, 'b> = &'a mut InterpreterContext<'b>;
 type ExprVisitorResult = Result<Value, EngineError>;
 
 impl ExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>> for Interpreter {
+    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: VisitorCtx) -> ExprVisitorResult {
+        // Maybe make values reference counted instead of cloning here?
+        let literal = expr.value.clone();
+        Ok(Value::from(literal))
+    }
+
+    fn visit_tuple_expr(&mut self, expr: &TupleExpr, ctx: VisitorCtx<'_, '_>) -> ExprVisitorResult {
+        let values = expr
+            .elements
+            .iter()
+            .map(|expr| self.visit_expr(expr, ctx))
+            .collect::<Result<Vec<Value>, _>>()?;
+
+        Ok(Value::from(Tuple::from(values)))
+    }
+
+    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> ExprVisitorResult {
+        self.visit_expr(&expr.expr, ctx)
+    }
+
     fn visit_binary_expr(&mut self, expr: &BinaryExpr, ctx: VisitorCtx) -> ExprVisitorResult {
         if let Operator::And | Operator::Or = expr.operator {
             self.visit_lazy_binary_expr(expr, ctx)
@@ -207,10 +228,6 @@ impl ExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>> for Interpreter {
                 expr.operator
             ))),
         }
-    }
-
-    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> ExprVisitorResult {
-        self.visit_expr(&expr.expr, ctx)
     }
 
     fn visit_var_expr(&mut self, expr: &VarExpr, ctx: VisitorCtx) -> ExprVisitorResult {
@@ -241,11 +258,6 @@ impl ExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>> for Interpreter {
                 .unwrap_or_else(|| panic!("Unresolved variable '{name}'."));
             ctx.environment.assign_var(resolved, value.clone());
         })
-    }
-
-    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: VisitorCtx) -> ExprVisitorResult {
-        // Maybe make values reference counted instead of cloning here?
-        Ok(Value::from(expr.value.clone()))
     }
 
     fn visit_function_expr(&mut self, expr: &FunctionExpr, ctx: VisitorCtx) -> ExprVisitorResult {

--- a/packages/coln-query/src/interpreter.rs
+++ b/packages/coln-query/src/interpreter.rs
@@ -9,8 +9,8 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitor, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
-        UnaryExpr, UnionExpr, VarExpr,
+        FunctionExpr, GetIndexExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr,
+        TupleExpr, UnaryExpr, UnionExpr, VarExpr,
     },
     function::new_function,
     operator::Operator,
@@ -198,6 +198,44 @@ impl ExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>> for Interpreter {
             .collect::<Result<Vec<Value>, _>>()?;
 
         Ok(Value::from(Tuple::from(values)))
+    }
+
+    fn visit_get_index_expr(
+        &mut self,
+        expr: &GetIndexExpr,
+        ctx: VisitorCtx<'_, '_>,
+    ) -> ExprVisitorResult {
+        let target = self.visit_expr(&expr.target, ctx)?;
+        let index = self.visit_expr(&expr.index, ctx)?;
+
+        if let Value::Uint(idx) = index {
+            match target {
+                Value::Tuple(tuple) => {
+                    let idx = idx as usize;
+                    let tuple_len = tuple.len();
+                    if idx < tuple_len {
+                        Ok(tuple.get(idx).clone())
+                    } else {
+                        Err(EngineError::new(format!(
+                            "{} at index {idx} is out of bounds.",
+                            tuple.display_compact()
+                        )))
+                    }
+                }
+                // Extend here to handle arrays, string indexing, etc.
+                _ =>
+                // If the type checker is used this case is actually unreachable.
+                {
+                    Err(EngineError::new(format!(
+                        "Invalid index operation on {target}."
+                    )))
+                }
+            }
+        } else {
+            Err(EngineError::new(format!(
+                "Index {index} does not evaluate to an uint"
+            )))
+        }
     }
 
     fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> ExprVisitorResult {

--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -21,6 +21,7 @@ mod runtime;
 pub mod scalar;
 pub mod stmt;
 pub mod test_helper;
+mod tuple;
 pub mod type_resolver;
 mod util;
 pub mod variable;

--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -127,7 +127,7 @@ impl<O: Optimizer + Send + 'static> IncDataLog<O> {
     pub fn build_circuit_from_ir<F, Code>(
         &self,
         intermediate_representation: F,
-    ) -> Result<(DbspHandle, DbspInputs, DbspOutput), IncLogError>
+    ) -> Result<(DbspHandle, DbspInputs, Vec<DbspOutput>), IncLogError>
     where
         Code: IntoIterator<Item = Stmt>,
         F: Fn(&mut RootCircuit, &mut DbspInputs) -> Result<Code, SyntaxError>
@@ -155,7 +155,7 @@ impl<O: Optimizer + Send + 'static> IncDataLog<O> {
     pub fn build_circuit_from_parser<F>(
         &self,
         parser: F,
-    ) -> Result<(DbspHandle, DbspInputs, DbspOutput), IncLogError>
+    ) -> Result<(DbspHandle, DbspInputs, Vec<DbspOutput>), IncLogError>
     where
         F: Fn(&mut RootCircuit) -> Result<(DbspInputs, Code), SyntaxError> + Clone + Send + 'static,
     {
@@ -177,19 +177,38 @@ impl<O: Optimizer + Send + 'static> IncDataLog<O> {
         root_circuit: &mut RootCircuit,
         inputs: DbspInputs,
         program: Code,
-    ) -> Result<(DbspInputs, DbspOutput), EngineError> {
+    ) -> Result<(DbspInputs, Vec<DbspOutput>), EngineError> {
         let output = IncLog::with_recursion(root_circuit.clone()).execute(program);
 
         let output = match output {
             Ok(Some(Value::Relation(relation))) => {
-                let relation = relation.borrow();
-                let output_handle = relation.inner.output();
-                let output_schema = relation.schema.clone();
-                DbspOutput::new(output_schema, output_handle)
+                vec![DbspOutput::from(relation)]
             }
-            result => {
+            Ok(Some(Value::Tuple(tuple))) => tuple
+                .into_iter()
+                .map(|v| match v {
+                    // We deliberately only handle the basic case of programs
+                    // outputting a tuple made of relations exclusively and
+                    // also pretend as if nested tuples are not a thing ever.
+                    Value::Relation(r) => Ok(DbspOutput::from(r)),
+                    _ => Err(EngineError::new(format!(
+                        "Non relation found in program's output tuple: {v:?}"
+                    ))),
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+            Ok(Some(v)) => {
                 return Err(EngineError::new(format!(
-                    "Expected a relation as program's output, got {result:?}",
+                    "Expected relation(s) as the program's output, got {v:?}",
+                )));
+            }
+            Ok(None) => {
+                return Err(EngineError::new(
+                    "Expected relation(s) as the program's output, got nothing".to_string(),
+                ));
+            }
+            Err(e) => {
+                return Err(EngineError::new(format!(
+                    "Error during build_circuit, got {e:?}",
                 )));
             }
         };
@@ -202,16 +221,17 @@ impl<O: Optimizer + Send + 'static> IncDataLog<O> {
 mod test {
     use super::*;
     use crate::{
-        dbsp::{DbspInput, zset},
+        dbsp::{DbspInput, ZWeight, zset},
         expr::{
             AliasExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-            FixedPointIterExpr, ProjectionExpr, SelectionExpr, UnionExpr,
+            FixedPointIterExpr, ProjectionExpr, SelectionExpr, TupleExpr, UnionExpr,
         },
         relation::TupleValue,
         scalar::ScalarTypedValue,
         stmt::BlockStmt,
         test_helper::{person_profession_data, setup_inc_data_log},
     };
+    use ::dbsp::OrdZSet;
     use expr::{AssignExpr, BinaryExpr, CallExpr, Expr, Literal, LiteralExpr, VarExpr};
     use operator::Operator;
     use stmt::{ExprStmt, Stmt, VarStmt};
@@ -381,63 +401,80 @@ mod test {
                                 .collect(),
                         })),
                     }),
+                    Stmt::from(VarStmt {
+                        name: "selected_projected_tuple".to_string(),
+                        initializer: Some(Expr::from(TupleExpr {
+                            elements: ["selected", "projected"]
+                                .map(|var| Expr::from(VarExpr::new(var)))
+                                .into_iter()
+                                .collect(),
+                        })),
+                    }),
                 ])
             })?;
 
-        circuit.start_transaction()?;
-
         let edges_input = inputs.get("edges").unwrap();
 
-        let data1 = [Edge::new(0, 1, 1), Edge::new(1, 2, 2), Edge::new(2, 3, 3)];
-        let data2 = [Edge::new(3, 4, 1), Edge::new(4, 5, 2), Edge::new(5, 6, 3)];
+        const STEPS: usize = 3;
 
-        println!("Insert of data1:");
+        let mut edges_data = ([
+            [Edge::new(0, 1, 1), Edge::new(1, 2, 2), Edge::new(2, 3, 3)]
+                .map(|e| (e, 2))
+                .into_iter()
+                .collect(),
+            [Edge::new(3, 4, 1), Edge::new(4, 5, 2), Edge::new(5, 6, 3)]
+                .map(|e| (e, 1))
+                .into_iter()
+                .collect(),
+            [Edge::new(0, 1, 1), Edge::new(1, 2, 2), Edge::new(2, 3, 3)]
+                .map(|e| (e, -1))
+                .into_iter()
+                .collect(),
+        ] as [Vec<(Edge, ZWeight)>; STEPS])
+            .into_iter();
 
-        edges_input.insert_with_same_weight(data1.iter(), 2);
+        let mut selected_output = ([
+            zset! {
+                tuple!(1_u64, 2_u64, 2_u64, true) => 2,
+                tuple!(2_u64, 3_u64, 3_u64, true) => 2,
+            },
+            zset! {
+                tuple!(4_u64, 5_u64, 2_u64, true) => 1,
+                tuple!(5_u64, 6_u64, 3_u64, true) => 1,
+            },
+            zset! {
+                tuple!(1_u64, 2_u64, 2_u64, true) => -1,
+                tuple!(2_u64, 3_u64, 3_u64, true) => -1,
+            },
+        ] as [OrdZSet<TupleValue>; STEPS])
+            .into_iter();
 
-        circuit.transaction()?;
-
-        let batch = output.to_batch();
-        println!("{}", batch.as_table());
-        assert_eq!(
-            batch.as_debug_zset(),
+        let mut projected_output = ([
             zset! {
                 tuple!(1_u64, 2_u64, 2_u64, 2_u64) => 2,
                 tuple!(2_u64, 3_u64, 3_u64, 6_u64) => 2,
-            }
-        );
-
-        println!("Insert of data2:");
-
-        edges_input.insert_with_same_weight(data2.iter(), 1);
-
-        circuit.transaction()?;
-
-        let batch = output.to_batch();
-        println!("{}", batch.as_table());
-        assert_eq!(
-            batch.as_debug_zset(),
+            },
             zset! {
                 tuple!(4_u64, 5_u64, 2_u64, 20_u64) => 1,
                 tuple!(5_u64, 6_u64, 3_u64, 30_u64) => 1,
-            }
-        );
-
-        println!("Removal of data1:");
-
-        edges_input.insert_with_same_weight(data1.iter(), -1);
-
-        circuit.transaction()?;
-
-        let batch = output.to_batch();
-        println!("{}", batch.as_table());
-        assert_eq!(
-            batch.as_debug_zset(),
+            },
             zset! {
                 tuple!(1_u64, 2_u64, 2_u64, 2_u64) => -1,
                 tuple!(2_u64, 3_u64, 3_u64, 6_u64) => -1,
-            }
-        );
+            },
+        ] as [OrdZSet<TupleValue>; STEPS])
+            .into_iter();
+
+        for i in 1..=STEPS {
+            edges_input.insert_consume(edges_data.next().unwrap());
+            circuit.transaction()?;
+            let selected = output[0].to_batch();
+            println!("SELECTED\n{}", selected.as_table());
+            assert_eq!(selected.as_debug_zset(), selected_output.next().unwrap());
+            let projected = output[1].to_batch();
+            println!("PROJECTED\n{}", projected.as_table());
+            assert_eq!(projected.as_debug_zset(), projected_output.next().unwrap());
+        }
 
         Ok(())
     }
@@ -514,7 +551,7 @@ mod test {
 
             circuit.transaction()?;
 
-            let batch = output.to_batch();
+            let batch = output[0].to_batch();
             println!("{}", batch.as_table());
             assert_eq!(
                 batch.as_debug_zset(),
@@ -578,7 +615,7 @@ mod test {
 
             circuit.transaction()?;
 
-            let batch = output.to_batch();
+            let batch = output[0].to_batch();
             println!("{}", batch.as_debug_table());
             assert_eq!(
                 batch.as_debug_zset(),
@@ -791,7 +828,7 @@ mod test {
 
         circuit.transaction()?;
 
-        let batch = output.to_batch();
+        let batch = output[0].to_batch();
         println!("{}", batch.as_table());
         assert_eq!(
             batch.as_debug_zset(),
@@ -811,7 +848,7 @@ mod test {
 
         circuit.transaction()?;
 
-        let batch = output.to_batch();
+        let batch = output[0].to_batch();
         println!("{}", batch.as_table());
         assert_eq!(
             batch.as_debug_zset(),
@@ -951,7 +988,7 @@ mod test {
 
         circuit.transaction()?;
 
-        let batch = output.to_batch();
+        let batch = output[0].to_batch();
         println!("{}", batch.as_table());
         assert_eq!(
             batch.as_debug_zset(),
@@ -1214,7 +1251,7 @@ mod test {
 
             circuit.transaction()?;
 
-            let batch = output.to_batch();
+            let batch = output[0].to_batch();
             println!("{}", batch.as_table());
             assert_eq!(batch.as_zset(), expected.next().unwrap());
         }

--- a/packages/coln-query/src/relation.rs
+++ b/packages/coln-query/src/relation.rs
@@ -539,6 +539,24 @@ pub struct RelationType {
     fields: HashMap<String, ScalarType>,
 }
 
+impl Display for RelationType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Sort by field name so the output is deterministic (`HashMap`
+        // iteration order is not).
+        let mut fields: Vec<_> = self.fields.iter().collect();
+        fields.sort_by_key(|(name, _)| *name);
+        write!(f, "{{")?;
+        let mut iter = fields.into_iter();
+        if let Some((name, scalar_type)) = iter.next() {
+            write!(f, "{name}: {scalar_type}")?;
+            for (name, scalar_type) in iter {
+                write!(f, ", {name}: {scalar_type}")?;
+            }
+        }
+        write!(f, "}}")
+    }
+}
+
 impl RelationType {
     pub fn join(self, other: Self) -> Self {
         // We start with other to have duplicate fields' types be taken from self.

--- a/packages/coln-query/src/resolver.rs
+++ b/packages/coln-query/src/resolver.rs
@@ -8,8 +8,8 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitorMut, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, UnaryExpr,
-        UnionExpr, VarExpr,
+        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
+        UnaryExpr, UnionExpr, VarExpr,
     },
     stmt::{BlockStmt, ExprStmt, Stmt, StmtVisitorMut, VarStmt},
     util::{Named, Resolvable},
@@ -197,6 +197,20 @@ type VisitorResult = Result<(), SyntaxError>;
 type VisitorCtx<'a, 'b> = &'a mut ResolverContext<'b>;
 
 impl ExprVisitorMut<VisitorResult, VisitorCtx<'_, '_>> for Resolver {
+    fn visit_literal_expr(&mut self, expr: &mut LiteralExpr, ctx: VisitorCtx) -> VisitorResult {
+        Ok(())
+    }
+
+    fn visit_tuple_expr(&mut self, expr: &mut TupleExpr, ctx: VisitorCtx<'_, '_>) -> VisitorResult {
+        expr.elements
+            .iter_mut()
+            .try_for_each(|relation| self.visit_expr(relation, ctx))
+    }
+
+    fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: VisitorCtx) -> VisitorResult {
+        self.visit_expr(&mut expr.expr, ctx)
+    }
+
     fn visit_binary_expr(&mut self, expr: &mut BinaryExpr, ctx: VisitorCtx) -> VisitorResult {
         self.visit_expr(&mut expr.left, ctx)
             .and_then(|()| self.visit_expr(&mut expr.right, ctx))
@@ -204,10 +218,6 @@ impl ExprVisitorMut<VisitorResult, VisitorCtx<'_, '_>> for Resolver {
 
     fn visit_unary_expr(&mut self, expr: &mut UnaryExpr, ctx: VisitorCtx) -> VisitorResult {
         self.visit_expr(&mut expr.operand, ctx)
-    }
-
-    fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: VisitorCtx) -> VisitorResult {
-        self.visit_expr(&mut expr.expr, ctx)
     }
 
     fn visit_var_expr(&mut self, expr: &mut VarExpr, ctx: VisitorCtx) -> VisitorResult {
@@ -229,10 +239,6 @@ impl ExprVisitorMut<VisitorResult, VisitorCtx<'_, '_>> for Resolver {
         self.visit_expr(&mut expr.value, ctx)?;
         // `resolve_var` returns an error if the variable is not declared.
         self.resolve_var(expr, ctx)
-    }
-
-    fn visit_literal_expr(&mut self, expr: &mut LiteralExpr, ctx: VisitorCtx) -> VisitorResult {
-        Ok(())
     }
 
     fn visit_function_expr(&mut self, expr: &mut FunctionExpr, ctx: VisitorCtx) -> VisitorResult {

--- a/packages/coln-query/src/resolver.rs
+++ b/packages/coln-query/src/resolver.rs
@@ -8,8 +8,8 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitorMut, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
-        UnaryExpr, UnionExpr, VarExpr,
+        FunctionExpr, GetIndexExpr, GroupingExpr, LiteralExpr, ProjectionExpr, SelectionExpr,
+        TupleExpr, UnaryExpr, UnionExpr, VarExpr,
     },
     stmt::{BlockStmt, ExprStmt, Stmt, StmtVisitorMut, VarStmt},
     util::{Named, Resolvable},
@@ -205,6 +205,15 @@ impl ExprVisitorMut<VisitorResult, VisitorCtx<'_, '_>> for Resolver {
         expr.elements
             .iter_mut()
             .try_for_each(|relation| self.visit_expr(relation, ctx))
+    }
+
+    fn visit_get_index_expr(
+        &mut self,
+        expr: &mut GetIndexExpr,
+        ctx: VisitorCtx<'_, '_>,
+    ) -> VisitorResult {
+        self.visit_expr(&mut expr.target, ctx)
+            .and_then(|()| self.visit_expr(&mut expr.index, ctx))
     }
 
     fn visit_grouping_expr(&mut self, expr: &mut GroupingExpr, ctx: VisitorCtx) -> VisitorResult {

--- a/packages/coln-query/src/scalar.rs
+++ b/packages/coln-query/src/scalar.rs
@@ -158,3 +158,17 @@ pub enum ScalarType {
     Char,
     Null,
 }
+
+impl Display for ScalarType {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let name = match self {
+            ScalarType::String => "string",
+            ScalarType::Uint => "uint",
+            ScalarType::Iint => "iint",
+            ScalarType::Bool => "bool",
+            ScalarType::Char => "char",
+            ScalarType::Null => "null",
+        };
+        write!(f, "{name}")
+    }
+}

--- a/packages/coln-query/src/tuple.rs
+++ b/packages/coln-query/src/tuple.rs
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use crate::variable::Value;
+use std::fmt;
+use std::rc::Rc;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Tuple {
+    inner: Rc<[Value]>,
+}
+
+// TODO: Write test case with tuple (multiple DBSP circuits as output)!
+
+impl Tuple {
+    pub fn empty() -> Self {
+        Self { inner: Rc::new([]) }
+    }
+    pub fn get(&self, at: usize) -> &Value {
+        &self.inner[at]
+    }
+}
+
+impl<T: Into<Rc<[Value]>>> From<T> for Tuple {
+    fn from(value: T) -> Self {
+        Self {
+            inner: value.into(),
+        }
+    }
+}
+
+impl<T: Into<Value>> FromIterator<T> for Tuple {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        Self {
+            inner: iter.into_iter().map(Into::<Value>::into).collect(),
+        }
+    }
+}
+
+impl fmt::Display for Tuple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "(")?;
+        let mut iter = self.inner.iter();
+        if let Some(first) = iter.next() {
+            write!(f, "{}", first)?;
+            for v in iter {
+                write!(f, ", {}", v)?;
+            }
+        }
+        write!(f, ")")
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn tuple_creation_and_get() {
+        let check_tuple = |tuple: Tuple| {
+            assert_eq!(*tuple.get(0), Value::Uint(1));
+            assert_eq!(*tuple.get(1), Value::Uint(2));
+        };
+
+        let vec = vec![Value::Uint(1), Value::Uint(2)];
+        let tuple = Tuple::from(vec);
+        check_tuple(tuple);
+
+        let array = [Value::Uint(1), Value::Uint(2)];
+        let tuple = Tuple::from(array);
+        check_tuple(tuple);
+
+        let slice = &[Value::Uint(1), Value::Uint(2)][..];
+        let tuple = Tuple::from(slice);
+        check_tuple(tuple);
+
+        let tuple = vec![1_u32, 2].into_iter().collect::<Tuple>();
+        check_tuple(tuple);
+    }
+
+    #[test]
+    fn tuple_display() {
+        let tuple = Tuple::from([Value::from(1), Value::from(true), Value::from("Hi")]);
+        let display = format!("{tuple}");
+        assert_eq!(display, "(1, true, \"Hi\")");
+    }
+
+    #[test]
+    fn tuple_eq() {
+        let a = Tuple::from([Value::from(1), Value::from(true)]);
+        let b = Tuple::from(vec![Value::from(1), Value::from(true)]);
+        let c = Tuple::empty();
+
+        assert_eq!(a, b);
+        assert_ne!(a, c);
+    }
+}

--- a/packages/coln-query/src/tuple.rs
+++ b/packages/coln-query/src/tuple.rs
@@ -11,16 +11,89 @@ pub struct Tuple {
     inner: Rc<[Value]>,
 }
 
-// TODO: Write test case with tuple (multiple DBSP circuits as output)!
-
 impl Tuple {
     pub fn empty() -> Self {
         Self { inner: Rc::new([]) }
     }
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
     pub fn get(&self, at: usize) -> &Value {
         &self.inner[at]
     }
+    pub fn iter(&self) -> std::slice::Iter<'_, Value> {
+        self.inner.iter()
+    }
 }
+
+impl<'a> IntoIterator for &'a Tuple {
+    type Item = &'a Value;
+    type IntoIter = std::slice::Iter<'a, Value>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.inner.iter()
+    }
+}
+
+impl IntoIterator for Tuple {
+    type Item = Value;
+    type IntoIter = TupleIntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        let back = self.inner.len();
+        TupleIntoIter {
+            inner: self.inner,
+            front: 0,
+            back,
+        }
+    }
+}
+
+/// A consuming iterator over the [`Value`]s of a [`Tuple`].
+///
+/// The backing `Rc<[Value]>` may be shared, so the values cannot be moved out;
+/// they are cloned lazily as the iterator is advanced. This avoids allocating
+/// an intermediate buffer up front.
+pub struct TupleIntoIter {
+    inner: Rc<[Value]>,
+    /// Index of the next front element.
+    front: usize,
+    /// Index one past the next back element.
+    back: usize,
+}
+
+impl Iterator for TupleIntoIter {
+    type Item = Value;
+
+    fn next(&mut self) -> Option<Value> {
+        if self.front == self.back {
+            return None;
+        }
+        let value = self.inner[self.front].clone();
+        self.front += 1;
+        Some(value)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.back - self.front;
+        (remaining, Some(remaining))
+    }
+}
+
+impl DoubleEndedIterator for TupleIntoIter {
+    fn next_back(&mut self) -> Option<Value> {
+        if self.front == self.back {
+            return None;
+        }
+        self.back -= 1;
+        Some(self.inner[self.back].clone())
+    }
+}
+
+impl ExactSizeIterator for TupleIntoIter {}
 
 impl<T: Into<Rc<[Value]>>> From<T> for Tuple {
     fn from(value: T) -> Self {
@@ -94,5 +167,70 @@ mod test {
 
         assert_eq!(a, b);
         assert_ne!(a, c);
+    }
+
+    #[test]
+    fn tuple_iter() {
+        let tuple = Tuple::from([Value::Uint(1), Value::Uint(2), Value::Uint(3)]);
+        let expected = [Value::Uint(1), Value::Uint(2), Value::Uint(3)];
+
+        // via the inherent `iter` method
+        assert!(tuple.iter().eq(expected.iter()));
+
+        // via `IntoIterator` for `&Tuple` (e.g. in a `for` loop)
+        let collected: Vec<&Value> = (&tuple).into_iter().collect();
+        assert_eq!(collected, expected.iter().collect::<Vec<_>>());
+
+        let mut count = 0;
+        for value in &tuple {
+            assert_eq!(*value, expected[count]);
+            count += 1;
+        }
+        assert_eq!(count, tuple.len());
+
+        // an empty tuple yields nothing
+        assert_eq!(Tuple::empty().iter().next(), None);
+    }
+
+    #[test]
+    fn tuple_into_iter() {
+        let tuple = Tuple::from([Value::Uint(1), Value::Uint(2), Value::Uint(3)]);
+        let expected = vec![Value::Uint(1), Value::Uint(2), Value::Uint(3)];
+
+        // consuming iteration yields owned `Value`s
+        let collected: Vec<Value> = tuple.clone().into_iter().collect();
+        assert_eq!(collected, expected);
+
+        // `ExactSizeIterator` reports the correct length
+        let mut iter = tuple.clone().into_iter();
+        assert_eq!(iter.len(), 3);
+        iter.next();
+        assert_eq!(iter.len(), 2);
+
+        // `DoubleEndedIterator` yields from the back
+        let reversed: Vec<Value> = tuple.clone().into_iter().rev().collect();
+        assert_eq!(
+            reversed,
+            expected.iter().rev().cloned().collect::<Vec<Value>>(),
+        );
+
+        // front and back cursors meet without overlap
+        let mut iter = tuple.clone().into_iter();
+        assert_eq!(iter.next(), Some(Value::Uint(1)));
+        assert_eq!(iter.next_back(), Some(Value::Uint(3)));
+        assert_eq!(iter.next(), Some(Value::Uint(2)));
+        assert_eq!(iter.next(), None);
+        assert_eq!(iter.next_back(), None);
+
+        // usable directly in a `for` loop
+        let mut count = 0;
+        for value in tuple {
+            assert_eq!(value, expected[count]);
+            count += 1;
+        }
+        assert_eq!(count, expected.len());
+
+        // an empty tuple yields nothing
+        assert_eq!(Tuple::empty().into_iter().next(), None);
     }
 }

--- a/packages/coln-query/src/tuple.rs
+++ b/packages/coln-query/src/tuple.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::type_resolver::ExprType;
 use crate::variable::Value;
 use std::fmt;
 use std::rc::Rc;
@@ -122,6 +123,17 @@ impl fmt::Display for Tuple {
             }
         }
         write!(f, ")")
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TupleType {
+    element_types: Vec<ExprType>,
+}
+
+impl From<Vec<ExprType>> for TupleType {
+    fn from(element_types: Vec<ExprType>) -> Self {
+        Self { element_types }
     }
 }
 

--- a/packages/coln-query/src/tuple.rs
+++ b/packages/coln-query/src/tuple.rs
@@ -28,6 +28,12 @@ impl Tuple {
     pub fn iter(&self) -> std::slice::Iter<'_, Value> {
         self.inner.iter()
     }
+    pub fn display_compact(&self) -> CompactTupleDisplay<'_, Self> {
+        CompactTupleDisplay(self)
+    }
+    pub fn display_detailed(&self) -> DetailedTupleDisplay<'_, Self> {
+        DetailedTupleDisplay(self)
+    }
 }
 
 impl<'a> IntoIterator for &'a Tuple {
@@ -112,10 +118,50 @@ impl<T: Into<Value>> FromIterator<T> for Tuple {
     }
 }
 
-impl fmt::Display for Tuple {
+/// Shared slice access for the tuple-like types, backing the generic
+/// [`CompactTupleDisplay`] / [`DetailedTupleDisplay`] wrappers.
+///
+/// This is a private implementation detail: callers use the inherent
+/// `display_compact` / `display_detailed` methods on [`Tuple`] and [`TupleType`]
+/// instead of touching this trait.
+trait TupleLike {
+    type Elem;
+    fn elements(&self) -> &[Self::Elem];
+}
+
+impl TupleLike for Tuple {
+    type Elem = Value;
+    fn elements(&self) -> &[Self::Elem] {
+        &self.inner
+    }
+}
+
+impl TupleLike for TupleType {
+    type Elem = ExprType;
+    fn elements(&self) -> &[Self::Elem] {
+        &self.element_types
+    }
+}
+
+// The `TupleLike` bound is kept off the struct definitions (it lives only on the
+// `Display` impls) so the private trait does not leak into these public types.
+pub struct CompactTupleDisplay<'a, T>(&'a T);
+pub struct DetailedTupleDisplay<'a, T>(&'a T);
+
+impl<T: TupleLike> fmt::Display for CompactTupleDisplay<'_, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let len = self.0.elements().len();
+        write!(f, "{len}-tuple")
+    }
+}
+
+impl<T: TupleLike> fmt::Display for DetailedTupleDisplay<'_, T>
+where
+    T::Elem: fmt::Display,
+{
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "(")?;
-        let mut iter = self.inner.iter();
+        let mut iter = self.0.elements().iter();
         if let Some(first) = iter.next() {
             write!(f, "{}", first)?;
             for v in iter {
@@ -126,9 +172,33 @@ impl fmt::Display for Tuple {
     }
 }
 
+impl fmt::Display for Tuple {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display_detailed().fmt(f)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TupleType {
     element_types: Vec<ExprType>,
+}
+
+impl TupleType {
+    pub fn element_type(&self, at: usize) -> Option<&ExprType> {
+        self.element_types.get(at)
+    }
+    pub fn display_compact(&self) -> CompactTupleDisplay<'_, Self> {
+        CompactTupleDisplay(self)
+    }
+    pub fn display_detailed(&self) -> DetailedTupleDisplay<'_, Self> {
+        DetailedTupleDisplay(self)
+    }
+}
+
+impl fmt::Display for TupleType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.display_detailed().fmt(f)
+    }
 }
 
 impl From<Vec<ExprType>> for TupleType {
@@ -167,8 +237,34 @@ mod test {
     #[test]
     fn tuple_display() {
         let tuple = Tuple::from([Value::from(1), Value::from(true), Value::from("Hi")]);
-        let display = format!("{tuple}");
-        assert_eq!(display, "(1, true, \"Hi\")");
+
+        assert_eq!(format!("{}", tuple.display_compact()), "3-tuple");
+        assert_eq!(format!("{}", tuple.display_detailed()), "(1, true, \"Hi\")");
+        // the `Display` impl uses the detailed form
+        assert_eq!(format!("{tuple}"), "(1, true, \"Hi\")");
+
+        let empty = Tuple::empty();
+        assert_eq!(format!("{}", empty.display_compact()), "0-tuple");
+        assert_eq!(format!("{}", empty.display_detailed()), "()");
+    }
+
+    #[test]
+    fn tuple_type_display() {
+        use crate::scalar::ScalarType;
+
+        let tuple_type = TupleType::from(vec![
+            ExprType::Scalar(ScalarType::Uint),
+            ExprType::Scalar(ScalarType::Bool),
+        ]);
+
+        assert_eq!(format!("{}", tuple_type.display_compact()), "2-tuple");
+        assert_eq!(format!("{}", tuple_type.display_detailed()), "(uint, bool)");
+        // the `Display` impl uses the detailed form
+        assert_eq!(format!("{tuple_type}"), "(uint, bool)");
+
+        let empty = TupleType::from(Vec::<ExprType>::new());
+        assert_eq!(format!("{}", empty.display_compact()), "0-tuple");
+        assert_eq!(format!("{}", empty.display_detailed()), "()");
     }
 
     #[test]

--- a/packages/coln-query/src/type_resolver.rs
+++ b/packages/coln-query/src/type_resolver.rs
@@ -7,8 +7,8 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitor, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, Literal, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
-        UnaryExpr, UnionExpr, VarExpr,
+        FunctionExpr, GetIndexExpr, GroupingExpr, Literal, LiteralExpr, ProjectionExpr,
+        SelectionExpr, TupleExpr, UnaryExpr, UnionExpr, VarExpr,
     },
     operator::Operator,
     resolver::ScopeStack,
@@ -17,13 +17,14 @@ use crate::{
 };
 pub use crate::{function::FunctionType, relation::RelationType, scalar::ScalarType};
 use std::collections::HashMap;
+use std::fmt;
 
 macro_rules! assert_type {
     ($value:expr, $variant:path) => {
         match $value {
             $variant(inner) => Ok(inner),
             _ => Err(SyntaxError::new(format!(
-                "expected {} type, got: {:?}",
+                "expected {} type, got: {}",
                 stringify!($variant:path), $value
             ))),
         }
@@ -65,6 +66,28 @@ impl TypeResolver {
             .into_iter()
             .try_fold(None, |_prev, stmt| Ok(Some(self.resolve_stmt(stmt, ctx)?)))
     }
+    fn const_eval_uint(&self, expr: &Expr) -> Option<u64> {
+        match expr {
+            Expr::Literal(literal) => match literal.value {
+                Literal::Uint(n) => Some(n),
+                _ => None,
+            },
+            Expr::Grouping(grouping) => self.const_eval_uint(&grouping.expr),
+            Expr::Binary(binary) => {
+                let left = self.const_eval_uint(&binary.left)?;
+                let right = self.const_eval_uint(&binary.right)?;
+
+                match binary.operator {
+                    Operator::Addition => left.checked_add(right),
+                    Operator::Subtraction => left.checked_sub(right),
+                    Operator::Multiplication => left.checked_mul(right),
+                    Operator::Division => left.checked_div(right),
+                    _ => None,
+                }
+            }
+            _ => None,
+        }
+    }
 }
 
 type VisitorCtx<'a, 'b> = &'a mut TypeResolverContext<'b>;
@@ -76,6 +99,17 @@ pub enum ExprType {
     Relation(RelationType),
     Function(FunctionType),
     Tuple(TupleType),
+}
+
+impl fmt::Display for ExprType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ExprType::Scalar(scalar_type) => write!(f, "{scalar_type}"),
+            ExprType::Relation(relation_type) => write!(f, "{relation_type}"),
+            ExprType::Function(function_type) => write!(f, "{function_type}"),
+            ExprType::Tuple(tuple_type) => write!(f, "{tuple_type}"),
+        }
+    }
 }
 
 pub struct TypeResolverContext<'a> {
@@ -150,6 +184,40 @@ impl ExprVisitor<VisitorResult, VisitorCtx<'_, '_>> for TypeResolver {
             .map(|expr| self.visit_expr(expr, ctx))
             .collect::<Result<Vec<ExprType>, _>>()?;
         Ok(ExprType::Tuple(TupleType::from(element_types)))
+    }
+
+    fn visit_get_index_expr(
+        &mut self,
+        expr: &GetIndexExpr,
+        ctx: VisitorCtx<'_, '_>,
+    ) -> VisitorResult {
+        let index_type = self.visit_expr(&expr.index, ctx).and_then(|expr_type| {
+            let scalar_type = assert_type!(expr_type, ExprType::Scalar)?;
+            match scalar_type {
+                ScalarType::Uint => Ok(scalar_type),
+                _ => Err(SyntaxError::new(format!(
+                    "expected {} type, got: {}",
+                    ScalarType::Uint,
+                    scalar_type
+                ))),
+            }
+        })?;
+
+        match self.visit_expr(&expr.target, ctx)? {
+            ExprType::Tuple(tuple_type) => {
+                let const_index = self
+                    .const_eval_uint(&expr.target)
+                    .ok_or(SyntaxError::new("cannot compute tuple index statically"))?;
+                tuple_type
+                    .element_type(const_index as usize)
+                    .ok_or(SyntaxError::new(format!(
+                        "{} at index {const_index} is out of bounds.",
+                        tuple_type.display_compact()
+                    )))
+                    .cloned()
+            }
+            expr_type => Err(SyntaxError::new(format!("cannot index {expr_type}"))),
+        }
     }
 
     fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> VisitorResult {

--- a/packages/coln-query/src/type_resolver.rs
+++ b/packages/coln-query/src/type_resolver.rs
@@ -7,12 +7,13 @@ use crate::{
     expr::{
         AliasExpr, AntiJoinExpr, AssignExpr, BinaryExpr, CallExpr, CartesianProductExpr,
         DifferenceExpr, DistinctExpr, EquiJoinExpr, Expr, ExprVisitor, FixedPointIterExpr,
-        FunctionExpr, GroupingExpr, Literal, LiteralExpr, ProjectionExpr, SelectionExpr, UnaryExpr,
-        UnionExpr, VarExpr,
+        FunctionExpr, GroupingExpr, Literal, LiteralExpr, ProjectionExpr, SelectionExpr, TupleExpr,
+        UnaryExpr, UnionExpr, VarExpr,
     },
     operator::Operator,
     resolver::ScopeStack,
     stmt::{BlockStmt, ExprStmt, Stmt, StmtVisitor, VarStmt},
+    tuple::TupleType,
 };
 pub use crate::{function::FunctionType, relation::RelationType, scalar::ScalarType};
 use std::collections::HashMap;
@@ -74,6 +75,7 @@ pub enum ExprType {
     Scalar(ScalarType),
     Relation(RelationType),
     Function(FunctionType),
+    Tuple(TupleType),
 }
 
 pub struct TypeResolverContext<'a> {
@@ -137,6 +139,23 @@ impl TypeResolver {
 }
 
 impl ExprVisitor<VisitorResult, VisitorCtx<'_, '_>> for TypeResolver {
+    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: VisitorCtx) -> VisitorResult {
+        Ok(ExprType::from(&expr.value))
+    }
+
+    fn visit_tuple_expr(&mut self, expr: &TupleExpr, ctx: VisitorCtx<'_, '_>) -> VisitorResult {
+        let element_types = expr
+            .elements
+            .iter()
+            .map(|expr| self.visit_expr(expr, ctx))
+            .collect::<Result<Vec<ExprType>, _>>()?;
+        Ok(ExprType::Tuple(TupleType::from(element_types)))
+    }
+
+    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> VisitorResult {
+        self.visit_expr(&expr.expr, ctx)
+    }
+
     fn visit_binary_expr(&mut self, expr: &BinaryExpr, ctx: VisitorCtx) -> VisitorResult {
         self.visit_expr(&expr.left, ctx).and_then(|left_type| {
             let right_type = self.visit_expr(&expr.right, ctx)?;
@@ -163,10 +182,6 @@ impl ExprVisitor<VisitorResult, VisitorCtx<'_, '_>> for TypeResolver {
         }
     }
 
-    fn visit_grouping_expr(&mut self, expr: &GroupingExpr, ctx: VisitorCtx) -> VisitorResult {
-        self.visit_expr(&expr.expr, ctx)
-    }
-
     fn visit_var_expr(&mut self, expr: &VarExpr, ctx: VisitorCtx) -> VisitorResult {
         let name = &expr.name;
         ctx.get_type(name)
@@ -176,10 +191,6 @@ impl ExprVisitor<VisitorResult, VisitorCtx<'_, '_>> for TypeResolver {
     fn visit_assign_expr(&mut self, expr: &AssignExpr, ctx: VisitorCtx) -> VisitorResult {
         // We return the type of the value that is being assigned.
         self.visit_expr(&expr.value, ctx)
-    }
-
-    fn visit_literal_expr(&mut self, expr: &LiteralExpr, ctx: VisitorCtx) -> VisitorResult {
-        Ok(ExprType::from(&expr.value))
     }
 
     fn visit_function_expr(&mut self, expr: &FunctionExpr, ctx: VisitorCtx) -> VisitorResult {

--- a/packages/coln-query/src/variable.rs
+++ b/packages/coln-query/src/variable.rs
@@ -27,7 +27,7 @@ pub enum Value {
     Iint(i64),
     /// Boolean.
     Bool(bool),
-    /// Character.
+    /// A single character as defined by Rust's [`char`].
     Char(char),
     /// Null.
     // The `Null` variant carries the unit type to align its field-arity with

--- a/packages/coln-query/src/variable.rs
+++ b/packages/coln-query/src/variable.rs
@@ -71,6 +71,12 @@ impl From<RelationRef> for Value {
     }
 }
 
+impl From<Tuple> for Value {
+    fn from(value: Tuple) -> Self {
+        Value::Tuple(value)
+    }
+}
+
 impl From<ScalarTypedValue> for Value {
     fn from(value: ScalarTypedValue) -> Self {
         match value {

--- a/packages/coln-query/src/variable.rs
+++ b/packages/coln-query/src/variable.rs
@@ -4,6 +4,7 @@
 
 use crate::{
     expr::Literal, function::FunctionRef, relation::RelationRef, scalar::ScalarTypedValue,
+    tuple::Tuple,
 };
 use std::{
     cell::{Ref, RefCell},
@@ -36,6 +37,8 @@ pub enum Value {
     Function(FunctionRef),
     /// Relation.
     Relation(RelationRef),
+    /// Tuple.
+    Tuple(Tuple),
 }
 
 impl Eq for Value {}
@@ -50,6 +53,7 @@ impl PartialEq for Value {
             (Value::Null(()), Value::Null(())) => true,
             (Value::Function(a), Value::Function(b)) => Rc::ptr_eq(a, b),
             (Value::Relation(a), Value::Relation(b)) => Rc::ptr_eq(a, b),
+            (Value::Tuple(a), Value::Tuple(b)) => a == b,
             _ => false,
         }
     }
@@ -93,10 +97,46 @@ impl From<Literal> for Value {
     }
 }
 
+impl From<&str> for Value {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
+impl From<u64> for Value {
+    fn from(value: u64) -> Self {
+        Self::Uint(value)
+    }
+}
+
+impl From<u32> for Value {
+    fn from(value: u32) -> Self {
+        Self::Uint(value as u64)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(value: i64) -> Self {
+        Self::Iint(value)
+    }
+}
+
+impl From<i32> for Value {
+    fn from(value: i32) -> Self {
+        Self::Iint(value as i64)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
 impl fmt::Display for Value {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Value::String(value) => write!(f, "{value}"),
+            Value::String(value) => write!(f, "\"{value}\""),
             Value::Uint(value) => write!(f, "{value}"),
             Value::Iint(value) => write!(f, "{value}"),
             Value::Bool(value) => write!(f, "{value}"),
@@ -104,6 +144,7 @@ impl fmt::Display for Value {
             Value::Null(()) => write!(f, "null"),
             Value::Function(function) => write!(f, "{}", function.borrow()),
             Value::Relation(relation) => write!(f, "{}", relation.borrow()),
+            Value::Tuple(tuple) => write!(f, "{}", tuple),
         }
     }
 }


### PR DESCRIPTION
- This PR adds tuple support in Coln-query's IR. This is required for outputting multiple queries/circuits.
- It also fixes an issue with clippy being installed twice in our `flake.nix`, resulting  in a broken Rust dev environment.