### PR TITLE
Empty store changes

### DIFF
--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -4,10 +4,10 @@
 
 use coln_flir_rs::ir;
 use coln_store::{
-    commit::{chunk::Chunk, hash::CommitHash as StoreCommitHash, pst::decode_commit_chunks},
+    commit::{chunk::Chunk, hash::CommitHash as StoreCommitHash},
     store::{
         Store,
-        error::{CommitApplyError, StoreIntError},
+        error::{CommitApplyError, StoreError},
     },
     table::RowId as StoreRowId,
     txn::{OwnedTransaction, RowHandle as StoreRowHandle},
@@ -323,9 +323,9 @@ impl StoreHandle {
                 *has_root |= decoded.iter().any(Chunk::is_root);
                 chunks.extend(chunk_bytes);
                 if *has_root {
-                    match decode_commit_chunks(chunks.iter()) {
+                    match Store::try_from_commit_chunks(chunks.iter()) {
                         Ok(store) => self.state = StoreHandle::ready(store).state,
-                        Err(StoreIntError::Commit(CommitApplyError::MissingDep)) => return Ok(()),
+                        Err(StoreError::Commit(CommitApplyError::MissingDep)) => return Ok(()),
                         Err(error) => {
                             chunks.truncate(previous_len);
                             *has_root = previously_had_root;
@@ -346,7 +346,7 @@ impl StoreHandle {
                         pending_chunks.clear();
                         Ok(())
                     }
-                    Err(StoreIntError::Commit(CommitApplyError::MissingDep)) => Ok(()),
+                    Err(StoreError::Commit(CommitApplyError::MissingDep)) => Ok(()),
                     Err(error) => {
                         pending_chunks.truncate(previous_len);
                         Err(error.to_string())
@@ -405,7 +405,7 @@ mod tests {
             }],
             rules: vec![],
         };
-        let mut store = Store::try_from_theory(theory).expect("store");
+        let mut store = Store::try_from_ir(theory).expect("store");
         let mut transaction = store.transaction();
         transaction
             .add(&Path::from("T"), vec![42_i64.into()])

--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -4,8 +4,11 @@
 
 use coln_flir_rs::ir;
 use coln_store::{
-    commit::hash::CommitHash as StoreCommitHash,
-    store::Store,
+    commit::{chunk::Chunk, hash::CommitHash as StoreCommitHash, pst::decode_commit_chunks},
+    store::{
+        Store,
+        error::{CommitApplyError, StoreIntError},
+    },
     table::RowId as StoreRowId,
     txn::{OwnedTransaction, RowHandle as StoreRowHandle},
 };
@@ -19,7 +22,16 @@ use wasm_bindgen::prelude::wasm_bindgen;
 
 #[wasm_bindgen]
 pub struct StoreHandle {
-    store: Option<Store>,
+    state: StoreHandleState,
+}
+
+enum StoreHandleState {
+    Uninitialized {
+        chunks: Vec<Vec<u8>>,
+        has_root: bool,
+    },
+    Ready(Box<Store>),
+    Moved,
 }
 
 #[wasm_bindgen]
@@ -94,7 +106,7 @@ impl TransactionHandle {
 
                 Ok(CommitResult {
                     commit: commit.to_string(),
-                    store: Some(StoreHandle { store: Some(store) }),
+                    store: Some(StoreHandle::ready(store)),
                 })
             }
             Err((err, store)) => {
@@ -110,12 +122,15 @@ impl TransactionHandle {
     // after committing
     #[wasm_bindgen(js_name = takeStore)]
     pub fn take_store(&mut self) -> Result<StoreHandle, JsValue> {
+        if let Some(tx) = self.tx.take() {
+            return Ok(StoreHandle::ready(tx.abort()));
+        }
         let store = self
             .recovered_store
             .take()
             .ok_or_else(|| js_error("transaction does not have a recovered store"))?;
 
-        Ok(StoreHandle { store: Some(store) })
+        Ok(StoreHandle::ready(store))
     }
 }
 
@@ -127,13 +142,22 @@ pub struct CommitResult {
 
 #[wasm_bindgen]
 impl StoreHandle {
+    pub fn empty() -> StoreHandle {
+        Self {
+            state: StoreHandleState::Uninitialized {
+                chunks: Vec::new(),
+                has_root: false,
+            },
+        }
+    }
+
     #[wasm_bindgen(js_name = fromTheory)]
     pub fn from_theory(flat_theory_json: String) -> Result<StoreHandle, JsValue> {
         let theory = serde_json::from_str::<ir::FlatRealm>(&flat_theory_json)
             .map_err(|err| js_error(format!("invalid flat theory JSON: {err}")))?;
         let store = Store::try_from_ir(theory).map_err(js_error)?;
 
-        Ok(Self { store: Some(store) })
+        Ok(Self::ready(store))
     }
 
     #[wasm_bindgen(js_name = jsonIR)]
@@ -163,10 +187,19 @@ impl StoreHandle {
 
     #[wasm_bindgen(js_name = beginTransaction)]
     pub fn begin_transaction(&mut self) -> Result<TransactionHandle, JsValue> {
-        let store = self
-            .store
-            .take()
-            .ok_or_else(|| js_error("store handle has already been moved into a transaction"))?;
+        let state = std::mem::replace(&mut self.state, StoreHandleState::Moved);
+        let store = match state {
+            StoreHandleState::Ready(store) => *store,
+            state @ StoreHandleState::Uninitialized { .. } => {
+                self.state = state;
+                return Err(js_error("store handle has not been initialized"));
+            }
+            StoreHandleState::Moved => {
+                return Err(js_error(
+                    "store handle has already been moved into a transaction",
+                ));
+            }
+        };
 
         Ok(TransactionHandle {
             tx: Some(store.into_transaction()),
@@ -182,12 +215,19 @@ impl StoreHandle {
     // For automerge-repo interfacing
 
     pub fn heads(&self) -> Result<Vec<CommitHash>, JsValue> {
-        let heads = self
-            .store()?
-            .heads()
-            .into_iter()
-            .map(CommitHash::from)
-            .collect::<Vec<_>>();
+        let heads = match &self.state {
+            StoreHandleState::Uninitialized { .. } => return Ok(Vec::new()),
+            StoreHandleState::Ready(store) => store,
+            StoreHandleState::Moved => {
+                return Err(js_error(
+                    "store handle has already been moved into a transaction",
+                ));
+            }
+        }
+        .heads()
+        .into_iter()
+        .map(CommitHash::from)
+        .collect::<Vec<_>>();
 
         Ok(heads)
     }
@@ -197,6 +237,9 @@ impl StoreHandle {
         &self,
         have_heads: Vec<CommitHash>,
     ) -> Result<Vec<CommitChunk>, JsValue> {
+        if matches!(self.state, StoreHandleState::Uninitialized { .. }) {
+            return Ok(Vec::new());
+        }
         let have_heads = have_heads
             .into_iter()
             .map(StoreCommitHash::try_from)
@@ -217,10 +260,7 @@ impl StoreHandle {
     pub fn apply_chunk_bytes(&mut self, chunk_bytes: JsValue) -> Result<(), JsValue> {
         let chunk_bytes =
             serde_wasm_bindgen::from_value::<Vec<Vec<u8>>>(chunk_bytes).map_err(js_error)?;
-
-        self.store_mut()?
-            .apply_chunk_bytes(chunk_bytes)
-            .map_err(js_error)
+        self.apply_chunks(chunk_bytes).map_err(js_error)
     }
 }
 
@@ -240,16 +280,58 @@ impl CommitResult {
 }
 
 impl StoreHandle {
-    fn store(&self) -> Result<&Store, JsValue> {
-        self.store
-            .as_ref()
-            .ok_or_else(|| js_error("store handle has been moved into a transaction"))
+    fn ready(store: Store) -> Self {
+        Self {
+            state: StoreHandleState::Ready(Box::new(store)),
+        }
     }
 
-    fn store_mut(&mut self) -> Result<&mut Store, JsValue> {
-        self.store
-            .as_mut()
-            .ok_or_else(|| js_error("store handle has been moved into a transaction"))
+    fn apply_chunks(&mut self, chunk_bytes: Vec<Vec<u8>>) -> Result<(), String> {
+        match &mut self.state {
+            StoreHandleState::Uninitialized { chunks, has_root } => {
+                let decoded = chunk_bytes
+                    .iter()
+                    .map(|bytes| Chunk::decode(bytes))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|error| error.to_string())?;
+                let previous_len = chunks.len();
+                let previously_had_root = *has_root;
+                *has_root |= decoded.iter().any(Chunk::is_root);
+                chunks.extend(chunk_bytes);
+                if *has_root {
+                    match decode_commit_chunks(chunks.iter()) {
+                        Ok(store) => self.state = StoreHandleState::Ready(Box::new(store)),
+                        Err(error) => {
+                            if !matches!(error, StoreIntError::Commit(CommitApplyError::MissingDep))
+                            {
+                                chunks.truncate(previous_len);
+                                *has_root = previously_had_root;
+                            }
+                            return Err(error.to_string());
+                        }
+                    }
+                }
+                Ok(())
+            }
+            StoreHandleState::Ready(store) => store
+                .apply_chunk_bytes(chunk_bytes)
+                .map_err(|error| error.to_string()),
+            StoreHandleState::Moved => {
+                Err("store handle has already been moved into a transaction".into())
+            }
+        }
+    }
+
+    fn store(&self) -> Result<&Store, JsValue> {
+        match &self.state {
+            StoreHandleState::Uninitialized { .. } => {
+                Err(js_error("store handle has not been initialized"))
+            }
+            StoreHandleState::Ready(store) => Ok(store),
+            StoreHandleState::Moved => Err(js_error(
+                "store handle has already been moved into a transaction",
+            )),
+        }
     }
 }
 
@@ -258,5 +340,148 @@ impl TransactionHandle {
         self.tx
             .as_mut()
             .ok_or_else(|| js_error("transaction has already been committed"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use coln_flir_rs::ir::{
+        BuiltinTy, ColType, ColumnEntry, EntityVariant, FlatRealm, Path, Schema, TableEntry,
+    };
+
+    use super::*;
+
+    fn source_store() -> Store {
+        let theory = FlatRealm {
+            tables: vec![TableEntry {
+                path: Path::from("T"),
+                table: Schema {
+                    entity_variant: EntityVariant::Table,
+                    columns: vec![ColumnEntry {
+                        path: Path::from("value"),
+                        col_type: ColType::BuiltinTy {
+                            builtin_ty: BuiltinTy::BuiltinInt,
+                        },
+                    }],
+                    primary_key: None,
+                },
+            }],
+            rules: vec![],
+        };
+        let mut store = Store::try_from_theory(theory).expect("store");
+        let mut transaction = store.transaction();
+        transaction
+            .add(&Path::from("T"), vec![42_i64.into()])
+            .expect("add row");
+        transaction.commit().expect("commit");
+        store
+    }
+
+    #[test]
+    fn empty_handle_buffers_data_until_root_arrives() {
+        let source = source_store();
+        let (root, data): (Vec<_>, Vec<_>) = source
+            .commit_chunks_after(&[])
+            .into_iter()
+            .map(|chunk| chunk.bytes)
+            .partition(|bytes| Chunk::decode(bytes).expect("chunk").is_root());
+        let mut handle = StoreHandle::empty();
+
+        handle.apply_chunks(data).expect("buffer data");
+        assert!(matches!(
+            handle.state,
+            StoreHandleState::Uninitialized { .. }
+        ));
+        assert!(handle.heads().expect("heads").is_empty());
+
+        handle.apply_chunks(root).expect("apply root");
+        let store = handle.store().expect("initialized store");
+        let table = store.table_at(&Path::from("T")).expect("table");
+        assert_eq!(table.row_count(), 1);
+    }
+
+    #[test]
+    fn empty_handle_retries_bootstrap_when_missing_parent_arrives() {
+        let mut source = source_store();
+        let mut transaction = source.transaction();
+        transaction
+            .add(&Path::from("T"), vec![84_i64.into()])
+            .expect("add second row");
+        transaction.commit().expect("second commit");
+
+        let mut root = None;
+        let mut data = Vec::new();
+        for chunk in source.commit_chunks_after(&[]) {
+            if Chunk::decode(&chunk.bytes).expect("chunk").is_root() {
+                root = Some(chunk.bytes);
+            } else {
+                data.push(chunk.bytes);
+            }
+        }
+        assert_eq!(data.len(), 2);
+
+        let mut handle = StoreHandle::empty();
+        let child = data.pop().expect("child commit");
+        assert!(
+            handle
+                .apply_chunks(vec![root.expect("root"), child])
+                .is_err()
+        );
+
+        handle.apply_chunks(data).expect("retry with parent");
+        let table = handle
+            .store()
+            .expect("initialized store")
+            .table_at(&Path::from("T"))
+            .expect("table");
+        assert_eq!(table.row_count(), 2);
+    }
+
+    #[test]
+    fn active_transaction_can_return_its_store_without_committing() {
+        let mut handle = StoreHandle::ready(source_store());
+        let mut transaction = handle.begin_transaction().expect("transaction");
+        transaction
+            .tx()
+            .expect("owned transaction")
+            .add(&Path::from("T"), vec![84_i64.into()])
+            .expect("stage row");
+
+        let recovered = transaction.take_store().expect("recover store");
+        let table = recovered
+            .store()
+            .expect("store")
+            .table_at(&Path::from("T"))
+            .expect("table");
+        assert_eq!(table.row_count(), 1);
+    }
+
+    #[test]
+    fn malformed_batch_does_not_poison_later_bootstrap() {
+        let source = source_store();
+        let chunks = source
+            .commit_chunks_after(&[])
+            .into_iter()
+            .map(|chunk| chunk.bytes)
+            .collect::<Vec<_>>();
+        let root = chunks
+            .iter()
+            .find(|bytes| Chunk::decode(bytes).expect("chunk").is_root())
+            .expect("root")
+            .clone();
+        let mut handle = StoreHandle::empty();
+
+        assert!(handle.apply_chunks(vec![root, vec![0xff]]).is_err());
+        handle.apply_chunks(chunks).expect("valid retry");
+
+        assert_eq!(
+            handle
+                .store()
+                .expect("initialized store")
+                .table_at(&Path::from("T"))
+                .expect("table")
+                .row_count(),
+            1
+        );
     }
 }

--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -30,7 +30,10 @@ enum StoreHandleState {
         chunks: Vec<Vec<u8>>,
         has_root: bool,
     },
-    Ready(Box<Store>),
+    Ready {
+        store: Box<Store>,
+        pending_chunks: Vec<Vec<u8>>,
+    },
     Moved,
 }
 
@@ -38,6 +41,7 @@ enum StoreHandleState {
 pub struct TransactionHandle {
     tx: Option<OwnedTransaction>,
     recovered_store: Option<Store>,
+    pending_chunks: Vec<Vec<u8>>,
 
     pending_handles: Vec<(StoreRowHandle, JsValue)>,
 }
@@ -106,7 +110,10 @@ impl TransactionHandle {
 
                 Ok(CommitResult {
                     commit: commit.to_string(),
-                    store: Some(StoreHandle::ready(store)),
+                    store: Some(StoreHandle::ready_with_pending(
+                        store,
+                        std::mem::take(&mut self.pending_chunks),
+                    )),
                 })
             }
             Err((err, store)) => {
@@ -123,14 +130,20 @@ impl TransactionHandle {
     #[wasm_bindgen(js_name = takeStore)]
     pub fn take_store(&mut self) -> Result<StoreHandle, JsValue> {
         if let Some(tx) = self.tx.take() {
-            return Ok(StoreHandle::ready(tx.abort()));
+            return Ok(StoreHandle::ready_with_pending(
+                tx.abort(),
+                std::mem::take(&mut self.pending_chunks),
+            ));
         }
         let store = self
             .recovered_store
             .take()
             .ok_or_else(|| js_error("transaction does not have a recovered store"))?;
 
-        Ok(StoreHandle::ready(store))
+        Ok(StoreHandle::ready_with_pending(
+            store,
+            std::mem::take(&mut self.pending_chunks),
+        ))
     }
 }
 
@@ -188,8 +201,11 @@ impl StoreHandle {
     #[wasm_bindgen(js_name = beginTransaction)]
     pub fn begin_transaction(&mut self) -> Result<TransactionHandle, JsValue> {
         let state = std::mem::replace(&mut self.state, StoreHandleState::Moved);
-        let store = match state {
-            StoreHandleState::Ready(store) => *store,
+        let (store, pending_chunks) = match state {
+            StoreHandleState::Ready {
+                store,
+                pending_chunks,
+            } => (*store, pending_chunks),
             state @ StoreHandleState::Uninitialized { .. } => {
                 self.state = state;
                 return Err(js_error("store handle has not been initialized"));
@@ -204,6 +220,7 @@ impl StoreHandle {
         Ok(TransactionHandle {
             tx: Some(store.into_transaction()),
             recovered_store: None,
+            pending_chunks,
 
             pending_handles: Vec::new(),
         })
@@ -217,7 +234,7 @@ impl StoreHandle {
     pub fn heads(&self) -> Result<Vec<CommitHash>, JsValue> {
         let heads = match &self.state {
             StoreHandleState::Uninitialized { .. } => return Ok(Vec::new()),
-            StoreHandleState::Ready(store) => store,
+            StoreHandleState::Ready { store, .. } => store,
             StoreHandleState::Moved => {
                 return Err(js_error(
                     "store handle has already been moved into a transaction",
@@ -281,8 +298,15 @@ impl CommitResult {
 
 impl StoreHandle {
     fn ready(store: Store) -> Self {
+        Self::ready_with_pending(store, Vec::new())
+    }
+
+    fn ready_with_pending(store: Store, pending_chunks: Vec<Vec<u8>>) -> Self {
         Self {
-            state: StoreHandleState::Ready(Box::new(store)),
+            state: StoreHandleState::Ready {
+                store: Box::new(store),
+                pending_chunks,
+            },
         }
     }
 
@@ -300,22 +324,35 @@ impl StoreHandle {
                 chunks.extend(chunk_bytes);
                 if *has_root {
                     match decode_commit_chunks(chunks.iter()) {
-                        Ok(store) => self.state = StoreHandleState::Ready(Box::new(store)),
+                        Ok(store) => self.state = StoreHandle::ready(store).state,
+                        Err(StoreIntError::Commit(CommitApplyError::MissingDep)) => return Ok(()),
                         Err(error) => {
-                            if !matches!(error, StoreIntError::Commit(CommitApplyError::MissingDep))
-                            {
-                                chunks.truncate(previous_len);
-                                *has_root = previously_had_root;
-                            }
+                            chunks.truncate(previous_len);
+                            *has_root = previously_had_root;
                             return Err(error.to_string());
                         }
                     }
                 }
                 Ok(())
             }
-            StoreHandleState::Ready(store) => store
-                .apply_chunk_bytes(chunk_bytes)
-                .map_err(|error| error.to_string()),
+            StoreHandleState::Ready {
+                store,
+                pending_chunks,
+            } => {
+                let previous_len = pending_chunks.len();
+                pending_chunks.extend(chunk_bytes);
+                match store.apply_chunk_bytes(pending_chunks.iter().cloned()) {
+                    Ok(()) => {
+                        pending_chunks.clear();
+                        Ok(())
+                    }
+                    Err(StoreIntError::Commit(CommitApplyError::MissingDep)) => Ok(()),
+                    Err(error) => {
+                        pending_chunks.truncate(previous_len);
+                        Err(error.to_string())
+                    }
+                }
+            }
             StoreHandleState::Moved => {
                 Err("store handle has already been moved into a transaction".into())
             }
@@ -327,7 +364,7 @@ impl StoreHandle {
             StoreHandleState::Uninitialized { .. } => {
                 Err(js_error("store handle has not been initialized"))
             }
-            StoreHandleState::Ready(store) => Ok(store),
+            StoreHandleState::Ready { store, .. } => Ok(store),
             StoreHandleState::Moved => Err(js_error(
                 "store handle has already been moved into a transaction",
             )),
@@ -422,13 +459,51 @@ mod tests {
 
         let mut handle = StoreHandle::empty();
         let child = data.pop().expect("child commit");
-        assert!(
-            handle
-                .apply_chunks(vec![root.expect("root"), child])
-                .is_err()
-        );
+        handle
+            .apply_chunks(vec![root.expect("root"), child])
+            .expect("buffer child");
 
         handle.apply_chunks(data).expect("retry with parent");
+        let table = handle
+            .store()
+            .expect("initialized store")
+            .table_at(&Path::from("T"))
+            .expect("table");
+        assert_eq!(table.row_count(), 2);
+    }
+
+    #[test]
+    fn ready_handle_retries_commit_when_missing_parent_arrives() {
+        let mut source = source_store();
+        let mut transaction = source.transaction();
+        transaction
+            .add(&Path::from("T"), vec![84_i64.into()])
+            .expect("add second row");
+        transaction.commit().expect("second commit");
+
+        let mut root = None;
+        let mut data = Vec::new();
+        for chunk in source.commit_chunks_after(&[]) {
+            if Chunk::decode(&chunk.bytes).expect("chunk").is_root() {
+                root = Some(chunk.bytes);
+            } else {
+                data.push(chunk.bytes);
+            }
+        }
+        assert_eq!(data.len(), 2);
+
+        let mut handle = StoreHandle::empty();
+        handle
+            .apply_chunks(vec![root.expect("root")])
+            .expect("apply root");
+        assert!(matches!(handle.state, StoreHandleState::Ready { .. }));
+
+        let child = data.pop().expect("child commit");
+        handle.apply_chunks(vec![child]).expect("buffer child");
+        let mut transaction = handle.begin_transaction().expect("begin transaction");
+        handle = transaction.take_store().expect("abort transaction");
+        handle.apply_chunks(data).expect("retry with parent");
+
         let table = handle
             .store()
             .expect("initialized store")

--- a/packages/coln-js-runtime/src/ts/RealmBindings.ts
+++ b/packages/coln-js-runtime/src/ts/RealmBindings.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+import type { StoreHandle, TransactionHandle } from "#wasm-bodge/bindings"
+
+type JsonObject = { readonly [key: string]: JsonValue }
+type JsonValue = null | boolean | number | string | readonly JsonValue[] | JsonObject
+
+export interface ColnSchema {
+  entities: readonly JsonValue[]
+  rules: readonly JsonValue[]
+}
+
+export interface RealmBindings<ViewRoot = unknown, TransactionRoot = unknown> {
+  schema: ColnSchema
+  View: new (store: StoreHandle) => { root: ViewRoot }
+  Transaction: new (store: StoreHandle, transaction: TransactionHandle) => { root: TransactionRoot }
+}

--- a/packages/coln-js-runtime/src/ts/RealmBindings.ts
+++ b/packages/coln-js-runtime/src/ts/RealmBindings.ts
@@ -4,12 +4,9 @@
 
 import type { StoreHandle, TransactionHandle } from "#wasm-bodge/bindings"
 
-type JsonObject = { readonly [key: string]: JsonValue }
-type JsonValue = null | boolean | number | string | readonly JsonValue[] | JsonObject
-
 export interface ColnSchema {
-  entities: readonly JsonValue[]
-  rules: readonly JsonValue[]
+  entities: readonly unknown[]
+  rules: readonly unknown[]
 }
 
 export interface RealmBindings<ViewRoot = unknown, TransactionRoot = unknown> {

--- a/packages/coln-js-runtime/src/ts/index.ts
+++ b/packages/coln-js-runtime/src/ts/index.ts
@@ -5,6 +5,8 @@
 export type { CommitChunk, RowRef, RowView, Value } from "#wasm-bodge/bindings";
 export { CommitResult, StoreHandle, TransactionHandle, valueEqual } from "#wasm-bodge/bindings"
 
+export type { RealmBindings, ColnSchema } from "./RealmBindings"
+
 export * as ColnSet from "./ColnSet";
 
 export * as ColnRef from "./ColnRef";

--- a/packages/coln-js-runtime/tests/basic-ir/helpers.ts
+++ b/packages/coln-js-runtime/tests/basic-ir/helpers.ts
@@ -2,19 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-import { StoreHandle, type TransactionHandle } from "@coln-project/runtime";
-
-interface RealmModule<ViewRoot, TransactionRoot> {
-  schema: unknown;
-  View: new (store: StoreHandle) => { root: ViewRoot };
-  Transaction: new (
-    store: StoreHandle,
-    transaction: TransactionHandle,
-  ) => { root: TransactionRoot };
-}
+import { StoreHandle, type RealmBindings } from "@coln-project/runtime";
 
 export function beginRealm<ViewRoot, TransactionRoot>(
-  realm: RealmModule<ViewRoot, TransactionRoot>,
+  realm: RealmBindings<ViewRoot, TransactionRoot>,
 ) {
   let store = StoreHandle.fromTheory(JSON.stringify(realm.schema));
   const transaction = store.beginTransaction();

--- a/packages/coln-store/src/commit/chunk.rs
+++ b/packages/coln-store/src/commit/chunk.rs
@@ -53,6 +53,10 @@ impl Chunk {
         Ok(chunk)
     }
 
+    pub fn is_root(&self) -> bool {
+        self.chunk_type() == ChunkType::Root
+    }
+
     pub(crate) fn chunk_type(&self) -> ChunkType {
         match self {
             Chunk::Commit { header, .. } | Chunk::Root { header, .. } => header.chunk_type,

--- a/packages/coln-store/src/store/mod.rs
+++ b/packages/coln-store/src/store/mod.rs
@@ -277,6 +277,50 @@ impl Store {
             rowing: rowing::Rowing::new(),
         })
     }
+
+    /// Builds a store from individually framed commit chunks received during sync.
+    pub fn try_from_commit_chunks(
+        chunk_bytes: impl IntoIterator<Item = impl AsRef<[u8]>>,
+    ) -> Result<Self, StoreError> {
+        let chunks = chunk_bytes
+            .into_iter()
+            .map(|bytes| Chunk::decode(bytes.as_ref()))
+            .collect::<Result<Vec<_>, _>>()?;
+        let roots = chunks
+            .iter()
+            .filter(|chunk| chunk.is_root())
+            .collect::<Vec<_>>();
+        let root = match roots.as_slice() {
+            [] => {
+                return Err(
+                    CodecError::DataFormatError("commit graph has no root commit".into()).into(),
+                );
+            }
+            [root] => *root,
+            _ => {
+                return Err(CodecError::DataFormatError(
+                    "commit graph has multiple root commits".into(),
+                )
+                .into());
+            }
+        };
+        let root_commit = Commit::from_chunk(root.clone(), |_| None)?;
+        let mut store = Self::try_from_ir(root_commit.root_payload()?)?;
+        let commits = chunks
+            .into_iter()
+            .filter(|chunk| !chunk.is_root())
+            .map(|chunk| {
+                Commit::from_chunk(chunk, |path| {
+                    store
+                        .resolve_table(path)
+                        .and_then(|oid| store.table_meta(oid))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        store.apply_commits(commits)?;
+
+        Ok(store)
+    }
 }
 
 impl Store {

--- a/packages/coln-store/src/store/tests.rs
+++ b/packages/coln-store/src/store/tests.rs
@@ -827,6 +827,39 @@ mod commits {
     }
 
     #[test]
+    fn commit_chunks_create_empty_store() {
+        let source = Store::new();
+        let chunks = source
+            .commit_chunks_after(&[])
+            .into_iter()
+            .map(|chunk| chunk.bytes)
+            .collect::<Vec<_>>();
+
+        let restored = Store::try_from_commit_chunks(chunks).expect("store from chunks");
+
+        assert_eq!(restored.table_count(), 0);
+        assert_eq!(restored.heads(), source.heads());
+    }
+
+    #[test]
+    fn commit_chunks_create_store_from_out_of_order_data() {
+        let mut source = single_int_store();
+        let commit = commit_int(&mut source, 99);
+        let mut chunks = source
+            .commit_chunks_after(&[])
+            .into_iter()
+            .map(|chunk| chunk.bytes)
+            .collect::<Vec<_>>();
+        chunks.reverse();
+
+        let restored = Store::try_from_commit_chunks(chunks).expect("store from chunks");
+
+        let table = restored.table_at(&Path::from("T")).expect("table");
+        assert_eq!(table.cell_at(0, 0), Some(CellValue::Int(99)));
+        assert_eq!(restored.heads(), vec![commit]);
+    }
+
+    #[test]
     fn apply_commits_applies_rows_and_updates_heads() {
         let mut source = single_int_store();
         let mut target = single_int_store();

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -79,6 +79,10 @@ impl OwnedTransaction {
         self.inner.add(&self.store, table, values)
     }
 
+    pub fn abort(self) -> Store {
+        self.store
+    }
+
     // We need to return Store to the user for roll back purposes, so the Err variant must be large
     #[allow(clippy::result_large_err)]
     pub fn commit(mut self) -> Result<(CommitHash, Store), (StoreError, Store)> {


### PR DESCRIPTION
Hello @incipit0 @alexjg @mvr @olynch et al
I have been working on getting sync up and running with automerge repo and there are a few changes which I would be most grateful for your input on.

This PR is a *largely LLM generated* example of what I think is required:

**Empty Stores**
Firstly, it enables creation of empty stores, which can then be hydrated from the synced commit chunks. This is used to load coln stores of any schema, even if the schema is unknown. It also allows us to buffer out-of-order chunks until the root and dependencies arrive; Automerge Repo and Subduction do not guarantee the arrival order of entries in the hash graph.

Essentially this means that from typescript we can call `StoreHandle.empty()` to initialise a store within repo without needing to use the schema.

Calling `StoreHandle.heads()` in typescript will also return an empty array until the store has loaded, allowing us to determine store readiness.

**Additional Types**
These are some Realm typings which I found in one of the test helpers for `coln-js-runtime` and which I have found useful in the higher level typescript work. Included here for completeness.

**Transaction recovery**
A store should be rolled back if a transaction throws prior to commit. This was an LLM discovery, so I'll let it describe the issue better that I can:

> On main, if the change callback throws before commit():
> - The store remains owned by the active TransactionHandle.
> - takeStore() cannot reclaim it because it only handles failed commit attempts.
> - The staged changes have not mutated the store, but the store itself becomes inaccessible.
> Our change adds abort(): takeStore() now returns the original store and discards the transaction’s staged operations. So the store is both reclaimed and effectively rolled back.

This makes sense to me, but I will leave it to you to determine if this is the correct behaviour.

Please let me know your thoughts and questions when you can.

Many thanks, Alex