### PR TITLE
Nextest Rust test runner

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -60,8 +60,14 @@ jobs:
       - name: Install Rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
+
+      - name: Install just
+        uses: extractions/setup-just@v3
+
       - name: Run tests
-        run: cargo test
+        run: just check-rust
 
   coln-js-runtime-check:
     runs-on: ubuntu-latest
@@ -73,6 +79,9 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           target: wasm32-unknown-unknown
+
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
 
       - name: Install wasm-bindgen-cli
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -217,6 +217,7 @@
             cabal-install
             cabal2nix
             cargo-llvm-cov
+            cargo-nextest
             coln-manual-dev
             forester
             fourmolu

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ fix package:
 
 check-haskell: (check "coln-compiler") (check "coln-cli") (check "coln-repl") (check "coln-ls") (check "fnotation") (check "diagnostician")
 
-check-rust: (check "coln-store") (check "coln-batch")
+check-rust: (check "coln-store") (check "coln-query") (check "coln-batch")
 
 check-typescript: (check "coln-js-runtime")
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ fix package:
 
 check-haskell: (check "coln-compiler") (check "coln-cli") (check "coln-repl") (check "coln-ls") (check "fnotation") (check "diagnostician")
 
-check-rust: (check "coln-store") (check "coln-query") (check "coln-batch")
+check-rust: (check "coln-store") (check "coln-query") (check "coln-batch") (check "coln-flir-rs")
 
 check-typescript: (check "coln-js-runtime")
 

--- a/packages/coln-batch/justfile
+++ b/packages/coln-batch/justfile
@@ -18,7 +18,10 @@ clippy:
     cargo clippy -p {{crate}} --all-targets --all-features -- -D warnings
 
 test:
-    cargo test -p {{crate}} --all-targets
+    cargo nextest run -p {{crate}} --all-targets
+    # As of now nextest does not support doc tests, so we fallback to
+    # cargo test to run them.
+    cargo test --doc -p {{crate}}
 
 import:
     cargo fix -p {{crate}} --all-targets --all-features --allow-dirty --allow-staged

--- a/packages/coln-flir-rs/justfile
+++ b/packages/coln-flir-rs/justfile
@@ -1,0 +1,39 @@
+# Task runner: https://github.com/casey/just
+# From packages/coln-flir-rs, with Rust on PATH (e.g. `nix develop`):
+#   just              # list available recipes
+#   just check        # fmt-check + clippy + test
+#   just cargo-check  # type-check coln-flir-rs targets
+#   just import
+#   just fix          # apply cargo fixes + format
+
+crate := "coln-flir-rs"
+
+default:
+    @just --list
+
+fmt:
+    cargo fmt -p {{crate}}
+
+fmt-check:
+    cargo fmt -p {{crate}} --check
+
+cargo-check:
+    cargo check -p {{crate}} --all-targets
+
+clippy:
+    cargo clippy -p {{crate}} --all-targets --all-features -- -D warnings
+
+import:
+    cargo fix -p {{crate}} --all-targets --all-features --allow-dirty --allow-staged
+
+fix: import fmt
+
+test:
+    cargo nextest run -p {{crate}} --all-targets
+    # As of now nextest does not support doc tests, so we fallback to
+    # cargo test to run them.
+    cargo test --doc -p {{crate}}
+
+check: fmt-check clippy test
+
+ci: check

--- a/packages/coln-js-runtime/justfile
+++ b/packages/coln-js-runtime/justfile
@@ -3,11 +3,16 @@
 #   just              # list recipes
 #   just test         # rust + npm tests
 
+crate := "coln-js-runtime"
+
 default:
     @just --list
 
 test-rust:
-    cargo test --all-targets
+    cargo nextest run -p {{crate}} --all-targets
+    # As of now nextest does not support doc tests, so we fallback to
+    # cargo test to run them.
+    cargo test --doc -p {{crate}}
 
 build:
     npm run build

--- a/packages/coln-query/justfile
+++ b/packages/coln-query/justfile
@@ -30,7 +30,10 @@ import:
 fix: import fmt
 
 test:
-    cargo test -p {{crate}} --all-targets
+    cargo nextest run -p {{crate}} --all-targets
+    # As of now nextest does not support doc tests, so we fallback to
+    # cargo test to run them.
+    cargo test --doc -p {{crate}}
 
 check: fmt-check clippy test
 

--- a/packages/coln-store/justfile
+++ b/packages/coln-store/justfile
@@ -30,7 +30,10 @@ import:
 fix: import fmt
 
 test:
-    cargo test -p {{crate}} --all-targets
+    cargo nextest run -p {{crate}} --all-targets
+    # As of now nextest does not support doc tests, so we fallback to
+    # cargo test to run them.
+    cargo test --doc -p {{crate}}
 
 check: fmt-check clippy test
 


### PR DESCRIPTION
Adds [nextest](https://github.com/nextest-rs/nextest) to our Rust packages. It is a more modern test runner and noticeably faster. @incipit0: I've tested the test runner for `coln-store`, `coln-js-runtime`, and `coln-batch` next to `coln-query`. Looks good to me. It's mostly a drop-in replacement for `cargo test` besides the missing doc test support but that is handled by the just files.