### PR TITLE
Sort directories in tests for consistency

### DIFF
--- a/packages/coln-compiler/test/Main.hs
+++ b/packages/coln-compiler/test/Main.hs
@@ -14,7 +14,7 @@ import Coln.Frontend.Parser
 import Control.Exception (evaluate, finally, onException)
 import Data.ByteString.Lazy qualified as LBS
 import Data.Functor.Contravariant (contramap)
-import Data.List (partition)
+import Data.List (partition, sort)
 import Data.Map.Ordered qualified as OMap
 import Data.Text.IO.Utf8 qualified as T
 import Data.Text.Lazy.Encoding qualified as TLE
@@ -106,7 +106,7 @@ generateTypeScript fp outdir = do
 
 typescriptFiles :: FilePath -> IO [FilePath]
 typescriptFiles directory =
-  filter (\path -> takeExtension path `elem` [".json", ".ts"])
+  sort . filter (\path -> takeExtension path `elem` [".json", ".ts"])
     <$> listDirectory directory
 
 elaboratorTests :: IO TestTree


### PR DESCRIPTION
Without this, `nix develop -c cabal test coln-compiler`, `nix build .#coln-cli` and others fail for me. I guess this is down to `listDirectory` being filesystem-dependent or something.