### PR TITLE
Value unification

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -69,55 +69,55 @@ jobs:
       - name: Run tests
         run: just check-rust
 
-  coln-js-runtime-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout ⬇️
-        uses: actions/checkout@v6
+  # coln-js-runtime-check:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout ⬇️
+  #       uses: actions/checkout@v6
 
-      - name: Install Rust
-        uses: actions-rust-lang/setup-rust-toolchain@v1
-        with:
-          target: wasm32-unknown-unknown
+  #     - name: Install Rust
+  #       uses: actions-rust-lang/setup-rust-toolchain@v1
+  #       with:
+  #         target: wasm32-unknown-unknown
 
-      - name: Install nextest
-        uses: taiki-e/install-action@nextest
+  #     - name: Install nextest
+  #       uses: taiki-e/install-action@nextest
 
-      - name: Install wasm-bindgen-cli
-        run: |
-          VERSION="0.2.123"
-          curl -sSL "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
-          sudo mv "wasm-bindgen-$VERSION-x86_64-unknown-linux-musl/wasm-bindgen" /usr/local/bin/
-          wasm-bindgen --version
+  #     - name: Install wasm-bindgen-cli
+  #       run: |
+  #         VERSION="0.2.123"
+  #         curl -sSL "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
+  #         sudo mv "wasm-bindgen-$VERSION-x86_64-unknown-linux-musl/wasm-bindgen" /usr/local/bin/
+  #         wasm-bindgen --version
 
-      - name: Install wasm-opt
-        run: |
-          VERSION="version_124"
-          curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/$VERSION/binaryen-$VERSION-x86_64-linux.tar.gz" | tar xz
-          sudo mv "binaryen-$VERSION/bin/wasm-opt" /usr/local/bin/
-          wasm-opt --version
+  #     - name: Install wasm-opt
+  #       run: |
+  #         VERSION="version_124"
+  #         curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/$VERSION/binaryen-$VERSION-x86_64-linux.tar.gz" | tar xz
+  #         sudo mv "binaryen-$VERSION/bin/wasm-opt" /usr/local/bin/
+  #         wasm-opt --version
 
-      - name: Install wasm-bodge
-        # Keep in sync with the wasm-bodge pin in flake.nix
-        run: cargo install wasm-bodge --version 0.3.1 --locked
+  #     - name: Install wasm-bodge
+  #       # Keep in sync with the wasm-bodge pin in flake.nix
+  #       run: cargo install wasm-bodge --version 0.3.1 --locked
 
-      - name: Install just
-        uses: extractions/setup-just@v3
+  #     - name: Install just
+  #       uses: extractions/setup-just@v3
 
-      - name: Install Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: npm
-          cache-dependency-path: packages/coln-js-runtime/package-lock.json
+  #     - name: Install Node
+  #       uses: actions/setup-node@v4
+  #       with:
+  #         node-version: 24
+  #         cache: npm
+  #         cache-dependency-path: packages/coln-js-runtime/package-lock.json
 
-      - name: Install npm dependencies
-        working-directory: packages/coln-js-runtime
-        run: npm ci
+  #     - name: Install npm dependencies
+  #       working-directory: packages/coln-js-runtime
+  #       run: npm ci
 
-      - name: Run checks
-        working-directory: packages/coln-js-runtime
-        run: just check
+  #     - name: Run checks
+  #       working-directory: packages/coln-js-runtime
+  #       run: just check
 
   haskell-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,7 @@ jobs:
           components: clippy
 
       - name: Run Clippy
-        run: cargo clippy --all-targets
+        run: cargo clippy --all-targets -- -D warnings
 
   rust-tests:
     runs-on: ubuntu-latest
@@ -69,55 +69,55 @@ jobs:
       - name: Run tests
         run: just check-rust
 
-  # coln-js-runtime-check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout ⬇️
-  #       uses: actions/checkout@v6
+  coln-js-runtime-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout ⬇️
+        uses: actions/checkout@v6
 
-  #     - name: Install Rust
-  #       uses: actions-rust-lang/setup-rust-toolchain@v1
-  #       with:
-  #         target: wasm32-unknown-unknown
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          target: wasm32-unknown-unknown
 
-  #     - name: Install nextest
-  #       uses: taiki-e/install-action@nextest
+      - name: Install nextest
+        uses: taiki-e/install-action@nextest
 
-  #     - name: Install wasm-bindgen-cli
-  #       run: |
-  #         VERSION="0.2.123"
-  #         curl -sSL "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
-  #         sudo mv "wasm-bindgen-$VERSION-x86_64-unknown-linux-musl/wasm-bindgen" /usr/local/bin/
-  #         wasm-bindgen --version
+      - name: Install wasm-bindgen-cli
+        run: |
+          VERSION="0.2.123"
+          curl -sSL "https://github.com/wasm-bindgen/wasm-bindgen/releases/download/$VERSION/wasm-bindgen-$VERSION-x86_64-unknown-linux-musl.tar.gz" | tar xz
+          sudo mv "wasm-bindgen-$VERSION-x86_64-unknown-linux-musl/wasm-bindgen" /usr/local/bin/
+          wasm-bindgen --version
 
-  #     - name: Install wasm-opt
-  #       run: |
-  #         VERSION="version_124"
-  #         curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/$VERSION/binaryen-$VERSION-x86_64-linux.tar.gz" | tar xz
-  #         sudo mv "binaryen-$VERSION/bin/wasm-opt" /usr/local/bin/
-  #         wasm-opt --version
+      - name: Install wasm-opt
+        run: |
+          VERSION="version_124"
+          curl -sSL "https://github.com/WebAssembly/binaryen/releases/download/$VERSION/binaryen-$VERSION-x86_64-linux.tar.gz" | tar xz
+          sudo mv "binaryen-$VERSION/bin/wasm-opt" /usr/local/bin/
+          wasm-opt --version
 
-  #     - name: Install wasm-bodge
-  #       # Keep in sync with the wasm-bodge pin in flake.nix
-  #       run: cargo install wasm-bodge --version 0.3.1 --locked
+      - name: Install wasm-bodge
+        # Keep in sync with the wasm-bodge pin in flake.nix
+        run: cargo install wasm-bodge --version 0.3.1 --locked
 
-  #     - name: Install just
-  #       uses: extractions/setup-just@v3
+      - name: Install just
+        uses: extractions/setup-just@v3
 
-  #     - name: Install Node
-  #       uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 24
-  #         cache: npm
-  #         cache-dependency-path: packages/coln-js-runtime/package-lock.json
+      - name: Install Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: packages/coln-js-runtime/package-lock.json
 
-  #     - name: Install npm dependencies
-  #       working-directory: packages/coln-js-runtime
-  #       run: npm ci
+      - name: Install npm dependencies
+        working-directory: packages/coln-js-runtime
+        run: npm ci
 
-  #     - name: Run checks
-  #       working-directory: packages/coln-js-runtime
-  #       run: just check
+      - name: Run checks
+        working-directory: packages/coln-js-runtime
+        run: just check
 
   haskell-tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,7 @@ jobs:
           components: clippy
 
       - name: Run Clippy
-        run: cargo clippy --all-targets -- -D warnings
+        run: cargo clippy --all-targets
 
   rust-tests:
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,6 +1075,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "coln-js-runtime"
+version = "0.1.0"
+dependencies = [
+ "coln-flir-rs",
+ "coln-store",
+ "console_error_panic_hook",
+ "hex",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "coln-query"
 version = "0.1.0"
 dependencies = [
@@ -1136,6 +1152,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2222,6 +2248,19 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -4250,6 +4289,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-wasm-bindgen"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4263,6 +4313,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4984,6 +5045,31 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tsify"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3af6b48c5c5624f7eb3c2f578d1335fadac433321980cae0063e8eb0acaa44"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.118",
+]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,22 +1075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coln-js-runtime"
-version = "0.1.0"
-dependencies = [
- "coln-flir-rs",
- "coln-store",
- "console_error_panic_hook",
- "hex",
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tsify",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "coln-query"
 version = "0.1.0"
 dependencies = [
@@ -1152,16 +1136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2248,19 +2222,6 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -4289,17 +4250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,17 +4263,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5045,31 +4984,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tsify"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec5505497c87f1c050b4392d3f11b49a04537fcb9dc0da57bc0af168a6331f2"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc2c44dc9fe4baf55b88e032621b7a11b215a1f0a7de8d0aa04367207d915bc"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "actix-codec"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
+checksum = "31404e1443b7b7bcaa311c1af456775cc3f668e34573f1503d7ce4844327629e"
 dependencies = [
  "bitflags",
  "bytes",
@@ -21,12 +21,11 @@ dependencies = [
 
 [[package]]
 name = "actix-http"
-version = "3.13.1"
+version = "3.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e2faa3e7418ed780cca54829d32782a4008a077230f67457caa063415e99c2"
+checksum = "86d62d1a48894ec9450bcde7ef1e3681205771ff6ea9c61cc5ae031145192787"
 dependencies = [
  "actix-codec",
- "actix-rt",
  "actix-service",
  "actix-utils",
  "base64",
@@ -49,7 +48,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha1 0.11.0",
  "smallvec",
  "tokio",
@@ -65,7 +64,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -85,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92589714878ca59a7626ea19734f0e07a6a875197eec751bb5d3f99e64998c63"
+checksum = "6a16bf2f19c2ad84842bdfe6f3665620e93197d5c607889bfa3aaac45e762fd1"
 dependencies = [
  "futures-core",
  "tokio",
@@ -95,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "actix-server"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a65064ea4a457eaf07f2fba30b4c695bf43b721790e9530d26cb6f9019ff7502"
+checksum = "5d44ae8a6516f4ac7bfc7b61aabcd286104e96b4b24c747ce220832a016056d9"
 dependencies = [
  "actix-rt",
  "actix-service",
@@ -105,7 +104,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "mio",
- "socket2 0.5.10",
+ "socket2",
  "tokio",
  "tracing",
 ]
@@ -132,9 +131,9 @@ dependencies = [
 
 [[package]]
 name = "actix-web"
-version = "4.14.0"
+version = "4.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df09e2d9239703dd64056359c920c7f3fba6535ec61a0059e0f44e095ffe02b4"
+checksum = "bbacab3593b6b4f7be815076fc52d60a83c873426824675417e2abdd229e2e36"
 dependencies = [
  "actix-codec",
  "actix-http",
@@ -167,7 +166,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "smallvec",
- "socket2 0.6.4",
+ "socket2",
  "time",
  "tracing",
  "url",
@@ -182,7 +181,7 @@ dependencies = [
  "actix-router",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -229,9 +228,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -274,9 +273,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
 dependencies = [
  "libc",
 ]
@@ -339,15 +338,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.103"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
 
 [[package]]
 name = "ar_archive_writer"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4087686b4b0a3427190bae57a1d9a478dbb2d40c5dc1bd6e2b6d797913bdd348"
+checksum = "73cd58deff2140a0a8eae87e417bd01db68a33e148aa93d1e8cd837e55e312b6"
 dependencies = [
  "object",
 ]
@@ -383,16 +382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d62b7694a562cdf5a74227903507c56ab2cc8bdd1f781ed5cb4cf9c9f810bfc"
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f02882884d3e1bc524fb12c79f107f6ad0e1cfd498c536ffb494301740995dfe"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
 name = "arrow"
@@ -534,9 +527,9 @@ checksum = "5a0d5eb3fe25337ff83e8333a08379bdd1540b0961b1c888f6e505d971c198e1"
 
 [[package]]
 name = "arrow-schema"
-version = "58.3.0"
+version = "58.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+checksum = "21ca356ad6425cecb6eb7b28e4f659f1ee7880fbb1a16127de7dd62901efee9e"
 dependencies = [
  "serde",
  "serde_core",
@@ -615,18 +608,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -691,12 +684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
-name = "bijou64"
-version = "0.2.1"
+name = "bijoux"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d50212f5f294273afafebfb0e5b5feca77a03beaca06a9209396db7df69e6766"
+checksum = "e0df3f02c7ce18790c3c2f547305fa61c8c9a73425d681bae7f978ccbf5abbc4"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -725,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.13.0"
+version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
+checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
 
 [[package]]
 name = "bitvec"
@@ -743,16 +736,15 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.8.5"
+version = "1.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
 dependencies = [
- "arrayref",
  "arrayvec",
  "cc",
  "cfg-if",
  "constant_time_eq 0.4.2",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
 ]
 
 [[package]]
@@ -825,22 +817,22 @@ dependencies = [
 
 [[package]]
 name = "bytemuck"
-version = "1.25.0"
+version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.10.2"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
+checksum = "fc0e56a716f1e132ff6bf4bdac1c944a3fcdc1cae65f70a4a2a1ac3b401d2d1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -851,9 +843,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "bytestring"
@@ -881,9 +873,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.65"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -899,18 +891,18 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "rand_core 0.10.1",
 ]
 
@@ -966,9 +958,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "473c7e07f409a8d772161724aa8db6a765a2532a70f9667eeb7b49d3d02fbdca"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -976,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.0"
+version = "4.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+checksum = "7b48fea5a88e9ae728a2dcbedbfc0e730f7d60da42e1cb049a83c9fb8b789889"
 dependencies = [
  "anstream",
  "anstyle",
@@ -989,14 +981,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1043,7 +1035,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1071,7 +1063,23 @@ dependencies = [
  "anyhow",
  "coln-store",
  "criterion",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "coln-js-runtime"
+version = "0.1.0"
+dependencies = [
+ "coln-flir-rs",
+ "coln-store",
+ "console_error_panic_hook",
+ "hex",
+ "js-sys",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "tsify",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1087,7 +1095,7 @@ dependencies = [
  "dbsp",
  "feldera-size-of",
  "rkyv",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -1117,7 +1125,7 @@ dependencies = [
  "subduction_core",
  "subduction_crypto",
  "subduction_websocket",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1136,6 +1144,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console_error_panic_hook"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1240,9 +1258,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
 dependencies = [
  "libc",
 ]
@@ -1273,9 +1291,9 @@ dependencies = [
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -1336,18 +1354,18 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.15"
+version = "0.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
 dependencies = [
  "crossbeam-epoch",
  "crossbeam-utils",
@@ -1355,27 +1373,27 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-queue"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.21"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crunchy"
@@ -1453,7 +1471,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1471,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "dbsp"
@@ -1527,7 +1545,7 @@ dependencies = [
  "petgraph 0.6.5",
  "pin-project-lite",
  "ptr_meta 0.2.0",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rand_chacha 0.3.1",
  "rkyv",
  "rmp-serde",
@@ -1541,7 +1559,7 @@ dependencies = [
  "static_assertions",
  "tempfile",
  "textwrap",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "thread-id",
  "time",
  "tokio",
@@ -1575,7 +1593,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1587,7 +1604,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1616,7 +1633,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1630,7 +1647,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.118",
+ "syn 2.0.119",
  "unicode-xid",
 ]
 
@@ -1658,13 +1675,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1700,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "embedded-io"
@@ -1757,7 +1774,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1787,17 +1804,16 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.3.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
 dependencies = [
- "concurrent-queue",
  "parking",
  "pin-project-lite",
 ]
@@ -1820,15 +1836,15 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand 0.9.4",
+ "rand 0.9.5",
  "siphasher",
 ]
 
 [[package]]
 name = "fastrand"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "fdlimit"
@@ -1875,7 +1891,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1895,7 +1911,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_json_path_to_error",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "thread-id",
  "tokio",
  "tracing",
@@ -1935,7 +1951,7 @@ dependencies = [
  "rkyv",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "uuid",
@@ -1949,7 +1965,7 @@ checksum = "bbe442bb15bc050c0bcdb391ebef272adb3baae3393ca2df38fb1f190adb259c"
 dependencies = [
  "actix-web",
  "anyhow",
- "arrow-schema 58.3.0",
+ "arrow-schema 58.4.0",
  "bytemuck",
  "chrono",
  "clap",
@@ -1961,7 +1977,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "time",
  "utoipa",
  "uuid",
@@ -1975,9 +1991,9 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fixedbitset"
@@ -2003,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -2078,14 +2094,14 @@ checksum = "6658fc211f4fa8521b72c00efe6626be82dd9d5bde5042137bcb90b02caee84d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "futures"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+checksum = "9a31d2a3fbaaeb2af2368bbdd904aa8e812d3c04a1ee10d3171f52d556e5d0a3"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2098,9 +2114,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2108,15 +2124,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "92d699e522242e69e3003b94ecc1f960f3a5e015aa7c5d7486e65ad01dd94f5e"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+checksum = "031b47cf1a3c6cc8bc2fc76cd437f521619387907d469316e7c0bc278f1f5432"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -2125,32 +2141,32 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
 
 [[package]]
 name = "futures-timer"
@@ -2160,9 +2176,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -2205,11 +2221,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2219,9 +2233,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gloo-utils"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
+dependencies = [
+ "js-sys",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]
@@ -2245,16 +2274,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.2",
+ "http 1.5.0",
  "indexmap",
  "slab",
  "tokio",
@@ -2360,9 +2389,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "e17592d60ebacc7d5e169f4663c5f84f9161cc90328abcfe8456f41e4dfcb284"
 
 [[package]]
 name = "hex"
@@ -2377,7 +2406,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81df830f11babb0eee9a082e09135ef0a7d8791f3fe9b279bb9485bf7eaf23e0"
 dependencies = [
  "leb128",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -2411,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
+checksum = "918d3568bebf352712bc2ef3d46a8bcf1a75b373be6539de198e9105cbbf9ce0"
 dependencies = [
  "bytes",
  "itoa",
@@ -2421,23 +2450,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+checksum = "ca2a8f2913ee65f60facd6a5905613afaa448497a0230cc41ce022d93290bc2c"
 dependencies = [
  "bytes",
- "http 1.4.2",
+ "http 1.5.0",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
 ]
@@ -2456,31 +2485,31 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "15cdd26707701c53297e2fa6afb323d55fbc1d0810c3aec078ae3ef0424c3c15"
 
 [[package]]
 name = "hybrid-array"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+checksum = "707114b52a152fa7bdb290cd7cd5912d9467273b6d74e21b8d81aca1f8533f6b"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
+checksum = "27b501faa50e7a26c3d3560ca625132f4078a17771f4810baf70475ae48cbe43"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
- "http 1.4.2",
+ "h2 0.4.19",
+ "http 1.5.0",
  "http-body",
  "httparse",
  "itoa",
@@ -2496,7 +2525,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.2",
+ "http 1.5.0",
  "hyper",
  "hyper-util",
  "rustls",
@@ -2516,14 +2545,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2555,9 +2584,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -2569,9 +2598,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2582,9 +2611,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -2596,16 +2625,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -2616,15 +2646,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2658,9 +2688,9 @@ dependencies = [
 
 [[package]]
 name = "impl-more"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35a84fd5aa25fae5c0f4a33d9cac2ca017fc622cbd089be2229993514990f870"
+checksum = "277ff51754a3f68f12f58446c5d006aa8baa4914ea273cce24a599cfaff33d4f"
 
 [[package]]
 name = "impl-trait-for-tuples"
@@ -2670,14 +2700,14 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.14.0"
+version = "2.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+checksum = "07aa2048142242915a31d35844fb311e0e53fcca590c3a0a40dcf1b841fa09eb"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
@@ -2705,9 +2735,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2741,19 +2771,19 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2843,9 +2873,9 @@ checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libm"
@@ -2861,9 +2891,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "local-channel"
@@ -2893,9 +2923,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "lru-slab"
@@ -2940,9 +2970,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "memory-stats"
@@ -2982,9 +3012,9 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -2992,9 +3022,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.1"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3094,9 +3124,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.6"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -3125,7 +3155,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3140,20 +3170,19 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -3191,9 +3220,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.37.3"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
 dependencies = [
  "memchr",
 ]
@@ -3210,7 +3239,7 @@ dependencies = [
  "chrono",
  "form_urlencoded",
  "futures",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body-util",
  "httparse",
  "humantime",
@@ -3220,14 +3249,14 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand 0.9.4",
+ "rand 0.9.5",
  "reqwest",
  "ring",
  "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "url",
@@ -3276,7 +3305,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3313,7 +3342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
 dependencies = [
  "num-traits",
- "rand 0.8.6",
+ "rand 0.8.8",
  "rkyv",
  "serde",
 ]
@@ -3339,7 +3368,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3449,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -3483,9 +3512,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "postcard"
@@ -3502,9 +3531,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -3517,9 +3546,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppmd-rust"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
+checksum = "9e9219bcb9d7aca6b2f63c83cf100cf78bcd619ac46e6ecbd0dd90869a39345d"
 
 [[package]]
 name = "ppv-lite86"
@@ -3537,7 +3566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3566,9 +3595,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
@@ -3581,16 +3610,16 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "version_check",
  "yansi",
 ]
 
 [[package]]
 name = "psm"
-version = "0.1.31"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645dbe486e346d9b5de3ef16ede18c26e6c70ad97418f4874b8b1889d6e761ea"
+checksum = "4dcd034599e63b970727f70d79e02d62390a4a84f7c6b827c27c46d5ac3fa622"
 dependencies = [
  "ar_archive_writer",
  "cc",
@@ -3671,8 +3700,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
- "thiserror 2.0.18",
+ "socket2",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
  "web-time",
@@ -3680,20 +3709,21 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.15"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.2",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tinyvec",
  "tracing",
  "web-time",
@@ -3701,23 +3731,23 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
 dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.46"
+version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
+checksum = "1fbf4db142a473a8d80c26bbf18454ed458bf8d26c8219c331daecfdbd079001"
 dependencies = [
  "proc-macro2",
 ]
@@ -3752,9 +3782,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.6"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -3764,9 +3794,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3774,9 +3804,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.3",
@@ -3829,6 +3859,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rayon"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3865,7 +3904,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
 dependencies = [
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3879,9 +3918,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "f020237b6c8eed93db2e2cb53c00c60a8e1bc73da7d073199a1180401450218d"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3891,9 +3930,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3931,8 +3970,8 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.15",
- "http 1.4.2",
+ "h2 0.4.19",
+ "http 1.5.0",
  "http-body",
  "http-body-util",
  "hyper",
@@ -4037,9 +4076,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
 
 [[package]]
 name = "rustc_version"
@@ -4065,9 +4104,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.41"
+version = "0.23.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
+checksum = "0283386ce02abc0151e1761d08802dfe86c173b0b494af5cbc086574e453da06"
 dependencies = [
  "once_cell",
  "ring",
@@ -4100,9 +4139,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.15.0"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4110,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4121,9 +4160,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "rustyline"
@@ -4207,12 +4246,12 @@ dependencies = [
 
 [[package]]
 name = "sedimentree_core"
-version = "0.13.0"
-source = "git+https://github.com/inkandswitch/subduction#03d322c0313578e232d989697d0f47f772083f25"
+version = "0.14.0"
+source = "git+https://github.com/inkandswitch/subduction#61d1030f805b469ee9df39bfbc944c33f5605058"
 dependencies = [
  "arbitrary",
  "async-lock",
- "bijou64",
+ "bijoux",
  "blake3",
  "future_form",
  "futures",
@@ -4220,10 +4259,10 @@ dependencies = [
  "getrandom 0.2.17",
  "nonempty",
  "num-bigint",
- "rand 0.8.6",
+ "rand 0.8.8",
  "serde",
  "siphasher",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tracing",
 ]
 
@@ -4241,39 +4280,61 @@ checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
 ]
 
 [[package]]
-name = "serde_core"
-version = "1.0.228"
+name = "serde-wasm-bindgen"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
+dependencies = [
+ "js-sys",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.229"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",
@@ -4318,9 +4379,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -4334,7 +4395,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
+ "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
 
@@ -4385,9 +4446,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
 
 [[package]]
 name = "simdutf8"
@@ -4420,9 +4481,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -4435,25 +4496,15 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "snap"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
+checksum = "199905e6153d6405f9728fe44daace35f8f837bbf830bb6e85fbd5828709a886"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
+checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4461,9 +4512,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -4496,9 +4547,9 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stacker"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "640c8cdd92b6b12f5bcb1803ca3bbf5ab96e5e6b6b96b9ab77dabe9e880b3190"
+checksum = "707f49d46706bacf8a2b00d51dace3f9de527c13eec3778f570c411f89e69967"
 dependencies = [
  "cc",
  "cfg-if",
@@ -4521,12 +4572,12 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subduction_core"
-version = "0.16.0"
-source = "git+https://github.com/inkandswitch/subduction#03d322c0313578e232d989697d0f47f772083f25"
+version = "0.18.0"
+source = "git+https://github.com/inkandswitch/subduction#61d1030f805b469ee9df39bfbc944c33f5605058"
 dependencies = [
  "async-channel",
  "async-lock",
- "bijou64",
+ "bijoux",
  "blake3",
  "ed25519-dalek",
  "future_form",
@@ -4536,15 +4587,15 @@ dependencies = [
  "sedimentree_core",
  "siphasher",
  "subduction_crypto",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "subduction_crypto"
-version = "0.8.0"
-source = "git+https://github.com/inkandswitch/subduction#03d322c0313578e232d989697d0f47f772083f25"
+version = "0.9.0"
+source = "git+https://github.com/inkandswitch/subduction#61d1030f805b469ee9df39bfbc944c33f5605058"
 dependencies = [
  "ed25519-dalek",
  "future_form",
@@ -4552,13 +4603,13 @@ dependencies = [
  "getrandom 0.2.17",
  "sedimentree_core",
  "serde",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "subduction_websocket"
-version = "0.11.0"
-source = "git+https://github.com/inkandswitch/subduction#03d322c0313578e232d989697d0f47f772083f25"
+version = "0.12.0"
+source = "git+https://github.com/inkandswitch/subduction#61d1030f805b469ee9df39bfbc944c33f5605058"
 dependencies = [
  "async-channel",
  "async-lock",
@@ -4568,11 +4619,11 @@ dependencies = [
  "futures",
  "futures-timer",
  "futures-util",
- "rand 0.8.6",
+ "rand 0.8.8",
  "sedimentree_core",
  "subduction_core",
  "subduction_crypto",
- "thiserror 2.0.18",
+ "thiserror 2.0.20",
  "tokio",
  "tokio-util",
  "tracing",
@@ -4598,9 +4649,20 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.118"
+version = "2.0.119"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
+checksum = "872831b642d1a07999a962a351ed35b955ea2cfc8f3862091e2a240a84f17297"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4624,7 +4686,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4687,11 +4749,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.20",
 ]
 
 [[package]]
@@ -4702,18 +4764,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4728,21 +4790,20 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -4752,15 +4813,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "7e689342a48d2ea927c87ea50cabf8594854bf940e9310208848d680d668ed85"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4777,9 +4838,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4797,9 +4858,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4812,9 +4873,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.3"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -4822,20 +4883,20 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.4",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.0"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4860,14 +4921,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]
@@ -4896,7 +4958,7 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.2",
+ "http 1.5.0",
  "http-body",
  "pin-project-lite",
  "tower",
@@ -4937,7 +4999,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -4986,6 +5048,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "tsify"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea3af6b48c5c5624f7eb3c2f578d1335fadac433321980cae0063e8eb0acaa44"
+dependencies = [
+ "gloo-utils",
+ "serde",
+ "serde_json",
+ "tsify-macros",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "tsify-macros"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "tungstenite"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4993,13 +5080,13 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.4.2",
+ "http 1.5.0",
  "httparse",
  "log",
  "native-tls",
- "rand 0.9.4",
- "sha1 0.10.6",
- "thiserror 2.0.18",
+ "rand 0.9.5",
+ "sha1 0.10.7",
+ "thiserror 2.0.20",
  "utf-8",
 ]
 
@@ -5111,15 +5198,15 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "uuid",
 ]
 
 [[package]]
 name = "uuid"
-version = "1.23.4"
+version = "1.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+checksum = "b5772d71c9be8a8a6ac2117d949c5b224c1b72241bb611d9a3012edcf8af7812"
 dependencies = [
  "getrandom 0.4.3",
  "js-sys",
@@ -5181,9 +5268,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5194,9 +5281,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5204,9 +5291,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5214,22 +5301,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
@@ -5249,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5319,7 +5406,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5330,7 +5417,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5363,16 +5450,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -5390,31 +5468,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -5424,22 +5485,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5448,22 +5497,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5472,22 +5509,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -5496,22 +5521,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
@@ -5521,9 +5534,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "wyz"
@@ -5536,9 +5549,9 @@ dependencies = [
 
 [[package]]
 name = "xxhash-rust"
-version = "0.8.15"
+version = "0.8.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd20c5420375476fbd4394763288da7eb0cc0b8c11deed431a91562af7335d3"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "yansi"
@@ -5565,28 +5578,28 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.52"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5606,7 +5619,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
  "synstructure",
 ]
 
@@ -5627,14 +5640,14 @@ checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 2.0.119",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -5643,9 +5656,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -5654,13 +5667,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -5683,7 +5696,7 @@ dependencies = [
  "memchr",
  "pbkdf2",
  "ppmd-rust",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "time",
  "zeroize",
  "zopfli",
@@ -5692,15 +5705,15 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.4"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
 
 [[package]]
 name = "zmij"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1075,22 +1075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "coln-js-runtime"
-version = "0.1.0"
-dependencies = [
- "coln-flir-rs",
- "coln-store",
- "console_error_panic_hook",
- "hex",
- "js-sys",
- "serde",
- "serde-wasm-bindgen",
- "serde_json",
- "tsify",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "coln-query"
 version = "0.1.0"
 dependencies = [
@@ -1152,16 +1136,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
-]
-
-[[package]]
-name = "console_error_panic_hook"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
-dependencies = [
- "cfg-if",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2248,19 +2222,6 @@ dependencies = [
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5555354113b18c547c1d3a98fbf7fb32a9ff4f6fa112ce823a21641a0ba3aa"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -4289,17 +4250,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-wasm-bindgen"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4313,17 +4263,6 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5045,31 +4984,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tsify"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3af6b48c5c5624f7eb3c2f578d1335fadac433321980cae0063e8eb0acaa44"
-dependencies = [
- "gloo-utils",
- "serde",
- "serde_json",
- "tsify-macros",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "tsify-macros"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef1e2e93369379d0a527c7d6632b58c55d52db7a106d8afbde3b354f3a57a9f1"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.118",
-]
 
 [[package]]
 name = "tungstenite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,5 @@
 [workspace]
 members = [
-  "packages/coln-js-runtime",
   "packages/coln-flir-rs",
   "packages/coln-store",
   "packages/coln-query",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [workspace]
 members = [
+  "packages/coln-js-runtime",
   "packages/coln-flir-rs",
   "packages/coln-store",
   "packages/coln-query",
   "packages/coln-integrator",
-  "packages/coln-batch"
+  "packages/coln-batch",
 ]
 resolver = "3"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+  "packages/coln-js-runtime",
   "packages/coln-flir-rs",
   "packages/coln-store",
   "packages/coln-query",

--- a/packages/coln-flir-rs/src/ir/mod.rs
+++ b/packages/coln-flir-rs/src/ir/mod.rs
@@ -141,7 +141,7 @@ pub struct Schema {
 #[serde(tag = "tag", rename_all = "lowercase")]
 pub enum Lit {
     #[serde(rename = "int")]
-    Int { value: i64 },
+    Int { value: i32 },
     #[serde(rename = "string")]
     String { value: String },
 }

--- a/packages/coln-js-runtime/Cargo.toml
+++ b/packages/coln-js-runtime/Cargo.toml
@@ -14,7 +14,7 @@ js-sys = "0.3.83"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6.5"
 serde_json = "1.0.150"
-tsify = "0.5.6"
+tsify = "0.5.8"
 wasm-bindgen = "0.2.123"
 
 [lib]

--- a/packages/coln-js-runtime/src/rust/dto.rs
+++ b/packages/coln-js-runtime/src/rust/dto.rs
@@ -10,8 +10,8 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use coln_store::{
     commit::hash::CommitHash as StoreCommitHash,
     store::CommitChunk as StoreCommitChunk,
-    table::{CellValue as StoreCellValue, RowId as StoreRowId, RowView as StoreRowView},
-    txn::{RowHandle, TxnValue as StoreTxnValue},
+    table::{CellValue as StoreCellValue, WireRowId as StoreRowId, RowView as StoreRowView},
+    txn::{TxnLiveRowId, TxnLiveValue as StoreTxnValue},
 };
 
 use crate::error::BoundaryError;
@@ -163,9 +163,9 @@ impl From<Value> for StoreTxnValue {
             Value::Id(row_ref) => {
                 let handle = match row_ref {
                     RowRef::Pending(temp_row_id) => {
-                        RowHandle::from_pending(temp_row_id.tx_id.into(), temp_row_id.counter)
+                        TxnLiveRowId::from_pending(temp_row_id.tx_id.into(), temp_row_id.counter)
                     }
-                    RowRef::Existing(row_id) => RowHandle::from_existing(
+                    RowRef::Existing(row_id) => TxnLiveRowId::from_existing(
                         row_id.try_into().expect("commit hash not messed up"),
                     ),
                 };

--- a/packages/coln-js-runtime/src/rust/dto.rs
+++ b/packages/coln-js-runtime/src/rust/dto.rs
@@ -4,7 +4,8 @@
 
 use serde::{Deserialize, Serialize};
 use std::array::TryFromSliceError;
-use tsify::Tsify;
+use tsify::{Ts, Tsify};
+use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
 use coln_store::{
@@ -14,10 +15,9 @@ use coln_store::{
     txn::{TxnLiveRowId, TxnLiveValue as StoreTxnValue},
 };
 
-use crate::error::BoundaryError;
+use crate::error::{BoundaryError, js_error};
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct CommitChunk {
     pub hash: CommitHash,
@@ -36,7 +36,6 @@ impl From<StoreCommitChunk> for CommitChunk {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(transparent)]
 pub struct CommitHash {
     value: String,
@@ -60,7 +59,6 @@ impl TryFrom<CommitHash> for StoreCommitHash {
 
 /// TempRowId for JS runtime, different from TempRowId in coln-store
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct TempRowId {
     pub tx_id: u64,
@@ -68,7 +66,6 @@ pub struct TempRowId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct RowId {
     pub commit: CommitHash,
@@ -76,7 +73,6 @@ pub struct RowId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub enum RowRef {
     Pending(TempRowId),
@@ -108,7 +104,6 @@ impl TryFrom<RowRef> for StoreRowId {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(from_wasm_abi, into_wasm_abi)]
 #[serde(tag = "tag", content = "value", rename_all = "lowercase")]
 pub enum Value {
     #[serde(rename = "row_id")]
@@ -137,13 +132,19 @@ impl Value {
 }
 
 #[wasm_bindgen(js_name = valueEqual)]
-pub fn value_equal(v0: Value, v1: Value) -> bool {
-    v0 == v1
+pub fn value_equal(v0: Ts<Value>, v1: Ts<Value>) -> Result<bool, JsValue> {
+    let v0 = v0.to_rust().map_err(js_error)?;
+    let v1 = v1.to_rust().map_err(js_error)?;
+
+    Ok(v0 == v1)
 }
 
 #[wasm_bindgen(js_name = getRowRef)]
-pub fn value_row_ref(v: Value) -> Option<RowRef> {
-    v.row_ref()
+pub fn value_row_ref(v: Ts<Value>) -> Result<Option<Ts<RowRef>>, JsValue> {
+    match v.to_rust().map_err(js_error)?.row_ref() {
+        Some(row_ref) => row_ref.into_ts().map(Some).map_err(js_error),
+        None => Ok(None),
+    }
 }
 
 // For reading
@@ -180,7 +181,6 @@ impl From<Value> for StoreTxnValue {
 // We use Value for both row_id and values to simplify the interface of the app
 // developer
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct RowView {
     pub row_id: Value,

--- a/packages/coln-js-runtime/src/rust/dto.rs
+++ b/packages/coln-js-runtime/src/rust/dto.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use coln_store::{
     commit::hash::CommitHash as StoreCommitHash,
     store::CommitChunk as StoreCommitChunk,
-    table::{CellValue as StoreCellValue, WireRowId as StoreRowId, RowView as StoreRowView},
+    table::{WireValue as StoreCellValue, WireRowId as StoreRowId, RowView as StoreRowView},
     txn::{TxnLiveRowId, TxnLiveValue as StoreTxnValue},
 };
 
@@ -113,7 +113,7 @@ impl TryFrom<RowRef> for StoreRowId {
 pub enum Value {
     #[serde(rename = "row_id")]
     Id(RowRef),
-    Int(i64),
+    Int(i32),
     String(String),
 }
 

--- a/packages/coln-js-runtime/src/rust/dto.rs
+++ b/packages/coln-js-runtime/src/rust/dto.rs
@@ -10,7 +10,7 @@ use wasm_bindgen::prelude::wasm_bindgen;
 use coln_store::{
     commit::hash::CommitHash as StoreCommitHash,
     store::CommitChunk as StoreCommitChunk,
-    table::{WireValue as StoreCellValue, WireRowId as StoreRowId, RowView as StoreRowView},
+    table::{RowView as StoreRowView, WireRowId as StoreRowId, WireValue as StoreCellValue},
     txn::{TxnLiveRowId, TxnLiveValue as StoreTxnValue},
 };
 

--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -14,6 +14,7 @@ use js_sys::Reflect;
 use crate::dto::{CommitChunk, CommitHash, RowId, RowRef, RowView, Value};
 use crate::error::js_error;
 
+use tsify::{Ts, Tsify};
 use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::wasm_bindgen;
 
@@ -78,9 +79,13 @@ fn resolve_value_id(js_value: &JsValue, row_id: RowId) -> Result<(), JsValue> {
 
 #[wasm_bindgen]
 impl TransactionHandle {
-    pub fn add(&mut self, path: String, values: Vec<Value>) -> Result<JsValue, JsValue> {
+    pub fn add(&mut self, path: String, values: Vec<Ts<Value>>) -> Result<JsValue, JsValue> {
         let path = ir::Path::from(path);
-        let values = values.into_iter().map(|v| v.into()).collect::<Vec<_>>();
+        let values = values
+            .iter()
+            .map(|value| value.to_rust())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(js_error)?;
         let handle = self.tx()?.add(&path, values).map_err(js_error)?;
 
         let (tx_id, counter) = handle.pending_ids().map_err(js_error)?;
@@ -176,7 +181,7 @@ impl StoreHandle {
     }
 
     #[wasm_bindgen(js_name = scanTable)]
-    pub fn scan_table(&self, path: String) -> Result<Vec<RowView>, JsValue> {
+    pub fn scan_table(&self, path: String) -> Result<Vec<Ts<RowView>>, JsValue> {
         let path = ir::Path::from(path);
         let rows = self
             .store()?
@@ -184,15 +189,26 @@ impl StoreHandle {
             .map(|rows| rows.map(RowView::from).collect::<Vec<_>>())
             .unwrap_or_default();
 
-        Ok(rows)
+        rows.iter()
+            .map(|row| row.into_ts())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = rowById)]
-    pub fn row_by_id(&self, path: String, row_id: RowRef) -> Result<Option<RowView>, JsValue> {
+    pub fn row_by_id(
+        &self,
+        path: String,
+        row_id: Ts<RowRef>,
+    ) -> Result<Option<Ts<RowView>>, JsValue> {
         let path = ir::Path::from(path);
+        let row_id = row_id.to_rust().map_err(js_error)?;
         let row_id = StoreRowId::try_from(row_id).map_err(js_error)?;
 
-        Ok(self.store()?.row_by_id(&path, row_id).map(RowView::from))
+        match self.store()?.row_by_id(&path, row_id) {
+            Some(row) => RowView::from(row).into_ts().map(Some).map_err(js_error),
+            None => Ok(None),
+        }
     }
 
     #[wasm_bindgen(js_name = beginTransaction)]
@@ -228,7 +244,7 @@ impl StoreHandle {
 impl StoreHandle {
     // For automerge-repo interfacing
 
-    pub fn heads(&self) -> Result<Vec<CommitHash>, JsValue> {
+    pub fn heads(&self) -> Result<Vec<Ts<CommitHash>>, JsValue> {
         let heads = match &self.state {
             StoreHandleState::Uninitialized { .. } => return Ok(Vec::new()),
             StoreHandleState::Ready { store, .. } => store,
@@ -243,31 +259,37 @@ impl StoreHandle {
         .map(CommitHash::from)
         .collect::<Vec<_>>();
 
-        Ok(heads)
+        heads
+            .iter()
+            .map(|hash| hash.into_ts())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = commitChunksAfter)]
     pub fn commit_chunks_after(
         &self,
-        have_heads: Vec<CommitHash>,
-    ) -> Result<Vec<CommitChunk>, JsValue> {
+        have_heads: Vec<Ts<CommitHash>>,
+    ) -> Result<Vec<Ts<CommitChunk>>, JsValue> {
         if matches!(self.state, StoreHandleState::Uninitialized { .. }) {
             return Ok(Vec::new());
         }
         let have_heads = have_heads
+            .iter()
+            .map(|hash| hash.to_rust())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(js_error)?
             .into_iter()
             .map(StoreCommitHash::try_from)
             .collect::<Result<Vec<_>, _>>()
             .map_err(js_error)?;
 
-        let chunks = self
-            .store()?
+        self.store()?
             .commit_chunks_after(&have_heads)
             .into_iter()
-            .map(CommitChunk::from)
-            .collect::<Vec<_>>();
-
-        Ok(chunks)
+            .map(|chunk| CommitChunk::from(chunk).into_ts())
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(js_error)
     }
 
     #[wasm_bindgen(js_name = applyChunkBytes)]
@@ -403,7 +425,7 @@ mod tests {
         let mut store = Store::try_from_ir(theory).expect("store");
         let mut transaction = store.transaction();
         transaction
-            .add(&Path::from("T"), vec![42_i32.into()])
+            .add(&Path::from("T"), vec![42_i32])
             .expect("add row");
         transaction.commit().expect("commit");
         store
@@ -437,7 +459,7 @@ mod tests {
         let mut source = source_store();
         let mut transaction = source.transaction();
         transaction
-            .add(&Path::from("T"), vec![84_i32.into()])
+            .add(&Path::from("T"), vec![84_i32])
             .expect("add second row");
         transaction.commit().expect("second commit");
 
@@ -472,7 +494,7 @@ mod tests {
         let mut source = source_store();
         let mut transaction = source.transaction();
         transaction
-            .add(&Path::from("T"), vec![84_i32.into()])
+            .add(&Path::from("T"), vec![84_i32])
             .expect("add second row");
         transaction.commit().expect("second commit");
 
@@ -514,7 +536,7 @@ mod tests {
         transaction
             .tx()
             .expect("owned transaction")
-            .add(&Path::from("T"), vec![84_i32.into()])
+            .add(&Path::from("T"), vec![84_i32])
             .expect("stage row");
 
         let recovered = transaction.take_store().expect("recover store");

--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -6,8 +6,8 @@ use coln_flir_rs::ir;
 use coln_store::{
     commit::{chunk::Chunk, hash::CommitHash as StoreCommitHash},
     store::Store,
-    table::RowId as StoreRowId,
-    txn::{OwnedTransaction, RowHandle as StoreRowHandle},
+    table::WireRowId as StoreRowId,
+    txn::{OwnedTransaction, TxnLiveRowId as StoreRowHandle},
 };
 use js_sys::Reflect;
 

--- a/packages/coln-js-runtime/src/rust/handles.rs
+++ b/packages/coln-js-runtime/src/rust/handles.rs
@@ -403,7 +403,7 @@ mod tests {
         let mut store = Store::try_from_ir(theory).expect("store");
         let mut transaction = store.transaction();
         transaction
-            .add(&Path::from("T"), vec![42_i64.into()])
+            .add(&Path::from("T"), vec![42_i32.into()])
             .expect("add row");
         transaction.commit().expect("commit");
         store
@@ -437,7 +437,7 @@ mod tests {
         let mut source = source_store();
         let mut transaction = source.transaction();
         transaction
-            .add(&Path::from("T"), vec![84_i64.into()])
+            .add(&Path::from("T"), vec![84_i32.into()])
             .expect("add second row");
         transaction.commit().expect("second commit");
 
@@ -472,7 +472,7 @@ mod tests {
         let mut source = source_store();
         let mut transaction = source.transaction();
         transaction
-            .add(&Path::from("T"), vec![84_i64.into()])
+            .add(&Path::from("T"), vec![84_i32.into()])
             .expect("add second row");
         transaction.commit().expect("second commit");
 
@@ -514,7 +514,7 @@ mod tests {
         transaction
             .tx()
             .expect("owned transaction")
-            .add(&Path::from("T"), vec![84_i64.into()])
+            .add(&Path::from("T"), vec![84_i32.into()])
             .expect("stage row");
 
         let recovered = transaction.take_store().expect("recover store");

--- a/packages/coln-query/src/api/query.rs
+++ b/packages/coln-query/src/api/query.rs
@@ -854,7 +854,7 @@ impl From<&ir::Path> for EntityRef {
 impl From<&ir::Lit> for Literal {
     fn from(value: &ir::Lit) -> Self {
         match value {
-            ir::Lit::Int { value } => Literal::Iint(*value),
+            ir::Lit::Int { value } => Literal::Iint((*value).into()),
             ir::Lit::String { value } => Literal::String(value.clone()),
         }
     }

--- a/packages/coln-query/src/test_utils.rs
+++ b/packages/coln-query/src/test_utils.rs
@@ -133,7 +133,9 @@ pub mod flir {
 
     pub fn lit_term(value: i64) -> ir::Term {
         ir::Term::Lit {
-            lit: ir::Lit::Int { value },
+            lit: ir::Lit::Int {
+                value: value.try_into().unwrap(),
+            },
         }
     }
 

--- a/packages/coln-store/docs/primitives.md
+++ b/packages/coln-store/docs/primitives.md
@@ -51,7 +51,7 @@ binding
 ```rust
 struct RowView {
     row_id: RowId,
-    values: Vec<CellValue>,
+    values: Vec<WireValue>,
 }
 
 Store::scan_table(table_path) -> Option<impl Iterator<Item = RowView>>

--- a/packages/coln-store/src/commit/mod.rs
+++ b/packages/coln-store/src/commit/mod.rs
@@ -228,8 +228,8 @@ mod tests {
     use crate::commit::chunk::{Chunk, hash};
     use crate::commit::hash::HASH_SIZE;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, TableEntry};
-    use crate::table::{WireRowId, TableMeta, TableOid};
-    use crate::txn::{TxnWireRowId, TempRowId};
+    use crate::table::{TableMeta, TableOid, WireRowId};
+    use crate::txn::{TempRowId, TxnWireRowId};
 
     fn zero_hash() -> CommitHash {
         CommitHash([0u8; HASH_SIZE])

--- a/packages/coln-store/src/commit/mod.rs
+++ b/packages/coln-store/src/commit/mod.rs
@@ -29,7 +29,7 @@ use crate::{
     ir::Path,
     op::Op,
     table::{TableMeta, TableOid},
-    txn::{PendingOp, RowRef, TxnCellValue},
+    txn::{PendingOp, TxnWireRowId, TxnWireValue},
 };
 
 /// A commit: canonical payload bytes, content hash, and parsed metadata.
@@ -211,7 +211,7 @@ fn collect_op_hashes(pending: &[PendingOp], hash_mapper: &mut HashMapper) {
     for op in pending {
         let PendingOp::Add { values, .. } = op;
         for value in values {
-            if let TxnCellValue::Id(RowRef::Existing(row_id)) = value {
+            if let TxnWireValue::Id(TxnWireRowId::Existing(row_id)) = value {
                 hash_mapper.insert(row_id.commit);
             }
         }
@@ -228,8 +228,8 @@ mod tests {
     use crate::commit::chunk::{Chunk, hash};
     use crate::commit::hash::HASH_SIZE;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, TableEntry};
-    use crate::table::{RowId, TableMeta, TableOid};
-    use crate::txn::{RowRef, TempRowId};
+    use crate::table::{WireRowId, TableMeta, TableOid};
+    use crate::txn::{TxnWireRowId, TempRowId};
 
     fn zero_hash() -> CommitHash {
         CommitHash([0u8; HASH_SIZE])
@@ -415,7 +415,7 @@ mod tests {
     fn decode_data_preserves_payload_metadata_and_ops() {
         let dep = zero_hash();
         let deps = vec![dep];
-        let rid = RowId {
+        let rid = WireRowId {
             commit: dep,
             counter: 7,
         };
@@ -423,15 +423,15 @@ mod tests {
             PendingOp::Add {
                 row_id: TempRowId(0),
                 table: 0,
-                values: vec![1i64.into()],
+                values: vec![1i32.into()],
             },
             PendingOp::Add {
                 row_id: TempRowId(1),
                 table: 1,
                 values: vec![
-                    TxnCellValue::Id(RowRef::Existing(rid)),
-                    TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
-                    TxnCellValue::Str("x".into()),
+                    TxnWireValue::Id(TxnWireRowId::Existing(rid)),
+                    TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
+                    TxnWireValue::Str("x".into()),
                 ],
             },
         ];
@@ -606,22 +606,22 @@ mod tests {
         let dep = zero_hash();
         let deps = vec![dep];
         let author = Author::foo();
-        let rid = RowId {
+        let rid = WireRowId {
             commit: dep,
             counter: 7,
         };
         let op0 = PendingOp::Add {
             row_id: TempRowId(0),
             table: 0,
-            values: vec![1i64.into()],
+            values: vec![1i32.into()],
         };
         let op1 = PendingOp::Add {
             row_id: TempRowId(1),
             table: 1,
             values: vec![
-                TxnCellValue::Id(RowRef::Existing(rid)),
-                TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
-                TxnCellValue::Str("x".into()),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid)),
+                TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
+                TxnWireValue::Str("x".into()),
             ],
         };
         let pending = vec![op0, op1];
@@ -650,22 +650,22 @@ mod tests {
         let dep = zero_hash();
         let deps = vec![dep];
         let author = Author::foo();
-        let rid = RowId {
+        let rid = WireRowId {
             commit: dep,
             counter: 7,
         };
         let op0 = PendingOp::Add {
             row_id: TempRowId(0),
             table: 0,
-            values: vec![1i64.into()],
+            values: vec![1i32.into()],
         };
         let op1 = PendingOp::Add {
             row_id: TempRowId(1),
             table: 1,
             values: vec![
-                TxnCellValue::Id(RowRef::Existing(rid)),
-                TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
-                TxnCellValue::Str("x".into()),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid)),
+                TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
+                TxnWireValue::Str("x".into()),
             ],
         };
         let pending = vec![op0, op1];
@@ -689,16 +689,16 @@ mod tests {
     fn other_hashes_contain_right_hashes() {
         let ha = CommitHash([1u8; HASH_SIZE]);
         let hb = CommitHash([2u8; HASH_SIZE]);
-        let rid_a = RowId {
+        let rid_a = WireRowId {
             commit: ha,
             counter: 0,
         };
-        let rid_b = RowId {
+        let rid_b = WireRowId {
             commit: hb,
             counter: 3,
         };
         // also point to ha
-        let rid_a_later = RowId {
+        let rid_a_later = WireRowId {
             commit: ha,
             counter: 99,
         };
@@ -707,16 +707,16 @@ mod tests {
             row_id: TempRowId(0),
             table: 0,
             values: vec![
-                TxnCellValue::Id(RowRef::Existing(rid_a)),
-                TxnCellValue::Id(RowRef::Existing(rid_a)),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid_a)),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid_a)),
             ],
         };
         let op1 = PendingOp::Add {
             row_id: TempRowId(1),
             table: 0,
             values: vec![
-                TxnCellValue::Id(RowRef::Existing(rid_b)),
-                TxnCellValue::Id(RowRef::Existing(rid_a_later)),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid_b)),
+                TxnWireValue::Id(TxnWireRowId::Existing(rid_a_later)),
             ],
         };
         let commit = Commit::from_commit_data(

--- a/packages/coln-store/src/commit/pst.rs
+++ b/packages/coln-store/src/commit/pst.rs
@@ -100,7 +100,7 @@ mod tests {
     use crate::commit::hash::{CommitHash, HASH_SIZE};
     use crate::commit::wire::CommitData;
     use crate::ir::{FlatRealm, Path, Schema, TableEntry};
-    use crate::table::CellValue;
+    use crate::table::WireValue;
 
     fn int_schema() -> Schema {
         Schema {
@@ -207,7 +207,7 @@ mod tests {
         let mut store = Store::try_from_ir(int_theory()).expect("store");
         let table = Path::from("T");
         let mut txn = store.transaction();
-        txn.add(&table, vec![99_i64.into()]).expect("add row");
+        txn.add(&table, vec![99_i32.into()]).expect("add row");
         txn.commit().expect("commit");
 
         let expected = store
@@ -347,7 +347,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root").hash();
         let table = Path::from("T");
         let mut txn = store.transaction();
-        txn.add(&table, vec![99_i64.into()]).expect("add row");
+        txn.add(&table, vec![99_i32.into()]).expect("add row");
         let commit = txn.commit().expect("commit");
 
         let bytes = encode_store(&store).unwrap();
@@ -355,7 +355,7 @@ mod tests {
 
         let restored_table = restored.table_at(&table).expect("table");
         assert_eq!(restored_table.row_count(), 1);
-        assert_eq!(restored_table.cell_at(0, 0), Some(CellValue::Int(99)));
+        assert_eq!(restored_table.cell_at(0, 0), Some(WireValue::Int(99)));
         assert_eq!(restored_table.row_id_at(0).expect("row id").commit, commit);
         assert_eq!(
             restored.commits().parents_of(&commit),

--- a/packages/coln-store/src/commit/pst.rs
+++ b/packages/coln-store/src/commit/pst.rs
@@ -207,7 +207,7 @@ mod tests {
         let mut store = Store::try_from_ir(int_theory()).expect("store");
         let table = Path::from("T");
         let mut txn = store.transaction();
-        txn.add(&table, vec![99_i32.into()]).expect("add row");
+        txn.add(&table, vec![99_i32]).expect("add row");
         txn.commit().expect("commit");
 
         let expected = store
@@ -347,7 +347,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root").hash();
         let table = Path::from("T");
         let mut txn = store.transaction();
-        txn.add(&table, vec![99_i32.into()]).expect("add row");
+        txn.add(&table, vec![99_i32]).expect("add row");
         let commit = txn.commit().expect("commit");
 
         let bytes = encode_store(&store).unwrap();

--- a/packages/coln-store/src/commit/wire/data.rs
+++ b/packages/coln-store/src/commit/wire/data.rs
@@ -20,8 +20,8 @@ use crate::{
     },
     ir::{BuiltinTy, ColType, Path, Schema},
     op::OP_KIND_ADD,
-    table::{RowId, TableMeta, TableOid},
-    txn::{PendingOp, RowRef, TempRowId, TxnCellValue},
+    table::{WireRowId, TableMeta, TableOid},
+    txn::{PendingOp, TxnWireRowId, TempRowId, TxnWireValue},
 };
 
 // TODO change this to i32 when we support it as a column type
@@ -205,28 +205,28 @@ where
 
 /// encode the row_ref column, which might be a pending id or a already resolved id
 fn encode_txn_row_ref_column(
-    values: &[TxnCellValue],
+    values: &[TxnWireValue],
     hash_mapper: &HashMapper,
 ) -> Result<Vec<u8>, CodecError> {
     let mut hash_indices: Vec<i64> = Vec::with_capacity(values.len());
     let mut counters = Vec::with_capacity(values.len());
 
     for value in values {
-        let TxnCellValue::Id(row_ref) = value else {
+        let TxnWireValue::Id(row_ref) = value else {
             return Err(CodecError::SchemaError(format!(
                 "expected row reference, got {value:?}"
             )));
         };
 
         match row_ref {
-            RowRef::Existing(RowId { commit, counter }) => {
+            TxnWireRowId::Existing(WireRowId { commit, counter }) => {
                 let hash_index = hash_mapper.index(*commit).ok_or_else(|| {
                     CodecError::SchemaError(format!("missing commit hash in dictionary: {commit}"))
                 })? as i64;
                 hash_indices.push(hash_index);
                 counters.push(*counter);
             }
-            RowRef::Pending(temp_id) => {
+            TxnWireRowId::Pending(temp_id) => {
                 hash_indices.push(LOCAL_COMMIT_HASH_INDEX);
                 counters.push(temp_id.counter());
             }
@@ -243,7 +243,7 @@ fn encode_txn_row_ref_column(
 }
 
 fn encode_txn_prim_value_column(
-    values: &[TxnCellValue],
+    values: &[TxnWireValue],
     prim: &BuiltinTy,
 ) -> Result<Vec<u8>, CodecError> {
     let mut value_bytes = Vec::new();
@@ -268,7 +268,7 @@ fn encode_txn_prim_value_column(
 
 /// Columnar encode for one schema column of transaction cell values.
 fn encode_txn_value_column(
-    values: &[TxnCellValue],
+    values: &[TxnWireValue],
     col_type: &ColType,
     hash_mapper: &HashMapper,
 ) -> Result<Vec<u8>, CodecError> {
@@ -290,7 +290,7 @@ fn encode_op_group(
     ops: &[&PendingOp],
     hash_mapper: &HashMapper,
 ) -> Result<Vec<u8>, CodecError> {
-    let mut rows: Vec<&[TxnCellValue]> = Vec::with_capacity(ops.len());
+    let mut rows: Vec<&[TxnWireValue]> = Vec::with_capacity(ops.len());
     for op in ops {
         let PendingOp::Add {
             table: op_table,
@@ -462,7 +462,7 @@ where
 
 struct DecodedOpGroup {
     table: TableOid,
-    rows: Vec<Vec<TxnCellValue>>,
+    rows: Vec<Vec<TxnWireValue>>,
 }
 
 fn decode_op_group<'s, F>(
@@ -534,7 +534,7 @@ fn decode_txn_value_column(
     data: &[u8],
     col_type: &ColType,
     hashes: &[CommitHash],
-) -> Result<Vec<TxnCellValue>, CodecError> {
+) -> Result<Vec<TxnWireValue>, CodecError> {
     match col_type {
         ColType::RowId { .. } => decode_txn_row_ref_column(data, hashes),
         ColType::BuiltinTy { builtin_ty } => decode_txn_prim_value_column(data, builtin_ty),
@@ -544,7 +544,7 @@ fn decode_txn_value_column(
 fn decode_txn_row_ref_column(
     data: &[u8],
     hashes: &[CommitHash],
-) -> Result<Vec<TxnCellValue>, CodecError> {
+) -> Result<Vec<TxnWireValue>, CodecError> {
     let mut pos = 0usize;
     let hash_index_blob =
         commit_leb128::read_len_prefixed_bytes(data, &mut pos, "txn row-ref hash-index column")?;
@@ -572,14 +572,14 @@ fn decode_txn_row_ref_column(
         .zip(counters)
         .map(|(hash_index, counter)| {
             if hash_index == LOCAL_COMMIT_HASH_INDEX {
-                Ok(TxnCellValue::Id(RowRef::Pending(TempRowId(counter))))
+                Ok(TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(counter))))
             } else {
                 let commit = hashes.get(hash_index as usize).copied().ok_or_else(|| {
                     CodecError::DataFormatError(format!(
                         "txn row-ref hash index {hash_index} out of bounds"
                     ))
                 })?;
-                Ok(TxnCellValue::Id(RowRef::Existing(RowId {
+                Ok(TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                     commit,
                     counter,
                 })))
@@ -591,7 +591,7 @@ fn decode_txn_row_ref_column(
 fn decode_txn_prim_value_column(
     data: &[u8],
     prim: &BuiltinTy,
-) -> Result<Vec<TxnCellValue>, CodecError> {
+) -> Result<Vec<TxnWireValue>, CodecError> {
     let mut pos = 0usize;
     let meta_blob =
         commit_leb128::read_len_prefixed_bytes(data, &mut pos, "txn prim value meta column")?;
@@ -641,8 +641,8 @@ mod tests {
     use crate::commit::hash::HASH_SIZE;
     use crate::commit::wire::prim::ValueType;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, Schema};
-    use crate::table::RowId;
-    use crate::txn::{RowRef, TempRowId};
+    use crate::table::WireRowId;
+    use crate::txn::{TxnWireRowId, TempRowId};
 
     #[test]
     fn txn_row_ref_column_round_trips_existing_and_pending_refs() {
@@ -652,16 +652,16 @@ mod tests {
         hash_mapper.insert(ha);
         hash_mapper.insert(hb);
         let values = vec![
-            TxnCellValue::Id(RowRef::Existing(RowId {
+            TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                 commit: ha,
                 counter: 7,
             })),
-            TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
-            TxnCellValue::Id(RowRef::Existing(RowId {
+            TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
+            TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                 commit: hb,
                 counter: 11,
             })),
-            TxnCellValue::Id(RowRef::Pending(TempRowId(2))),
+            TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(2))),
         ];
 
         let encoded = encode_txn_row_ref_column(&values, &hash_mapper).expect("encode row refs");
@@ -673,7 +673,7 @@ mod tests {
 
     #[test]
     fn txn_row_ref_column_rejects_non_ref_values() {
-        let err = encode_txn_row_ref_column(&[TxnCellValue::Int(42)], &HashMapper::new())
+        let err = encode_txn_row_ref_column(&[TxnWireValue::Int(42)], &HashMapper::new())
             .expect_err("int is not a row ref");
 
         assert!(matches!(err, CodecError::SchemaError(_)));
@@ -681,7 +681,7 @@ mod tests {
 
     #[test]
     fn txn_row_ref_column_rejects_unmapped_existing_hashes() {
-        let value = TxnCellValue::Id(RowRef::Existing(RowId {
+        let value = TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
             commit: CommitHash([9u8; HASH_SIZE]),
             counter: 1,
         }));
@@ -696,7 +696,7 @@ mod tests {
         let col = ColType::BuiltinTy {
             builtin_ty: BuiltinTy::BuiltinInt,
         };
-        let values = vec![1i64.into(), 2i64.into(), (-3i64).into()];
+        let values = vec![1i32.into(), 2i32.into(), (-3i32).into()];
         let encoded =
             encode_txn_value_column(&values, &col, &HashMapper::new()).expect("encode int col");
         let decoded = decode_txn_value_column(&encoded, &col, &[]).expect("decode int col");
@@ -722,15 +722,15 @@ mod tests {
         };
         // Span every leb byte-length boundary, including the signed extremes,
         // so the declared meta length must agree with the signed-leb encoding.
-        let values: Vec<TxnCellValue> = vec![
-            0i64.into(),
-            (-1i64).into(),
-            1i64.into(),
-            127i64.into(),
-            128i64.into(),
-            (-128i64).into(),
-            i64::MIN.into(),
-            i64::MAX.into(),
+        let values: Vec<TxnWireValue> = vec![
+            0i32.into(),
+            (-1i32).into(),
+            1i32.into(),
+            127i32.into(),
+            128i32.into(),
+            (-128i32).into(),
+            i32::MIN.into(),
+            i32::MAX.into(),
         ];
         let encoded =
             encode_txn_value_column(&values, &col, &HashMapper::new()).expect("encode int col");
@@ -746,14 +746,14 @@ mod tests {
 
         // Zero-length values interleaved with non-empty ones: the value blob
         // is shorter than the row count, so offsets must advance by zero.
-        let values: Vec<TxnCellValue> = vec!["".into(), "x".into(), "".into()];
+        let values: Vec<TxnWireValue> = vec!["".into(), "x".into(), "".into()];
         let encoded =
             encode_txn_value_column(&values, &col, &HashMapper::new()).expect("encode str col");
         let decoded = decode_txn_value_column(&encoded, &col, &[]).expect("decode str col");
         assert_eq!(decoded, values);
 
         // Zero rows: empty meta and value blobs must round-trip to an empty column.
-        let empty: Vec<TxnCellValue> = vec![];
+        let empty: Vec<TxnWireValue> = vec![];
         let encoded =
             encode_txn_value_column(&empty, &col, &HashMapper::new()).expect("encode empty col");
         let decoded = decode_txn_value_column(&encoded, &col, &[]).expect("decode empty col");
@@ -786,11 +786,11 @@ mod tests {
             path: Path::from("T.E"),
         };
         let values = vec![
-            TxnCellValue::Id(RowRef::Existing(RowId {
+            TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                 commit: ha,
                 counter: 1,
             })),
-            TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
+            TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
         ];
         let encoded =
             encode_txn_value_column(&values, &col, &hash_mapper).expect("encode entity col");
@@ -805,7 +805,7 @@ mod tests {
             builtin_ty: BuiltinTy::BuiltinInt,
         };
         let err = encode_txn_value_column(
-            &[TxnCellValue::Str("nope".into())],
+            &[TxnWireValue::Str("nope".into())],
             &col,
             &HashMapper::new(),
         )
@@ -848,9 +848,9 @@ mod tests {
                 row_id: TempRowId(0),
                 table: table_oid,
                 values: vec![
-                    1i64.into(),
+                    1i32.into(),
                     "a".into(),
-                    TxnCellValue::Id(RowRef::Existing(RowId {
+                    TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                         commit: ha,
                         counter: 7,
                     })),
@@ -860,9 +860,9 @@ mod tests {
                 row_id: TempRowId(1),
                 table: table_oid,
                 values: vec![
-                    2i64.into(),
+                    2i32.into(),
                     "b".into(),
-                    TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
+                    TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
                 ],
             },
         ];
@@ -888,16 +888,16 @@ mod tests {
             let decoded = decode_txn_value_column(blob, &col_entry.col_type, hash_mapper.hashes())
                 .expect("decode col");
             match index {
-                0 => assert_eq!(decoded, vec![1i64.into(), 2i64.into()]),
+                0 => assert_eq!(decoded, vec![1i32.into(), 2i32.into()]),
                 1 => assert_eq!(decoded, vec!["a".into(), "b".into()]),
                 2 => assert_eq!(
                     decoded,
                     vec![
-                        TxnCellValue::Id(RowRef::Existing(RowId {
+                        TxnWireValue::Id(TxnWireRowId::Existing(WireRowId {
                             commit: ha,
                             counter: 7,
                         })),
-                        TxnCellValue::Id(RowRef::Pending(TempRowId(0))),
+                        TxnWireValue::Id(TxnWireRowId::Pending(TempRowId(0))),
                     ]
                 ),
                 _ => unreachable!(),
@@ -986,7 +986,7 @@ mod tests {
             PendingOp::Add {
                 row_id: TempRowId(0),
                 table: 0,
-                values: vec![1i64.into()],
+                values: vec![1i32.into()],
             },
             PendingOp::Add {
                 row_id: TempRowId(1),
@@ -996,7 +996,7 @@ mod tests {
             PendingOp::Add {
                 row_id: TempRowId(2),
                 table: 0,
-                values: vec![2i64.into()],
+                values: vec![2i32.into()],
             },
         ];
 
@@ -1099,7 +1099,7 @@ mod tests {
             PendingOp::Add {
                 row_id: TempRowId(0),
                 table: 0,
-                values: vec![1i64.into()],
+                values: vec![1i32.into()],
             },
             PendingOp::Add {
                 row_id: TempRowId(1),
@@ -1109,7 +1109,7 @@ mod tests {
             PendingOp::Add {
                 row_id: TempRowId(2),
                 table: 0,
-                values: vec![2i64.into()],
+                values: vec![2i32.into()],
             },
         ];
 

--- a/packages/coln-store/src/commit/wire/data.rs
+++ b/packages/coln-store/src/commit/wire/data.rs
@@ -20,8 +20,8 @@ use crate::{
     },
     ir::{BuiltinTy, ColType, Path, Schema},
     op::OP_KIND_ADD,
-    table::{WireRowId, TableMeta, TableOid},
-    txn::{PendingOp, TxnWireRowId, TempRowId, TxnWireValue},
+    table::{TableMeta, TableOid, WireRowId},
+    txn::{PendingOp, TempRowId, TxnWireRowId, TxnWireValue},
 };
 
 // TODO change this to i32 when we support it as a column type
@@ -642,7 +642,7 @@ mod tests {
     use crate::commit::wire::prim::ValueType;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, Schema};
     use crate::table::WireRowId;
-    use crate::txn::{TxnWireRowId, TempRowId};
+    use crate::txn::{TempRowId, TxnWireRowId};
 
     #[test]
     fn txn_row_ref_column_round_trips_existing_and_pending_refs() {

--- a/packages/coln-store/src/commit/wire/prim.rs
+++ b/packages/coln-store/src/commit/wire/prim.rs
@@ -8,7 +8,7 @@ use coln_flir_rs::ir::{self, BuiltinTy};
 use hexane::{Codec, PackError, lebsize};
 
 use crate::commit::leb128 as commit_leb128;
-use crate::{commit::error::CodecError, txn::TxnCellValue};
+use crate::{commit::error::CodecError, txn::TxnWireValue};
 
 /// Number of low bits reserved for the [`ValueType`] code in a [`ValueMeta`].
 const TYPE_CODE_BITS: u32 = 5;
@@ -145,25 +145,25 @@ impl hexane::PrefixValue for ValueMeta {
 /// Writes to the buffer `out` the encoded data, and returns the corresponding
 /// `ValueMeta` representation
 pub(crate) fn encode_prim_value(
-    value: &TxnCellValue,
+    value: &TxnWireValue,
     prim: &BuiltinTy,
     out: &mut Vec<u8>,
 ) -> Result<ValueMeta, CodecError> {
     match prim {
         BuiltinTy::BuiltinInt => {
-            let TxnCellValue::Int(i) = value else {
+            let TxnWireValue::Int(i) = value else {
                 return Err(CodecError::SchemaError(format!(
                     "expected int, got {value:?}"
                 )));
             };
 
-            leb128::write::signed(out, *i)
+            leb128::write::signed(out, *i as i64)
                 .map_err(|e| CodecError::DataFormatError(e.to_string()))?;
 
-            Ok(ValueMeta::new(ValueType::Leb, lebsize(*i) as usize))
+            Ok(ValueMeta::new(ValueType::Leb, lebsize(*i as i64) as usize))
         }
         BuiltinTy::BuiltinStr => {
-            let TxnCellValue::Str(s) = value else {
+            let TxnWireValue::Str(s) = value else {
                 return Err(CodecError::SchemaError(format!(
                     "expected string, got {value:?}"
                 )));
@@ -180,7 +180,7 @@ pub(crate) fn decode_prim_value(
     meta: ValueMeta,
     prim: &BuiltinTy,
     bytes: &[u8],
-) -> Result<TxnCellValue, CodecError> {
+) -> Result<TxnWireValue, CodecError> {
     let ty = meta.type_code();
     if !ty.is_valid_for(prim) {
         return Err(CodecError::SchemaError(format!(
@@ -198,12 +198,12 @@ pub(crate) fn decode_prim_value(
                     "trailing bytes in leb value".into(),
                 ));
             }
-            Ok(TxnCellValue::Int(i))
+            Ok(TxnWireValue::Int(i as i32))
         }
         ValueType::String => {
             let s = std::str::from_utf8(bytes)
                 .map_err(|_| CodecError::DataFormatError("value column: invalid utf-8".into()))?;
-            Ok(TxnCellValue::Str(s.to_owned()))
+            Ok(TxnWireValue::Str(s.to_owned()))
         }
         other => Err(CodecError::DataFormatError(format!(
             "unsupported value type code {other:?}"

--- a/packages/coln-store/src/id_packer.rs
+++ b/packages/coln-store/src/id_packer.rs
@@ -5,7 +5,7 @@
 use crate::commit::hash_dict::HashMapper;
 use crate::op::Op;
 use crate::rollback::Rollback;
-use crate::table::{WireValue, PackedValue, PackedOp, PackedRowId, WireRowId};
+use crate::table::{PackedOp, PackedRowId, PackedValue, WireRowId, WireValue};
 
 /// A packer doing dictionary encoding while supporting rollbacks.
 #[derive(Debug)]

--- a/packages/coln-store/src/id_packer.rs
+++ b/packages/coln-store/src/id_packer.rs
@@ -5,7 +5,7 @@
 use crate::commit::hash_dict::HashMapper;
 use crate::op::Op;
 use crate::rollback::Rollback;
-use crate::table::{CellValue, PackedCell, PackedOp, PackedRowId, RowId};
+use crate::table::{WireValue, PackedValue, PackedOp, PackedRowId, WireRowId};
 
 /// A packer doing dictionary encoding while supporting rollbacks.
 #[derive(Debug)]
@@ -26,7 +26,7 @@ impl IdPacker {
     }
 
     /// Packs `id`, interning its commit hash if it is new.
-    pub(crate) fn pack_row_id(&mut self, id: RowId) -> PackedRowId {
+    pub(crate) fn pack_row_id(&mut self, id: WireRowId) -> PackedRowId {
         PackedRowId {
             commit_idx: self.dict.insert(id.commit),
             counter: id.counter,
@@ -36,15 +36,15 @@ impl IdPacker {
     /// Packs `id` without interning its commit hash.
     ///
     /// Returns `None` when the commit hash has not already been interned.
-    pub(crate) fn lookup_row_id(&self, id: RowId) -> Option<PackedRowId> {
+    pub(crate) fn lookup_row_id(&self, id: WireRowId) -> Option<PackedRowId> {
         Some(PackedRowId {
             commit_idx: self.dict.index(id.commit)?,
             counter: id.counter,
         })
     }
 
-    pub(crate) fn unpack_row_id(&self, id: PackedRowId) -> RowId {
-        RowId {
+    pub(crate) fn unpack_row_id(&self, id: PackedRowId) -> WireRowId {
+        WireRowId {
             commit: self
                 .dict
                 .hash_at(id.commit_idx)
@@ -53,11 +53,11 @@ impl IdPacker {
         }
     }
 
-    pub(crate) fn pack_cell(&mut self, value: CellValue) -> PackedCell {
+    pub(crate) fn pack_cell(&mut self, value: WireValue) -> PackedValue {
         match value {
-            CellValue::Id(id) => PackedCell::Id(self.pack_row_id(id)),
-            CellValue::Int(value) => PackedCell::Int(value),
-            CellValue::Str(value) => PackedCell::Str(value),
+            WireValue::Id(id) => PackedValue::Id(self.pack_row_id(id)),
+            WireValue::Int(value) => PackedValue::Int(value),
+            WireValue::Str(value) => PackedValue::Str(value),
         }
     }
 
@@ -77,11 +77,11 @@ impl IdPacker {
     /// Packs a cell without modifying the dictionary.
     ///
     /// Returns `None` when an ID cell's commit hash has not been interned.
-    pub(crate) fn try_pack_cell(&self, value: &CellValue) -> Option<PackedCell> {
+    pub(crate) fn try_pack_cell(&self, value: &WireValue) -> Option<PackedValue> {
         Some(match value {
-            CellValue::Id(id) => PackedCell::Id(self.lookup_row_id(*id)?),
-            CellValue::Int(value) => PackedCell::Int(*value),
-            CellValue::Str(value) => PackedCell::Str(value.clone()),
+            WireValue::Id(id) => PackedValue::Id(self.lookup_row_id(*id)?),
+            WireValue::Int(value) => PackedValue::Int(*value),
+            WireValue::Str(value) => PackedValue::Str(value.clone()),
         })
     }
 
@@ -122,8 +122,8 @@ mod tests {
     use super::*;
     use crate::commit::hash::CommitHash;
 
-    fn row_id(byte: u8, counter: u32) -> RowId {
-        RowId {
+    fn row_id(byte: u8, counter: u32) -> WireRowId {
+        WireRowId {
             commit: CommitHash([byte; 32]),
             counter,
         }

--- a/packages/coln-store/src/lib.rs
+++ b/packages/coln-store/src/lib.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-pub mod value;
 mod column_map;
 pub mod commit;
 mod id_packer;
@@ -15,5 +14,6 @@ pub mod solver;
 pub mod store;
 pub mod table;
 pub mod txn;
+pub mod value;
 
 use coln_flir_rs::ir;

--- a/packages/coln-store/src/lib.rs
+++ b/packages/coln-store/src/lib.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+pub mod value;
 mod column_map;
 pub mod commit;
 mod id_packer;

--- a/packages/coln-store/src/op.rs
+++ b/packages/coln-store/src/op.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::table::{WireValue, WireRowId, TableOid};
+use crate::table::{TableOid, WireRowId, WireValue};
 
 pub const OP_KIND_ADD: u32 = 0;
 

--- a/packages/coln-store/src/op.rs
+++ b/packages/coln-store/src/op.rs
@@ -2,16 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::table::{CellValue, RowId, TableOid};
+use crate::table::{WireValue, WireRowId, TableOid};
 
 pub const OP_KIND_ADD: u32 = 0;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Op {
     Add {
-        row_id: RowId,
+        row_id: WireRowId,
         table: TableOid,
-        values: Vec<CellValue>,
+        values: Vec<WireValue>,
     },
     // Delete {
     //     row_id: RowId,
@@ -20,7 +20,7 @@ pub enum Op {
 }
 
 impl Op {
-    pub fn id(&self) -> RowId {
+    pub fn id(&self) -> WireRowId {
         match self {
             Op::Add { row_id, .. } => *row_id,
         }

--- a/packages/coln-store/src/repl/exe/mod.rs
+++ b/packages/coln-store/src/repl/exe/mod.rs
@@ -27,7 +27,7 @@ use crate::{
             coln::{self, BatchAssignment, parse_cell_value, parse_cell_value_batch},
         },
     },
-    txn::{TxnWireRowId, liven},
+    txn::TxnWireRowId,
 };
 
 fn help_text(mode: ShellMode) -> String {

--- a/packages/coln-store/src/repl/exe/mod.rs
+++ b/packages/coln-store/src/repl/exe/mod.rs
@@ -12,16 +12,22 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::{repl::{
-    Session, ShellMode, Step,
-    parse::{ColnCommand, MetaCommand, SqlCommand, coln::{self, BatchAssignment, parse_cell_value, parse_cell_value_batch}},
-}, txn::{TxnWireRowId, liven}};
 use crate::{
     commit::pst::{decode_store, encode_store},
     ir::{BuiltinTy, ColType, ColumnEntry, FlatRealm},
     store::Store,
-    table::{WireRowId, TableRef},
+    table::{TableRef, WireRowId},
     txn::{TempRowId, TxnWireValue},
+};
+use crate::{
+    repl::{
+        Session, ShellMode, Step,
+        parse::{
+            ColnCommand, MetaCommand, SqlCommand,
+            coln::{self, BatchAssignment, parse_cell_value, parse_cell_value_batch},
+        },
+    },
+    txn::{TxnWireRowId, liven},
 };
 
 fn help_text(mode: ShellMode) -> String {

--- a/packages/coln-store/src/repl/exe/mod.rs
+++ b/packages/coln-store/src/repl/exe/mod.rs
@@ -12,17 +12,16 @@ use std::{
 
 use anyhow::{Context, Result, anyhow, bail};
 
-use crate::repl::{
+use crate::{repl::{
     Session, ShellMode, Step,
-    parse::coln::{self, BatchAssignment, parse_cell_value, parse_cell_value_batch},
-    parse::{ColnCommand, MetaCommand, SqlCommand},
-};
+    parse::{ColnCommand, MetaCommand, SqlCommand, coln::{self, BatchAssignment, parse_cell_value, parse_cell_value_batch}},
+}, txn::{TxnWireRowId, liven}};
 use crate::{
     commit::pst::{decode_store, encode_store},
     ir::{BuiltinTy, ColType, ColumnEntry, FlatRealm},
     store::Store,
-    table::{RowId, TableRef},
-    txn::{TempRowId, TxnCellValue},
+    table::{WireRowId, TableRef},
+    txn::{TempRowId, TxnWireValue},
 };
 
 fn help_text(mode: ShellMode) -> String {
@@ -387,7 +386,7 @@ pub fn add_rows(
     store: &mut Store,
     table_name: &str,
     raw_rows: &[Vec<String>],
-) -> Result<Vec<RowId>> {
+) -> Result<Vec<WireRowId>> {
     let table_path = crate::ir::Path::from(table_name);
     let oid = store
         .resolve_table(&table_path)
@@ -474,7 +473,7 @@ pub fn run_transact(store: &mut Store, assignments: &[BatchAssignment]) -> Resul
     Ok(message)
 }
 
-fn parse_txn_values(table: TableRef<'_>, raw_values: &[String]) -> Result<Vec<TxnCellValue>> {
+fn parse_txn_values(table: TableRef<'_>, raw_values: &[String]) -> Result<Vec<TxnWireValue>> {
     let expected = table.schema().columns.len();
     if raw_values.len() != expected {
         bail!(
@@ -488,10 +487,10 @@ fn parse_txn_values(table: TableRef<'_>, raw_values: &[String]) -> Result<Vec<Tx
         .columns
         .iter()
         .enumerate()
-        .map(|(idx, column)| -> Result<TxnCellValue> {
+        .map(|(idx, column)| -> Result<TxnWireValue> {
             let raw = &raw_values[idx];
             parse_cell_value(&column.col_type, raw)
-                .map(Into::into)
+                .map(|v| v.map_owned(TxnWireRowId::Existing))
                 .map_err(|message| anyhow!("column {idx}: {message}"))
         })
         .collect()

--- a/packages/coln-store/src/repl/parse/coln.rs
+++ b/packages/coln-store/src/repl/parse/coln.rs
@@ -7,8 +7,8 @@ use std::collections::HashMap;
 use crate::{
     commit::hash::{CommitHash, HASH_SIZE},
     ir::{BuiltinTy, ColType},
-    table::{CellValue, RowId},
-    txn::{TempRowId, TxnCellValue},
+    table::{WireRowId, WireValue},
+    txn::{TempRowId, TxnWireRowId, TxnWireValue},
 };
 
 /// Parse failure for a single cell inside a `begin batch` block (before column index is known).
@@ -94,24 +94,24 @@ pub(crate) fn parse_cell_value_batch(
     col_type: &ColType,
     raw: &str,
     bindings: &HashMap<String, TempRowId>,
-) -> Result<TxnCellValue, ParserError> {
+) -> Result<TxnWireValue, ParserError> {
     match col_type {
         ColType::RowId { .. } => {
             if raw.starts_with('#') {
-                parse_cell_value(col_type, raw).map(Into::into)
+                parse_cell_value(col_type, raw).map(|v| v.map_owned(TxnWireRowId::Existing))
             } else if is_binding_ident(raw) {
                 let id = bindings
                     .get(raw)
                     .copied()
                     .ok_or_else(|| ParserError::UnknownBinding(raw.to_string()))?;
-                Ok(TxnCellValue::from(id))
+                Ok(TxnWireValue::Id(TxnWireRowId::Pending(id)))
             } else {
                 Err(ParserError::InvalidValue(format!(
                     "expected entity id like #<commit>:<counter> or a binding name, got {raw}"
                 )))
             }
         }
-        _ => parse_cell_value(col_type, raw).map(Into::into),
+        _ => parse_cell_value(col_type, raw).map(|v| v.map_owned(TxnWireRowId::Existing)),
     }
 }
 
@@ -308,20 +308,20 @@ fn split_add_row_tokens(row_src: &str) -> Vec<String> {
     out
 }
 
-pub(crate) fn parse_cell_value(col_type: &ColType, raw: &str) -> Result<CellValue, ParserError> {
+pub(crate) fn parse_cell_value(col_type: &ColType, raw: &str) -> Result<WireValue, ParserError> {
     match col_type {
-        ColType::RowId { .. } => parse_row_id(raw).map(CellValue::Id),
+        ColType::RowId { .. } => parse_row_id(raw).map(WireValue::Id),
         ColType::BuiltinTy { builtin_ty } => match builtin_ty {
             BuiltinTy::BuiltinInt => raw
-                .parse::<i64>()
-                .map(CellValue::Int)
+                .parse::<i32>()
+                .map(WireValue::Int)
                 .map_err(|_| ParserError::InvalidValue(format!("invalid int: {raw}"))),
-            BuiltinTy::BuiltinStr => Ok(CellValue::Str(raw.to_string())),
+            BuiltinTy::BuiltinStr => Ok(WireValue::Str(raw.to_string())),
         },
     }
 }
 
-fn parse_row_id(raw: &str) -> Result<RowId, ParserError> {
+fn parse_row_id(raw: &str) -> Result<WireRowId, ParserError> {
     let Some(rest) = raw.strip_prefix('#') else {
         return invalid_input_err("expected entity id like #<commit>:<counter>");
     };
@@ -339,7 +339,7 @@ fn parse_row_id(raw: &str) -> Result<RowId, ParserError> {
     let counter = counter_raw
         .parse::<u32>()
         .map_err(|_| ParserError::InvalidValue(format!("invalid entity id: {raw}")))?;
-    Ok(RowId {
+    Ok(WireRowId {
         commit: CommitHash(hash),
         counter,
     })

--- a/packages/coln-store/src/rowing/mod.rs
+++ b/packages/coln-store/src/rowing/mod.rs
@@ -146,12 +146,12 @@ impl Rowing {
 #[cfg(test)]
 mod tests {
     use crate::commit::hash::CommitHash;
-    use crate::table::RowId;
+    use crate::table::WireRowId;
 
     use super::*;
 
-    fn row_id(byte: u8) -> RowId {
-        RowId {
+    fn row_id(byte: u8) -> WireRowId {
+        WireRowId {
             commit: CommitHash([byte; 32]),
             counter: 0,
         }

--- a/packages/coln-store/src/rowing/uf.rs
+++ b/packages/coln-store/src/rowing/uf.rs
@@ -4,7 +4,7 @@
 
 use ena::unify::{InPlaceUnificationTable, UnifyKey, UnifyValue};
 
-use crate::table::RowId;
+use crate::table::WireRowId;
 
 pub(super) type UnionFind = InPlaceUnificationTable<NodeId>;
 
@@ -12,7 +12,7 @@ pub(super) type UnionFind = InPlaceUnificationTable<NodeId>;
 pub(super) struct NodeId(u32);
 
 impl UnifyKey for NodeId {
-    type Value = RowId;
+    type Value = WireRowId;
 
     fn index(&self) -> u32 {
         self.0
@@ -27,7 +27,7 @@ impl UnifyKey for NodeId {
     }
 }
 
-impl UnifyValue for RowId {
+impl UnifyValue for WireRowId {
     type Error = ena::unify::NoError;
 
     fn unify_values(value1: &Self, value2: &Self) -> Result<Self, Self::Error> {

--- a/packages/coln-store/src/solver/bind.rs
+++ b/packages/coln-store/src/solver/bind.rs
@@ -205,12 +205,9 @@ mod tests {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![1i32.into(), 2i32.into()])
-            .expect("insert row");
-        txn.add(&path, vec![2i32.into(), 3i32.into()])
-            .expect("insert row");
-        txn.add(&path, vec![9i32.into(), 4i32.into()])
-            .expect("insert row");
+        txn.add(&path, vec![1i32, 2i32]).expect("insert row");
+        txn.add(&path, vec![2i32, 3i32]).expect("insert row");
+        txn.add(&path, vec![9i32, 4i32]).expect("insert row");
         txn.commit().expect("commit rows");
 
         let rule = enforced_rule(
@@ -281,7 +278,7 @@ mod tests {
             .expect("create table");
         let mut txn = store.transaction();
         for value in values {
-            txn.add(&path, vec![(*value).into()]).expect("insert row");
+            txn.add(&path, vec![(*value)]).expect("insert row");
         }
         txn.commit().expect("commit rows");
         (store, path)

--- a/packages/coln-store/src/solver/bind.rs
+++ b/packages/coln-store/src/solver/bind.rs
@@ -11,13 +11,13 @@ use crate::{
         matcher::term_matches,
     },
     store::Store,
-    table::{CellValue, RowId, TableRef},
+    table::{WireValue, WireRowId, TableRef},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum BoundValue {
-    RId(RowId),
-    Cell(CellValue),
+    RId(WireRowId),
+    Cell(WireValue),
 }
 
 pub type Binding = Vec<Option<BoundValue>>;
@@ -72,9 +72,9 @@ fn match_atom_row(
 pub fn eval_term(binding: &Binding, term: &CompTerm) -> Option<BoundValue> {
     match term {
         CompTerm::Var(slot) => binding.get(*slot).and_then(|v| v.clone()),
-        CompTerm::Lit(ir::Lit::Int { value }) => Some(BoundValue::Cell(CellValue::Int(*value))),
+        CompTerm::Lit(ir::Lit::Int { value }) => Some(BoundValue::Cell(WireValue::Int(*value))),
         CompTerm::Lit(ir::Lit::String { value }) => {
-            Some(BoundValue::Cell(CellValue::Str(value.clone())))
+            Some(BoundValue::Cell(WireValue::Str(value.clone())))
         }
     }
 }
@@ -152,7 +152,7 @@ mod tests {
             RuleVariant, Schema,
         },
         solver::compile::compile_rule,
-        table::CellValue,
+        table::WireValue, txn::liven_all,
     };
 
     fn int_ty() -> ColType {
@@ -207,17 +207,17 @@ mod tests {
         let mut txn = store.transaction();
         txn.add(
             &path,
-            vec![CellValue::Int(1).into(), CellValue::Int(2).into()],
+            liven_all(vec![WireValue::Int(1), WireValue::Int(2)]),
         )
         .expect("insert row");
         txn.add(
             &path,
-            vec![CellValue::Int(2).into(), CellValue::Int(3).into()],
+            liven_all(vec![WireValue::Int(2), WireValue::Int(3)]),
         )
         .expect("insert row");
         txn.add(
             &path,
-            vec![CellValue::Int(9).into(), CellValue::Int(4).into()],
+            liven_all(vec![WireValue::Int(9), WireValue::Int(4)]),
         )
         .expect("insert row");
         txn.commit().expect("commit rows");
@@ -275,14 +275,14 @@ mod tests {
         let bindings = bind_rule(&store, &compiled);
 
         assert_eq!(bindings.len(), 1);
-        assert_eq!(bindings[0][0], Some(BoundValue::Cell(CellValue::Int(1))));
-        assert_eq!(bindings[0][1], Some(BoundValue::Cell(CellValue::Int(2))));
-        assert_eq!(bindings[0][2], Some(BoundValue::Cell(CellValue::Int(3))));
+        assert_eq!(bindings[0][0], Some(BoundValue::Cell(WireValue::Int(1))));
+        assert_eq!(bindings[0][1], Some(BoundValue::Cell(WireValue::Int(2))));
+        assert_eq!(bindings[0][2], Some(BoundValue::Cell(WireValue::Int(3))));
     }
 
     /// Build a single-column `Int` table `T` populated with the supplied
     /// values, returning the store.
-    fn store_with_int_column(values: &[i64]) -> (Store, Path) {
+    fn store_with_int_column(values: &[i32]) -> (Store, Path) {
         let path = Path::from("T");
         let mut store = Store::new();
         store
@@ -290,7 +290,7 @@ mod tests {
             .expect("create table");
         let mut txn = store.transaction();
         for value in values {
-            txn.add(&path, vec![CellValue::Int(*value).into()])
+            txn.add(&path, liven_all(vec![WireValue::Int(*value)]))
                 .expect("insert row");
         }
         txn.commit().expect("commit rows");
@@ -396,6 +396,6 @@ mod tests {
         let bindings = bind_rule(&store, &compiled);
 
         assert_eq!(bindings.len(), 1);
-        assert_eq!(bindings[0][0], Some(BoundValue::Cell(CellValue::Int(2))));
+        assert_eq!(bindings[0][0], Some(BoundValue::Cell(WireValue::Int(2))));
     }
 }

--- a/packages/coln-store/src/solver/bind.rs
+++ b/packages/coln-store/src/solver/bind.rs
@@ -11,7 +11,7 @@ use crate::{
         matcher::term_matches,
     },
     store::Store,
-    table::{WireValue, WireRowId, TableRef},
+    table::{TableRef, WireRowId, WireValue},
 };
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -152,7 +152,8 @@ mod tests {
             RuleVariant, Schema,
         },
         solver::compile::compile_rule,
-        table::WireValue, txn::liven_all,
+        table::WireValue,
+        txn::liven_all,
     };
 
     fn int_ty() -> ColType {
@@ -205,21 +206,12 @@ mod tests {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(
-            &path,
-            liven_all(vec![WireValue::Int(1), WireValue::Int(2)]),
-        )
-        .expect("insert row");
-        txn.add(
-            &path,
-            liven_all(vec![WireValue::Int(2), WireValue::Int(3)]),
-        )
-        .expect("insert row");
-        txn.add(
-            &path,
-            liven_all(vec![WireValue::Int(9), WireValue::Int(4)]),
-        )
-        .expect("insert row");
+        txn.add(&path, liven_all(vec![WireValue::Int(1), WireValue::Int(2)]))
+            .expect("insert row");
+        txn.add(&path, liven_all(vec![WireValue::Int(2), WireValue::Int(3)]))
+            .expect("insert row");
+        txn.add(&path, liven_all(vec![WireValue::Int(9), WireValue::Int(4)]))
+            .expect("insert row");
         txn.commit().expect("commit rows");
 
         let rule = enforced_rule(

--- a/packages/coln-store/src/solver/bind.rs
+++ b/packages/coln-store/src/solver/bind.rs
@@ -281,8 +281,7 @@ mod tests {
             .expect("create table");
         let mut txn = store.transaction();
         for value in values {
-            txn.add(&path, vec![(*value).into()])
-                .expect("insert row");
+            txn.add(&path, vec![(*value).into()]).expect("insert row");
         }
         txn.commit().expect("commit rows");
         (store, path)

--- a/packages/coln-store/src/solver/bind.rs
+++ b/packages/coln-store/src/solver/bind.rs
@@ -153,7 +153,6 @@ mod tests {
         },
         solver::compile::compile_rule,
         table::WireValue,
-        txn::liven_all,
     };
 
     fn int_ty() -> ColType {
@@ -206,11 +205,11 @@ mod tests {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, liven_all(vec![WireValue::Int(1), WireValue::Int(2)]))
+        txn.add(&path, vec![1i32.into(), 2i32.into()])
             .expect("insert row");
-        txn.add(&path, liven_all(vec![WireValue::Int(2), WireValue::Int(3)]))
+        txn.add(&path, vec![2i32.into(), 3i32.into()])
             .expect("insert row");
-        txn.add(&path, liven_all(vec![WireValue::Int(9), WireValue::Int(4)]))
+        txn.add(&path, vec![9i32.into(), 4i32.into()])
             .expect("insert row");
         txn.commit().expect("commit rows");
 
@@ -282,7 +281,7 @@ mod tests {
             .expect("create table");
         let mut txn = store.transaction();
         for value in values {
-            txn.add(&path, liven_all(vec![WireValue::Int(*value)]))
+            txn.add(&path, vec![(*value).into()])
                 .expect("insert row");
         }
         txn.commit().expect("commit rows");

--- a/packages/coln-store/src/solver/matcher.rs
+++ b/packages/coln-store/src/solver/matcher.rs
@@ -10,15 +10,15 @@ use crate::{
         bind::{Binding, BoundValue},
         compile::CompTerm,
     },
-    table::CellValue,
+    table::WireValue,
 };
 
 /// Check if an _already_ bound variable slot matches value.
 pub(crate) fn boundvar_matches(binding: &Binding, slot: usize, value: &BoundValue) -> bool {
     match binding.get(slot) {
         Some(Some(bound)) => match (bound, value) {
-            (BoundValue::RId(a), BoundValue::Cell(CellValue::Id(b)))
-            | (BoundValue::Cell(CellValue::Id(a)), BoundValue::RId(b)) => {
+            (BoundValue::RId(a), BoundValue::Cell(WireValue::Id(b)))
+            | (BoundValue::Cell(WireValue::Id(a)), BoundValue::RId(b)) => {
                 debug!(bound=?bound, value = ?value, "matching");
                 a == b
             }
@@ -36,10 +36,10 @@ pub(crate) fn term_matches(binding: &Binding, term: &CompTerm, value: &BoundValu
     match term {
         CompTerm::Var(slot) => boundvar_matches(binding, *slot, value),
         CompTerm::Lit(ir::Lit::Int { value: expected }) => {
-            *value == BoundValue::Cell(CellValue::Int(*expected))
+            *value == BoundValue::Cell(WireValue::Int(*expected))
         }
         CompTerm::Lit(ir::Lit::String { value: expected }) => {
-            *value == BoundValue::Cell(CellValue::Str(expected.clone()))
+            *value == BoundValue::Cell(WireValue::Str(expected.clone()))
         }
     }
 }

--- a/packages/coln-store/src/solver/validate.rs
+++ b/packages/coln-store/src/solver/validate.rs
@@ -14,7 +14,7 @@ use crate::{
         matcher::term_matches,
     },
     store::Store,
-    table::CellValue,
+    table::WireValue,
 };
 
 /// Why a rule was violated at a given binding.
@@ -93,8 +93,8 @@ pub fn consequent_eq_holds(binding: &Binding, eq: &CompEq) -> bool {
     };
     match (&l, &r) {
         // Row ids and entity cells refer to the same identity when equal.
-        (BoundValue::RId(a), BoundValue::Cell(CellValue::Id(b)))
-        | (BoundValue::Cell(CellValue::Id(a)), BoundValue::RId(b)) => a == b,
+        (BoundValue::RId(a), BoundValue::Cell(WireValue::Id(b)))
+        | (BoundValue::Cell(WireValue::Id(a)), BoundValue::RId(b)) => a == b,
         _ => l == r,
     }
 }
@@ -157,7 +157,7 @@ mod tests {
             RuleVariant, Schema,
         },
         solver::compile::compile_rule,
-        table::CellValue,
+        table::WireValue,
     };
 
     fn int_ty() -> ColType {
@@ -246,9 +246,9 @@ mod tests {
             .expect("create target table");
 
         let mut txn = store.transaction();
-        txn.add(&source, vec![CellValue::Int(7).into()])
+        txn.add(&source, vec![7i32.into()])
             .expect("insert source row");
-        txn.add(&target, vec![CellValue::Int(7).into()])
+        txn.add(&target, vec![7i32.into()])
             .expect("insert target row");
         txn.commit().expect("commit matching rows");
 
@@ -345,7 +345,7 @@ mod tests {
         let mut txn = store.transaction();
         txn.add(
             &link,
-            vec![CellValue::Int(10).into(), CellValue::Int(20).into()],
+            vec![10i32.into(), 20i32.into()],
         )
         .expect("insert referencing row");
         txn.commit().expect("commit referencing row");
@@ -359,15 +359,15 @@ mod tests {
         assert_eq!(
             violation.binding,
             vec![
-                Some(BoundValue::Cell(CellValue::Int(10))),
-                Some(BoundValue::Cell(CellValue::Int(20))),
+                Some(BoundValue::Cell(WireValue::Int(10))),
+                Some(BoundValue::Cell(WireValue::Int(20))),
             ]
         );
 
         let mut txn = store.transaction();
-        txn.add(&left, vec![CellValue::Int(10).into()])
+        txn.add(&left, vec![10i32.into()])
             .expect("insert left row");
-        txn.add(&right, vec![CellValue::Int(20).into()])
+        txn.add(&right, vec![20i32.into()])
             .expect("insert right row");
         txn.commit().expect("commit referenced rows");
 
@@ -382,7 +382,7 @@ mod tests {
             .create_table(t.clone(), int_schema(&["c0", "c1"]))
             .expect("create table");
         let mut txn = store.transaction();
-        txn.add(&t, vec![CellValue::Int(5).into(), CellValue::Int(5).into()])
+        txn.add(&t, vec![5i32.into(), 5i32.into()])
             .expect("insert row");
         txn.commit().expect("commit row");
 
@@ -425,7 +425,7 @@ mod tests {
             .create_table(t.clone(), int_schema(&["c0", "c1"]))
             .expect("create table");
         let mut txn = store.transaction();
-        txn.add(&t, vec![CellValue::Int(1).into(), CellValue::Int(2).into()])
+        txn.add(&t, vec![1i32.into(), 2i32.into()])
             .expect("insert row");
         txn.commit().expect("commit row");
 

--- a/packages/coln-store/src/solver/validate.rs
+++ b/packages/coln-store/src/solver/validate.rs
@@ -343,11 +343,8 @@ mod tests {
         let compiled = compile_rule(&rule).expect("compile rule");
 
         let mut txn = store.transaction();
-        txn.add(
-            &link,
-            vec![10i32.into(), 20i32.into()],
-        )
-        .expect("insert referencing row");
+        txn.add(&link, vec![10i32.into(), 20i32.into()])
+            .expect("insert referencing row");
         txn.commit().expect("commit referencing row");
 
         let violation = check_rule(&store, &compiled).expect_err("missing referenced rows");
@@ -365,8 +362,7 @@ mod tests {
         );
 
         let mut txn = store.transaction();
-        txn.add(&left, vec![10i32.into()])
-            .expect("insert left row");
+        txn.add(&left, vec![10i32.into()]).expect("insert left row");
         txn.add(&right, vec![20i32.into()])
             .expect("insert right row");
         txn.commit().expect("commit referenced rows");

--- a/packages/coln-store/src/solver/validate.rs
+++ b/packages/coln-store/src/solver/validate.rs
@@ -246,10 +246,8 @@ mod tests {
             .expect("create target table");
 
         let mut txn = store.transaction();
-        txn.add(&source, vec![7i32.into()])
-            .expect("insert source row");
-        txn.add(&target, vec![7i32.into()])
-            .expect("insert target row");
+        txn.add(&source, vec![7i32]).expect("insert source row");
+        txn.add(&target, vec![7i32]).expect("insert target row");
         txn.commit().expect("commit matching rows");
 
         let rule = enforced_rule(
@@ -343,7 +341,7 @@ mod tests {
         let compiled = compile_rule(&rule).expect("compile rule");
 
         let mut txn = store.transaction();
-        txn.add(&link, vec![10i32.into(), 20i32.into()])
+        txn.add(&link, vec![10i32, 20i32])
             .expect("insert referencing row");
         txn.commit().expect("commit referencing row");
 
@@ -362,9 +360,8 @@ mod tests {
         );
 
         let mut txn = store.transaction();
-        txn.add(&left, vec![10i32.into()]).expect("insert left row");
-        txn.add(&right, vec![20i32.into()])
-            .expect("insert right row");
+        txn.add(&left, vec![10i32]).expect("insert left row");
+        txn.add(&right, vec![20i32]).expect("insert right row");
         txn.commit().expect("commit referenced rows");
 
         assert!(check_rule(&store, &compiled).is_ok());
@@ -378,8 +375,7 @@ mod tests {
             .create_table(t.clone(), int_schema(&["c0", "c1"]))
             .expect("create table");
         let mut txn = store.transaction();
-        txn.add(&t, vec![5i32.into(), 5i32.into()])
-            .expect("insert row");
+        txn.add(&t, vec![5i32, 5i32]).expect("insert row");
         txn.commit().expect("commit row");
 
         let rule = enforced_rule(
@@ -421,8 +417,7 @@ mod tests {
             .create_table(t.clone(), int_schema(&["c0", "c1"]))
             .expect("create table");
         let mut txn = store.transaction();
-        txn.add(&t, vec![1i32.into(), 2i32.into()])
-            .expect("insert row");
+        txn.add(&t, vec![1i32, 2i32]).expect("insert row");
         txn.commit().expect("commit row");
 
         let rule = enforced_rule(

--- a/packages/coln-store/src/store/mod.rs
+++ b/packages/coln-store/src/store/mod.rs
@@ -22,7 +22,8 @@ use crate::solver::validate::RuleViolation;
 use crate::solver::{self};
 use crate::store::error::{CommitApplyError, StoreError};
 use crate::table::{
-    WireValue, WireRowId, RowView, Table, TableMeta, TableOid, TableRef, TableSnapshot, ValidationError,
+    RowView, Table, TableMeta, TableOid, TableRef, TableSnapshot, ValidationError, WireRowId,
+    WireValue,
 };
 use crate::txn::{OwnedTransaction, Transaction};
 use crate::{op::Op, txn::TxnLiveRowId};

--- a/packages/coln-store/src/store/mod.rs
+++ b/packages/coln-store/src/store/mod.rs
@@ -22,10 +22,10 @@ use crate::solver::validate::RuleViolation;
 use crate::solver::{self};
 use crate::store::error::{CommitApplyError, StoreError};
 use crate::table::{
-    CellValue, RowId, RowView, Table, TableMeta, TableOid, TableRef, TableSnapshot, ValidationError,
+    WireValue, WireRowId, RowView, Table, TableMeta, TableOid, TableRef, TableSnapshot, ValidationError,
 };
 use crate::txn::{OwnedTransaction, Transaction};
-use crate::{op::Op, txn::RowHandle};
+use crate::{op::Op, txn::TxnLiveRowId};
 
 #[derive(Debug)]
 pub struct Store {
@@ -168,13 +168,13 @@ impl Store {
         Ok(serde_json::to_string(&realm).map_err(CodecError::from)?)
     }
 
-    pub(crate) fn canonical_row_id(&self, row_id: RowId) -> Option<RowId> {
+    pub(crate) fn canonical_row_id(&self, row_id: WireRowId) -> Option<WireRowId> {
         let packed = self.id_packer.lookup_row_id(row_id)?;
         let canonical = self.rowing.canonical_id(&packed, &self.id_packer);
         Some(self.id_packer.unpack_row_id(canonical))
     }
 
-    pub fn row_by_handle(&self, table: &ir::Path, row_handle: RowHandle) -> Option<RowView> {
+    pub fn row_by_handle(&self, table: &ir::Path, row_handle: TxnLiveRowId) -> Option<RowView> {
         let row_id = row_handle.row_id().ok()?;
         let con_rowid = self.canonical_row_id(row_id)?;
         // replace the rowid in the row_handle so it stays canonical
@@ -187,7 +187,7 @@ impl Store {
     // This function will canonicalise the row_id on read, but will not change it
     // See `row_by_handle` which will actually canonicalise the handle.
     // We need both because the TS FFI does not deal with handles.
-    pub fn row_by_id(&self, table: &ir::Path, row_id: RowId) -> Option<RowView> {
+    pub fn row_by_id(&self, table: &ir::Path, row_id: WireRowId) -> Option<RowView> {
         let row_id = self.canonical_row_id(row_id)?;
         self.table_at(table)
             .and_then(|table| table.row_at(table.row_position(row_id)?))
@@ -574,7 +574,7 @@ impl Store {
 
     // TODO also need to validate that ids in op is referring to an existing id
     fn validate_commit_ops(&self, ops: &[Op]) -> Result<(), StoreError> {
-        let mut pending_pk: HashMap<TableOid, Vec<Vec<CellValue>>> = HashMap::new();
+        let mut pending_pk: HashMap<TableOid, Vec<Vec<WireValue>>> = HashMap::new();
 
         for op in ops {
             let Op::Add { table, values, .. } = op;

--- a/packages/coln-store/src/store/tests.rs
+++ b/packages/coln-store/src/store/tests.rs
@@ -121,7 +121,7 @@ fn single_int_store() -> Store {
 fn commit_int(store: &mut Store, value: i32) -> CommitHash {
     let path = Path::from("T");
     let mut tx = store.transaction();
-    tx.add(&path, vec![value.into()]).expect("add row");
+    tx.add(&path, vec![value]).expect("add row");
     tx.commit().expect("commit row")
 }
 
@@ -211,8 +211,8 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![1i32.into()]).expect("first add");
-        txn.add(&path, vec![2i32.into()]).expect("second add");
+        txn.add(&path, vec![1i32]).expect("first add");
+        txn.add(&path, vec![2i32]).expect("second add");
 
         txn.commit().expect("commit");
 
@@ -241,9 +241,8 @@ mod transactions {
 
         let err = {
             let mut txn = store.transaction();
-            txn.add(&path, vec![1i32.into()]).expect("first add");
-            txn.add(&Path::from("missing"), vec![2i32.into()])
-                .unwrap_err()
+            txn.add(&path, vec![1i32]).expect("first add");
+            txn.add(&Path::from("missing"), vec![2i32]).unwrap_err()
         };
 
         assert!(matches!(
@@ -272,8 +271,8 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![1i32.into()]).expect("first add");
-        txn.add(&path, vec![1i32.into()]).expect("second add");
+        txn.add(&path, vec![1i32]).expect("first add");
+        txn.add(&path, vec![1i32]).expect("second add");
         let err = txn.commit().unwrap_err();
 
         assert!(matches!(
@@ -302,7 +301,7 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![42i32.into()]).expect("add");
+        txn.add(&path, vec![42i32]).expect("add");
         txn.commit().expect("commit");
 
         let t = store.table_at(&path).expect("T");
@@ -318,8 +317,7 @@ mod transactions {
         let packed_id_count = store.id_packer.len();
 
         let mut txn = store.transaction();
-        txn.add(&link, vec![10i32.into(), 20i32.into()])
-            .expect("add");
+        txn.add(&link, vec![10i32, 20i32]).expect("add");
         let err = txn.commit().unwrap_err();
 
         assert!(matches!(err, StoreError::Rule(_)));
@@ -334,8 +332,7 @@ mod transactions {
         let store = Store::try_from_ir(theory).expect("theory");
 
         let mut tx = OwnedTransaction::new(store);
-        tx.add(&link, vec![10_i32.into(), 20_i32.into()])
-            .expect("add");
+        tx.add(&link, vec![10_i32, 20_i32]).expect("add");
 
         let (err, recovered) = tx.commit().unwrap_err();
         assert!(matches!(err, StoreError::Rule(_)));

--- a/packages/coln-store/src/store/tests.rs
+++ b/packages/coln-store/src/store/tests.rs
@@ -211,10 +211,8 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![1i32.into()])
-            .expect("first add");
-        txn.add(&path, vec![2i32.into()])
-            .expect("second add");
+        txn.add(&path, vec![1i32.into()]).expect("first add");
+        txn.add(&path, vec![2i32.into()]).expect("second add");
 
         txn.commit().expect("commit");
 
@@ -243,8 +241,7 @@ mod transactions {
 
         let err = {
             let mut txn = store.transaction();
-            txn.add(&path, vec![1i32.into()])
-                .expect("first add");
+            txn.add(&path, vec![1i32.into()]).expect("first add");
             txn.add(&Path::from("missing"), vec![2i32.into()])
                 .unwrap_err()
         };
@@ -275,10 +272,8 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![1i32.into()])
-            .expect("first add");
-        txn.add(&path, vec![1i32.into()])
-            .expect("second add");
+        txn.add(&path, vec![1i32.into()]).expect("first add");
+        txn.add(&path, vec![1i32.into()]).expect("second add");
         let err = txn.commit().unwrap_err();
 
         assert!(matches!(
@@ -307,8 +302,7 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![42i32.into()])
-            .expect("add");
+        txn.add(&path, vec![42i32.into()]).expect("add");
         txn.commit().expect("commit");
 
         let t = store.table_at(&path).expect("T");
@@ -324,11 +318,8 @@ mod transactions {
         let packed_id_count = store.id_packer.len();
 
         let mut txn = store.transaction();
-        txn.add(
-            &link,
-            vec![10i32.into(), 20i32.into()],
-        )
-        .expect("add");
+        txn.add(&link, vec![10i32.into(), 20i32.into()])
+            .expect("add");
         let err = txn.commit().unwrap_err();
 
         assert!(matches!(err, StoreError::Rule(_)));
@@ -397,7 +388,10 @@ mod query {
                 values: vec![42i32.into()],
             })
         );
-        assert_eq!(store.row_by_id(&path, WireRowId { commit, counter: 1 }), None);
+        assert_eq!(
+            store.row_by_id(&path, WireRowId { commit, counter: 1 }),
+            None
+        );
         assert_eq!(store.row_by_id(&Path::from("missing"), row_id), None);
     }
 }
@@ -680,8 +674,11 @@ mod rowing {
         let tp = txn
             .add(&plus_path, vec![TxnLiveValue::Id(t7), TxnLiveValue::Id(t8)])
             .unwrap();
-        txn.add(&mult_path, vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)])
-            .unwrap();
+        txn.add(
+            &mult_path,
+            vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)],
+        )
+        .unwrap();
         txn.commit().unwrap();
 
         let mut txn2 = store.transaction();
@@ -690,8 +687,11 @@ mod rowing {
         let tp = txn2
             .add(&plus_path, vec![TxnLiveValue::Id(t7), TxnLiveValue::Id(t8)])
             .unwrap();
-        txn2.add(&mult_path, vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)])
-            .unwrap();
+        txn2.add(
+            &mult_path,
+            vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)],
+        )
+        .unwrap();
         txn2.commit().unwrap();
 
         let terms: Vec<RowView> = store.scan_table(&term_path).unwrap().collect();
@@ -738,9 +738,15 @@ mod rowing {
         let f = Path::from("F");
 
         let mut first = store.transaction();
-        let t1 = first.add(&term, vec![TxnLiveValue::Int(1)]).expect("Term(1)");
-        let t2 = first.add(&term, vec![TxnLiveValue::Int(2)]).expect("Term(2)");
-        first.add(&term, vec![TxnLiveValue::Int(3)]).expect("Term(3)");
+        let t1 = first
+            .add(&term, vec![TxnLiveValue::Int(1)])
+            .expect("Term(1)");
+        let t2 = first
+            .add(&term, vec![TxnLiveValue::Int(2)])
+            .expect("Term(2)");
+        first
+            .add(&term, vec![TxnLiveValue::Int(3)])
+            .expect("Term(3)");
         first
             .add(&f, vec![TxnLiveValue::Id(t1), TxnLiveValue::Id(t2)])
             .expect("F(Term1, Term2)");
@@ -756,8 +762,12 @@ mod rowing {
         // the two Term(1) rows canonicalise onto one id and F's x cell is
         // rewritten, which is why the check cannot live in the pre-apply pass.
         let mut second = store.transaction();
-        let t1_again = second.add(&term, vec![TxnLiveValue::Int(1)]).expect("Term(1)");
-        let t4 = second.add(&term, vec![TxnLiveValue::Int(4)]).expect("Term(4)");
+        let t1_again = second
+            .add(&term, vec![TxnLiveValue::Int(1)])
+            .expect("Term(1)");
+        let t4 = second
+            .add(&term, vec![TxnLiveValue::Int(4)])
+            .expect("Term(4)");
         second
             .add(&f, vec![TxnLiveValue::Id(t1_again), TxnLiveValue::Id(t4)])
             .expect("F(Term1, Term4)");

--- a/packages/coln-store/src/store/tests.rs
+++ b/packages/coln-store/src/store/tests.rs
@@ -118,7 +118,7 @@ fn single_int_store() -> Store {
     store
 }
 
-fn commit_int(store: &mut Store, value: i64) -> CommitHash {
+fn commit_int(store: &mut Store, value: i32) -> CommitHash {
     let path = Path::from("T");
     let mut tx = store.transaction();
     tx.add(&path, vec![value.into()]).expect("add row");
@@ -211,9 +211,9 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![CellValue::Int(1).into()])
+        txn.add(&path, vec![1i32.into()])
             .expect("first add");
-        txn.add(&path, vec![CellValue::Int(2).into()])
+        txn.add(&path, vec![2i32.into()])
             .expect("second add");
 
         txn.commit().expect("commit");
@@ -243,9 +243,9 @@ mod transactions {
 
         let err = {
             let mut txn = store.transaction();
-            txn.add(&path, vec![CellValue::Int(1).into()])
+            txn.add(&path, vec![1i32.into()])
                 .expect("first add");
-            txn.add(&Path::from("missing"), vec![CellValue::Int(2).into()])
+            txn.add(&Path::from("missing"), vec![2i32.into()])
                 .unwrap_err()
         };
 
@@ -275,9 +275,9 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![CellValue::Int(1).into()])
+        txn.add(&path, vec![1i32.into()])
             .expect("first add");
-        txn.add(&path, vec![CellValue::Int(1).into()])
+        txn.add(&path, vec![1i32.into()])
             .expect("second add");
         let err = txn.commit().unwrap_err();
 
@@ -307,13 +307,13 @@ mod transactions {
             .expect("create table");
 
         let mut txn = store.transaction();
-        txn.add(&path, vec![CellValue::Int(42).into()])
+        txn.add(&path, vec![42i32.into()])
             .expect("add");
         txn.commit().expect("commit");
 
         let t = store.table_at(&path).expect("T");
         assert_eq!(t.row_count(), 1);
-        assert_eq!(t.cell_at(0, 0), Some(CellValue::Int(42)));
+        assert_eq!(t.cell_at(0, 0), Some(42i32.into()));
     }
 
     #[test]
@@ -326,7 +326,7 @@ mod transactions {
         let mut txn = store.transaction();
         txn.add(
             &link,
-            vec![CellValue::Int(10).into(), CellValue::Int(20).into()],
+            vec![10i32.into(), 20i32.into()],
         )
         .expect("add");
         let err = txn.commit().unwrap_err();
@@ -343,7 +343,7 @@ mod transactions {
         let store = Store::try_from_ir(theory).expect("theory");
 
         let mut tx = OwnedTransaction::new(store);
-        tx.add(&link, vec![10_i64.into(), 20_i64.into()])
+        tx.add(&link, vec![10_i32.into(), 20_i32.into()])
             .expect("add");
 
         let (err, recovered) = tx.commit().unwrap_err();
@@ -377,8 +377,8 @@ mod query {
                 .expect("known table")
                 .collect::<Vec<_>>(),
             vec![RowView {
-                row_id: RowId { commit, counter: 0 },
-                values: vec![CellValue::Int(42)],
+                row_id: WireRowId { commit, counter: 0 },
+                values: vec![42i32.into()],
             }]
         );
     }
@@ -388,26 +388,26 @@ mod query {
         let path = Path::from("T");
         let mut store = single_int_store();
         let commit = commit_int(&mut store, 42);
-        let row_id = RowId { commit, counter: 0 };
+        let row_id = WireRowId { commit, counter: 0 };
 
         assert_eq!(
             store.row_by_id(&path, row_id),
             Some(RowView {
                 row_id,
-                values: vec![CellValue::Int(42)],
+                values: vec![42i32.into()],
             })
         );
-        assert_eq!(store.row_by_id(&path, RowId { commit, counter: 1 }), None);
+        assert_eq!(store.row_by_id(&path, WireRowId { commit, counter: 1 }), None);
         assert_eq!(store.row_by_id(&Path::from("missing"), row_id), None);
     }
 }
 
 mod rowing {
     use super::*;
-    use crate::txn::TxnValue;
+    use crate::txn::TxnLiveValue;
 
-    fn row_id_from(commit_byte: u8, counter: u32) -> RowId {
-        RowId {
+    fn row_id_from(commit_byte: u8, counter: u32) -> WireRowId {
+        WireRowId {
             commit: CommitHash([commit_byte; 32]),
             counter,
         }
@@ -501,7 +501,7 @@ mod rowing {
         store
     }
 
-    fn add_op(store: &Store, table: &str, rid: RowId, values: Vec<CellValue>) -> Op {
+    fn add_op(store: &Store, table: &str, rid: WireRowId, values: Vec<WireValue>) -> Op {
         Op::Add {
             row_id: rid,
             table: store
@@ -524,7 +524,7 @@ mod rowing {
                 &store,
                 "Term",
                 t_high,
-                vec![CellValue::Int(7)],
+                vec![WireValue::Int(7)],
             )])
             .unwrap();
 
@@ -536,23 +536,23 @@ mod rowing {
                     &store,
                     "Plus",
                     plus,
-                    vec![CellValue::Id(t_high), CellValue::Id(t_high)],
+                    vec![WireValue::Id(t_high), WireValue::Id(t_high)],
                 ),
-                add_op(&store, "Note", note, vec![CellValue::Id(t_high)]),
+                add_op(&store, "Note", note, vec![WireValue::Id(t_high)]),
             ])
             .unwrap();
 
         // A smaller equal term swaps the class canonical from t_high to t_low.
         let t_low = row_id_from(1, 0);
         store
-            .apply_ops_and_rebuild(vec![add_op(&store, "Term", t_low, vec![CellValue::Int(7)])])
+            .apply_ops_and_rebuild(vec![add_op(&store, "Term", t_low, vec![WireValue::Int(7)])])
             .unwrap();
 
         // The stored row is now t_low; the stale id t_high resolves to it.
         let term_path = Path::from("Term");
         let term_view = Some(RowView {
             row_id: t_low,
-            values: vec![CellValue::Int(7)],
+            values: vec![WireValue::Int(7)],
         });
         assert_eq!(store.row_by_id(&term_path, t_low), term_view);
         assert_eq!(store.row_by_id(&term_path, t_high), term_view);
@@ -564,14 +564,14 @@ mod rowing {
             store.row_by_id(&Path::from("Plus"), plus),
             Some(RowView {
                 row_id: plus,
-                values: vec![CellValue::Id(t_low), CellValue::Id(t_low)],
+                values: vec![WireValue::Id(t_low), WireValue::Id(t_low)],
             })
         );
         assert_eq!(
             store.row_by_id(&Path::from("Note"), note),
             Some(RowView {
                 row_id: note,
-                values: vec![CellValue::Id(t_low)],
+                values: vec![WireValue::Id(t_low)],
             })
         );
     }
@@ -595,19 +595,19 @@ mod rowing {
         let dup = row_id_from(4, 0);
         store
             .apply_ops_and_rebuild(vec![
-                add_op(&store, "Term", t_low, vec![CellValue::Int(7)]),
-                add_op(&store, "Term", t_high, vec![CellValue::Int(7)]),
+                add_op(&store, "Term", t_low, vec![WireValue::Int(7)]),
+                add_op(&store, "Term", t_high, vec![WireValue::Int(7)]),
                 add_op(
                     &store,
                     "Plus",
                     keep,
-                    vec![CellValue::Id(t_high), CellValue::Id(t_high)],
+                    vec![WireValue::Id(t_high), WireValue::Id(t_high)],
                 ),
                 add_op(
                     &store,
                     "Plus",
                     dup,
-                    vec![CellValue::Id(t_high), CellValue::Id(t_high)],
+                    vec![WireValue::Id(t_high), WireValue::Id(t_high)],
                 ),
             ])
             .expect("duplicates merge rather than failing the commit");
@@ -619,7 +619,7 @@ mod rowing {
 
         // The surviving row keeps the canonical id and names canonical children.
         assert_eq!(plus[0].row_id, keep);
-        assert_eq!(plus[0].values, [CellValue::Id(t_low), CellValue::Id(t_low)]);
+        assert_eq!(plus[0].values, [WireValue::Id(t_low), WireValue::Id(t_low)]);
         // Both stale ids still resolve to what replaced them.
         let plus_path = Path::from("Plus");
         assert_eq!(
@@ -642,15 +642,15 @@ mod rowing {
         let plus = row_id_from(3, 0);
         store
             .apply_ops_and_rebuild(vec![
-                add_op(&store, "Term", t_low, vec![CellValue::Int(7)]),
-                add_op(&store, "Term", u_low, vec![CellValue::Int(8)]),
-                add_op(&store, "Term", t_high, vec![CellValue::Int(7)]),
-                add_op(&store, "Term", u_high, vec![CellValue::Int(8)]),
+                add_op(&store, "Term", t_low, vec![WireValue::Int(7)]),
+                add_op(&store, "Term", u_low, vec![WireValue::Int(8)]),
+                add_op(&store, "Term", t_high, vec![WireValue::Int(7)]),
+                add_op(&store, "Term", u_high, vec![WireValue::Int(8)]),
                 add_op(
                     &store,
                     "Plus",
                     plus,
-                    vec![CellValue::Id(t_high), CellValue::Id(u_high)],
+                    vec![WireValue::Id(t_high), WireValue::Id(u_high)],
                 ),
             ])
             .expect("duplicates merge rather than failing the commit");
@@ -661,7 +661,7 @@ mod rowing {
             store.row_by_id(&Path::from("Plus"), plus),
             Some(RowView {
                 row_id: plus,
-                values: vec![CellValue::Id(t_low), CellValue::Id(u_low)],
+                values: vec![WireValue::Id(t_low), WireValue::Id(u_low)],
             })
         );
     }
@@ -675,22 +675,22 @@ mod rowing {
         let mult_path = Path::from("Mult");
 
         let mut txn = store.transaction();
-        let t7 = txn.add(&term_path, vec![TxnValue::Int(7)]).unwrap();
-        let t8 = txn.add(&term_path, vec![TxnValue::Int(8)]).unwrap();
+        let t7 = txn.add(&term_path, vec![TxnLiveValue::Int(7)]).unwrap();
+        let t8 = txn.add(&term_path, vec![TxnLiveValue::Int(8)]).unwrap();
         let tp = txn
-            .add(&plus_path, vec![TxnValue::Id(t7), TxnValue::Id(t8)])
+            .add(&plus_path, vec![TxnLiveValue::Id(t7), TxnLiveValue::Id(t8)])
             .unwrap();
-        txn.add(&mult_path, vec![TxnValue::Id(tp.clone()), TxnValue::Id(tp)])
+        txn.add(&mult_path, vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)])
             .unwrap();
         txn.commit().unwrap();
 
         let mut txn2 = store.transaction();
-        let t7 = txn2.add(&term_path, vec![TxnValue::Int(7)]).unwrap();
-        let t8 = txn2.add(&term_path, vec![TxnValue::Int(8)]).unwrap();
+        let t7 = txn2.add(&term_path, vec![TxnLiveValue::Int(7)]).unwrap();
+        let t8 = txn2.add(&term_path, vec![TxnLiveValue::Int(8)]).unwrap();
         let tp = txn2
-            .add(&plus_path, vec![TxnValue::Id(t7), TxnValue::Id(t8)])
+            .add(&plus_path, vec![TxnLiveValue::Id(t7), TxnLiveValue::Id(t8)])
             .unwrap();
-        txn2.add(&mult_path, vec![TxnValue::Id(tp.clone()), TxnValue::Id(tp)])
+        txn2.add(&mult_path, vec![TxnLiveValue::Id(tp.clone()), TxnLiveValue::Id(tp)])
             .unwrap();
         txn2.commit().unwrap();
 
@@ -704,10 +704,10 @@ mod rowing {
         assert_eq!(plus.len(), 1);
         assert_eq!(mult.len(), 1);
 
-        let term_id = |value: i64| {
+        let term_id = |value: i32| {
             let matching: Vec<&RowView> = terms
                 .iter()
-                .filter(|row| row.values == [CellValue::Int(value)])
+                .filter(|row| row.values == [value.into()])
                 .collect();
             assert_eq!(matching.len(), 1, "exactly one Term({value})");
             matching[0].row_id
@@ -717,10 +717,10 @@ mod rowing {
 
         // Each surviving row references the canonical id of its children, not the
         // duplicate the second commit allocated for them.
-        assert_eq!(plus[0].values, [CellValue::Id(t7), CellValue::Id(t8)]);
+        assert_eq!(plus[0].values, [WireValue::Id(t7), WireValue::Id(t8)]);
         assert_eq!(
             mult[0].values,
-            [CellValue::Id(plus[0].row_id), CellValue::Id(plus[0].row_id)]
+            [WireValue::Id(plus[0].row_id), WireValue::Id(plus[0].row_id)]
         );
     }
 
@@ -738,11 +738,11 @@ mod rowing {
         let f = Path::from("F");
 
         let mut first = store.transaction();
-        let t1 = first.add(&term, vec![TxnValue::Int(1)]).expect("Term(1)");
-        let t2 = first.add(&term, vec![TxnValue::Int(2)]).expect("Term(2)");
-        first.add(&term, vec![TxnValue::Int(3)]).expect("Term(3)");
+        let t1 = first.add(&term, vec![TxnLiveValue::Int(1)]).expect("Term(1)");
+        let t2 = first.add(&term, vec![TxnLiveValue::Int(2)]).expect("Term(2)");
+        first.add(&term, vec![TxnLiveValue::Int(3)]).expect("Term(3)");
         first
-            .add(&f, vec![TxnValue::Id(t1), TxnValue::Id(t2)])
+            .add(&f, vec![TxnLiveValue::Id(t1), TxnLiveValue::Id(t2)])
             .expect("F(Term1, Term2)");
         first.commit().expect("x is mapped only once");
 
@@ -756,10 +756,10 @@ mod rowing {
         // the two Term(1) rows canonicalise onto one id and F's x cell is
         // rewritten, which is why the check cannot live in the pre-apply pass.
         let mut second = store.transaction();
-        let t1_again = second.add(&term, vec![TxnValue::Int(1)]).expect("Term(1)");
-        let t4 = second.add(&term, vec![TxnValue::Int(4)]).expect("Term(4)");
+        let t1_again = second.add(&term, vec![TxnLiveValue::Int(1)]).expect("Term(1)");
+        let t4 = second.add(&term, vec![TxnLiveValue::Int(4)]).expect("Term(4)");
         second
-            .add(&f, vec![TxnValue::Id(t1_again), TxnValue::Id(t4)])
+            .add(&f, vec![TxnLiveValue::Id(t1_again), TxnLiveValue::Id(t4)])
             .expect("F(Term1, Term4)");
 
         let err = second.commit().unwrap_err();
@@ -857,7 +857,7 @@ mod commits {
 
         assert!(pending.is_empty());
         let table = restored.table_at(&Path::from("T")).expect("table");
-        assert_eq!(table.cell_at(0, 0), Some(CellValue::Int(99)));
+        assert_eq!(table.cell_at(0, 0), Some(WireValue::Int(99)));
         assert_eq!(restored.heads(), vec![commit]);
     }
 
@@ -872,7 +872,7 @@ mod commits {
 
         let table = target.table_at(&Path::from("T")).expect("table");
         assert_eq!(table.row_count(), 1);
-        assert_eq!(table.cell_at(0, 0), Some(CellValue::Int(99)));
+        assert_eq!(table.cell_at(0, 0), Some(WireValue::Int(99)));
         assert_eq!(table.row_id_at(0).expect("row id").commit, commit);
         assert_eq!(target.heads(), source.heads());
     }
@@ -890,8 +890,8 @@ mod commits {
 
         let table = target.table_at(&Path::from("T")).expect("table");
         assert_eq!(table.row_count(), 2);
-        assert_eq!(table.cell_at(0, 0), Some(CellValue::Int(1)));
-        assert_eq!(table.cell_at(1, 0), Some(CellValue::Int(2)));
+        assert_eq!(table.cell_at(0, 0), Some(WireValue::Int(1)));
+        assert_eq!(table.cell_at(1, 0), Some(WireValue::Int(2)));
         assert_eq!(target.heads(), source.heads());
     }
 
@@ -1005,8 +1005,8 @@ mod commits {
 
         let table = target.table_at(&Path::from("T")).expect("table");
         assert_eq!(table.row_count(), 2);
-        assert_eq!(table.cell_at(0, 0), Some(CellValue::Int(1)));
-        assert_eq!(table.cell_at(1, 0), Some(CellValue::Int(2)));
+        assert_eq!(table.cell_at(0, 0), Some(1i32.into()));
+        assert_eq!(table.cell_at(1, 0), Some(2i32.into()));
         assert_eq!(target.heads(), vec![second]);
     }
 }

--- a/packages/coln-store/src/table/cell.rs
+++ b/packages/coln-store/src/table/cell.rs
@@ -7,6 +7,7 @@ use std::fmt;
 use crate::column_map::ColIndex;
 use crate::commit::hash::CommitHash;
 use crate::ir::{BuiltinTy, ColType};
+use crate::value::Value;
 
 use super::ValidationError;
 
@@ -14,12 +15,12 @@ use super::ValidationError;
 ///
 /// It is managed by the database and read-only for the user.
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, Hash)]
-pub struct RowId {
+pub struct WireRowId {
     pub commit: CommitHash,
     pub counter: u32,
 }
 
-impl fmt::Display for RowId {
+impl fmt::Display for WireRowId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         for byte in &self.commit.0[..6] {
             write!(f, "{byte:02x}")?;
@@ -28,13 +29,7 @@ impl fmt::Display for RowId {
     }
 }
 
-/// One cell in columnar storage: an entity id or a primitive value.
-#[derive(Debug, Clone, PartialOrd, PartialEq, Eq, Hash)]
-pub enum CellValue {
-    Id(RowId),
-    Int(i64),
-    Str(String),
-}
+pub type WireValue = Value<WireRowId>;
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum CellKind {
@@ -57,12 +52,12 @@ impl From<&ColType> for CellKind {
     }
 }
 
-impl From<&CellValue> for CellKind {
-    fn from(value: &CellValue) -> Self {
+impl From<&WireValue> for CellKind {
+    fn from(value: &WireValue) -> Self {
         match value {
-            CellValue::Id(_) => CellKind::RowId,
-            CellValue::Int(_) => CellKind::Int,
-            CellValue::Str(_) => CellKind::Str,
+            WireValue::Id(_) => CellKind::RowId,
+            WireValue::Int(_) => CellKind::Int,
+            WireValue::Str(_) => CellKind::Str,
         }
     }
 }
@@ -77,7 +72,7 @@ impl fmt::Display for CellKind {
     }
 }
 
-impl CellValue {
+impl WireValue {
     pub(super) fn matches_schema(
         &self,
         col_type: &ColType,
@@ -97,12 +92,12 @@ impl CellValue {
     }
 }
 
-impl fmt::Display for CellValue {
+impl fmt::Display for WireValue {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            CellValue::Id(id) => write!(f, "#{id}"),
-            CellValue::Int(value) => write!(f, "{value}"),
-            CellValue::Str(value) => write!(f, "{value:?}"),
+            WireValue::Id(id) => write!(f, "#{id}"),
+            WireValue::Int(value) => write!(f, "{value}"),
+            WireValue::Str(value) => write!(f, "{value:?}"),
         }
     }
 }
@@ -166,9 +161,4 @@ impl ColIndex for PackedRowId {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) enum PackedCell {
-    Id(PackedRowId),
-    Int(i64),
-    Str(String),
-}
+pub type PackedValue = Value<PackedRowId>;

--- a/packages/coln-store/src/table/col.rs
+++ b/packages/coln-store/src/table/col.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 use crate::id_packer::IdPacker;
 
-use super::{CellKind, WireValue, PackedValue, PackedRowId};
+use super::{CellKind, PackedRowId, PackedValue, WireValue};
 
 /// Columnar storage for [`PackedRowId`]s, split into two parallel columns.
 ///
@@ -89,7 +89,6 @@ impl IdColumn {
     }
 }
 
-
 /// One column of typed storage. The variant is fixed by the schema column type.
 /// Each id is 8 bytes instead of a 40-byte [`WireValue`].
 #[derive(Debug, Clone)]
@@ -153,7 +152,9 @@ impl Column {
     pub(super) fn scope_to_value(&self, value: &PackedValue, range: Range<usize>) -> Range<usize> {
         match (self, value) {
             (Column::Id(column), PackedValue::Id(value)) => column.scope_to_value(*value, range),
-            (Column::Int(column), PackedValue::Int(value)) => column.scope_to_value(*value as i64, range),
+            (Column::Int(column), PackedValue::Int(value)) => {
+                column.scope_to_value(*value as i64, range)
+            }
             (Column::Str(column), PackedValue::Str(value)) => {
                 column.scope_to_value(value.as_str(), range)
             }

--- a/packages/coln-store/src/table/col.rs
+++ b/packages/coln-store/src/table/col.rs
@@ -7,7 +7,7 @@ use std::ops::Range;
 
 use crate::id_packer::IdPacker;
 
-use super::{CellKind, CellValue, PackedCell, PackedRowId};
+use super::{CellKind, WireValue, PackedValue, PackedRowId};
 
 /// Columnar storage for [`PackedRowId`]s, split into two parallel columns.
 ///
@@ -89,12 +89,13 @@ impl IdColumn {
     }
 }
 
+
 /// One column of typed storage. The variant is fixed by the schema column type.
-/// Each id is 8 bytes instead of a 40-byte [`CellValue`].
+/// Each id is 8 bytes instead of a 40-byte [`WireValue`].
 #[derive(Debug, Clone)]
 pub(super) enum Column {
     Id(IdColumn),
-    Int(hexane::Column<i64>),
+    Int(hexane::Column<i64>), // TODO: change to i32
     Str(hexane::Column<String>),
 }
 
@@ -111,11 +112,11 @@ impl Column {
     ///
     /// Panics on a type mismatch, which `Table::validate_insert` rules out
     /// before rows reach storage.
-    pub(super) fn insert(&mut self, row: usize, value: PackedCell) {
+    pub(super) fn insert(&mut self, row: usize, value: PackedValue) {
         match (self, value) {
-            (Column::Id(cells), PackedCell::Id(id)) => cells.insert(row, id),
-            (Column::Int(cells), PackedCell::Int(value)) => cells.insert(row, value),
-            (Column::Str(cells), PackedCell::Str(value)) => cells.insert(row, value),
+            (Column::Id(cells), PackedValue::Id(id)) => cells.insert(row, id),
+            (Column::Int(cells), PackedValue::Int(value)) => cells.insert(row, value as i64),
+            (Column::Str(cells), PackedValue::Str(value)) => cells.insert(row, value),
             (column, value) => panic!(
                 "cell type mismatch: column stores {:?}, got {value:?}",
                 CellKind::from(&*column)
@@ -131,29 +132,29 @@ impl Column {
         }
     }
 
-    pub(super) fn get(&self, row: usize, packer: &IdPacker) -> Option<CellValue> {
+    pub(super) fn get(&self, row: usize, packer: &IdPacker) -> Option<WireValue> {
         match self {
             Column::Id(cells) => cells
                 .get(row)
-                .map(|id| CellValue::Id(packer.unpack_row_id(id))),
-            Column::Int(cells) => cells.get(row).map(CellValue::Int),
-            Column::Str(cells) => cells.get(row).map(|s| CellValue::Str(s.to_owned())),
+                .map(|id| WireValue::Id(packer.unpack_row_id(id))),
+            Column::Int(cells) => cells.get(row).map(|i| WireValue::Int(i as i32)),
+            Column::Str(cells) => cells.get(row).map(|s| WireValue::Str(s.to_owned())),
         }
     }
 
-    pub(super) fn get_packed(&self, row: usize) -> Option<PackedCell> {
+    pub(super) fn get_packed(&self, row: usize) -> Option<PackedValue> {
         match self {
-            Column::Id(cells) => cells.get(row).map(PackedCell::Id),
-            Column::Int(cells) => cells.get(row).map(PackedCell::Int),
-            Column::Str(cells) => cells.get(row).map(|s| PackedCell::Str(s.to_owned())),
+            Column::Id(cells) => cells.get(row).map(PackedValue::Id),
+            Column::Int(cells) => cells.get(row).map(|i| PackedValue::Int(i as i32)),
+            Column::Str(cells) => cells.get(row).map(|s| PackedValue::Str(s.to_owned())),
         }
     }
 
-    pub(super) fn scope_to_value(&self, value: &PackedCell, range: Range<usize>) -> Range<usize> {
+    pub(super) fn scope_to_value(&self, value: &PackedValue, range: Range<usize>) -> Range<usize> {
         match (self, value) {
-            (Column::Id(column), PackedCell::Id(value)) => column.scope_to_value(*value, range),
-            (Column::Int(column), PackedCell::Int(value)) => column.scope_to_value(*value, range),
-            (Column::Str(column), PackedCell::Str(value)) => {
+            (Column::Id(column), PackedValue::Id(value)) => column.scope_to_value(*value, range),
+            (Column::Int(column), PackedValue::Int(value)) => column.scope_to_value(*value as i64, range),
+            (Column::Str(column), PackedValue::Str(value)) => {
                 column.scope_to_value(value.as_str(), range)
             }
             (column, value) => panic!(

--- a/packages/coln-store/src/table/index.rs
+++ b/packages/coln-store/src/table/index.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 
 use crate::ir::Schema;
 
-use super::{CellKind, Column, IdColumn, PackedValue, PackedRowId};
+use super::{CellKind, Column, IdColumn, PackedRowId, PackedValue};
 
 pub(crate) type IndexId = usize;
 

--- a/packages/coln-store/src/table/index.rs
+++ b/packages/coln-store/src/table/index.rs
@@ -15,7 +15,7 @@ use std::ops::Range;
 
 use crate::ir::Schema;
 
-use super::{CellKind, Column, IdColumn, PackedCell, PackedRowId};
+use super::{CellKind, Column, IdColumn, PackedValue, PackedRowId};
 
 pub(crate) type IndexId = usize;
 
@@ -57,7 +57,7 @@ impl TableIndex {
         }
     }
 
-    pub(super) fn insert(&mut self, key: Vec<PackedCell>, value: PackedRowId) {
+    pub(super) fn insert(&mut self, key: Vec<PackedValue>, value: PackedRowId) {
         let key_range = self.scope_key(&key);
         let value_range = self.values.scope_to_value(value, key_range);
         let position = value_range.end;
@@ -68,7 +68,7 @@ impl TableIndex {
         self.values.insert(position, value);
     }
 
-    pub(super) fn remove(&mut self, key: &[PackedCell], value: PackedRowId) {
+    pub(super) fn remove(&mut self, key: &[PackedValue], value: PackedRowId) {
         let key_range = self.scope_key(key);
         let value_range = self.values.scope_to_value(value, key_range);
         for position in value_range.rev() {
@@ -79,15 +79,15 @@ impl TableIndex {
         }
     }
 
-    pub(super) fn get(&self, key: &[PackedCell]) -> impl Iterator<Item = PackedRowId> {
+    pub(super) fn get(&self, key: &[PackedValue]) -> impl Iterator<Item = PackedRowId> {
         self.scope_key(key).map(|position| self.values.at(position))
     }
 
-    pub(super) fn contains_key(&self, key: &[PackedCell]) -> bool {
+    pub(super) fn contains_key(&self, key: &[PackedValue]) -> bool {
         self.get(key).next().is_some()
     }
 
-    fn scope_key(&self, key: &[PackedCell]) -> Range<usize> {
+    fn scope_key(&self, key: &[PackedValue]) -> Range<usize> {
         debug_assert_eq!(
             key.len(),
             self.keys.len(),
@@ -136,16 +136,16 @@ mod tests {
 
         let rows = [(5, packed(1)), (1, packed(2)), (9, packed(3))];
         for (key, row_id) in rows {
-            index.insert(vec![PackedCell::Int(key)], row_id);
+            index.insert(vec![PackedValue::Int(key)], row_id);
         }
 
         for (key, row_id) in rows {
             assert_eq!(
-                index.get(&[PackedCell::Int(key)]).collect::<Vec<_>>(),
+                index.get(&[PackedValue::Int(key)]).collect::<Vec<_>>(),
                 vec![row_id]
             );
         }
-        assert!(!index.contains_key(&[PackedCell::Int(3)]));
+        assert!(!index.contains_key(&[PackedValue::Int(3)]));
     }
 
     /// If there are multiple keys of the same value, then `get` returns an iterator
@@ -156,13 +156,13 @@ mod tests {
         let first = packed(1);
         let second = packed(2);
         let third = packed(3);
-        index.insert(vec![PackedCell::Int(5)], third);
-        index.insert(vec![PackedCell::Int(7)], packed(4));
-        index.insert(vec![PackedCell::Int(5)], first);
-        index.insert(vec![PackedCell::Int(5)], second);
+        index.insert(vec![PackedValue::Int(5)], third);
+        index.insert(vec![PackedValue::Int(7)], packed(4));
+        index.insert(vec![PackedValue::Int(5)], first);
+        index.insert(vec![PackedValue::Int(5)], second);
 
         assert_eq!(
-            index.get(&[PackedCell::Int(5)]).collect::<Vec<_>>(),
+            index.get(&[PackedValue::Int(5)]).collect::<Vec<_>>(),
             vec![first, second, third]
         );
     }
@@ -175,16 +175,16 @@ mod tests {
         let first = packed(1);
         let second = packed(2);
         let other = packed(3);
-        index.insert(vec![PackedCell::Int(5)], second);
-        index.insert(vec![PackedCell::Int(7)], other);
-        index.insert(vec![PackedCell::Int(5)], first);
+        index.insert(vec![PackedValue::Int(5)], second);
+        index.insert(vec![PackedValue::Int(7)], other);
+        index.insert(vec![PackedValue::Int(5)], first);
 
-        index.remove(&[PackedCell::Int(5)], first);
-        index.remove(&[PackedCell::Int(5)], second);
+        index.remove(&[PackedValue::Int(5)], first);
+        index.remove(&[PackedValue::Int(5)], second);
 
-        assert_eq!(index.get(&[PackedCell::Int(5)]).next(), None);
+        assert_eq!(index.get(&[PackedValue::Int(5)]).next(), None);
         assert_eq!(
-            index.get(&[PackedCell::Int(7)]).collect::<Vec<_>>(),
+            index.get(&[PackedValue::Int(7)]).collect::<Vec<_>>(),
             vec![other]
         );
     }
@@ -196,20 +196,20 @@ mod tests {
         let first = packed(1);
         let second = packed(2);
         let other = packed(3);
-        index.insert(vec![PackedCell::Int(5)], second);
-        index.insert(vec![PackedCell::Int(7)], other);
-        index.insert(vec![PackedCell::Int(5)], first);
+        index.insert(vec![PackedValue::Int(5)], second);
+        index.insert(vec![PackedValue::Int(7)], other);
+        index.insert(vec![PackedValue::Int(5)], first);
 
-        index.remove(&[PackedCell::Int(4)], first);
-        index.remove(&[PackedCell::Int(5)], packed(9));
-        index.remove(&[PackedCell::Int(4)], first);
+        index.remove(&[PackedValue::Int(4)], first);
+        index.remove(&[PackedValue::Int(5)], packed(9));
+        index.remove(&[PackedValue::Int(4)], first);
 
         assert_eq!(
-            index.get(&[PackedCell::Int(5)]).collect::<Vec<_>>(),
+            index.get(&[PackedValue::Int(5)]).collect::<Vec<_>>(),
             vec![first, second]
         );
         assert_eq!(
-            index.get(&[PackedCell::Int(7)]).collect::<Vec<_>>(),
+            index.get(&[PackedValue::Int(7)]).collect::<Vec<_>>(),
             vec![other]
         );
         assert_eq!(index.values.len(), 3);
@@ -242,7 +242,7 @@ mod tests {
         ];
 
         for ((c1, c0), row_id) in entries {
-            index.insert(vec![PackedCell::Int(c1), PackedCell::Int(c0)], row_id);
+            index.insert(vec![PackedValue::Int(c1), PackedValue::Int(c0)], row_id);
         }
 
         let stored = (0..index.values.len())
@@ -257,11 +257,11 @@ mod tests {
         assert_eq!(
             stored,
             vec![
-                (PackedCell::Int(0), PackedCell::Int(9), packed(5)),
-                (PackedCell::Int(1), PackedCell::Int(1), packed(1)),
-                (PackedCell::Int(1), PackedCell::Int(1), packed(2)),
-                (PackedCell::Int(1), PackedCell::Int(2), packed(4)),
-                (PackedCell::Int(2), PackedCell::Int(0), packed(3)),
+                (PackedValue::Int(0), PackedValue::Int(9), packed(5)),
+                (PackedValue::Int(1), PackedValue::Int(1), packed(1)),
+                (PackedValue::Int(1), PackedValue::Int(1), packed(2)),
+                (PackedValue::Int(1), PackedValue::Int(2), packed(4)),
+                (PackedValue::Int(2), PackedValue::Int(0), packed(3)),
             ]
         );
     }

--- a/packages/coln-store/src/table/mod.rs
+++ b/packages/coln-store/src/table/mod.rs
@@ -9,7 +9,7 @@ pub mod sorted;
 pub mod table_ref;
 mod undo;
 
-pub use cell::{CellKind, WireValue, WireRowId};
+pub use cell::{CellKind, WireRowId, WireValue};
 pub use table_ref::TableRef;
 
 use std::collections::{HashMap, HashSet};
@@ -24,7 +24,7 @@ use crate::table::index::{IndexId, IndexMeta, TableIndex};
 use crate::table::undo::UndoOp;
 use crate::txn::TxnId;
 
-pub(crate) use self::cell::{PackedValue, PackedRowId};
+pub(crate) use self::cell::{PackedRowId, PackedValue};
 use self::col::{Column, IdColumn};
 
 pub type TableOid = usize;

--- a/packages/coln-store/src/table/mod.rs
+++ b/packages/coln-store/src/table/mod.rs
@@ -9,7 +9,7 @@ pub mod sorted;
 pub mod table_ref;
 mod undo;
 
-pub use cell::{CellKind, CellValue, RowId};
+pub use cell::{CellKind, WireValue, WireRowId};
 pub use table_ref::TableRef;
 
 use std::collections::{HashMap, HashSet};
@@ -24,7 +24,7 @@ use crate::table::index::{IndexId, IndexMeta, TableIndex};
 use crate::table::undo::UndoOp;
 use crate::txn::TxnId;
 
-pub(crate) use self::cell::{PackedCell, PackedRowId};
+pub(crate) use self::cell::{PackedValue, PackedRowId};
 use self::col::{Column, IdColumn};
 
 pub type TableOid = usize;
@@ -42,7 +42,7 @@ pub(crate) struct TableMeta<'a> {
 pub(crate) enum PackedOp {
     Add {
         row_id: PackedRowId,
-        values: Vec<PackedCell>,
+        values: Vec<PackedValue>,
     },
     Delete {
         row_id: PackedRowId,
@@ -75,7 +75,7 @@ pub enum ValidationError {
     #[error("row handle belongs to a different transaction: current {current:?}, got {got:?}")]
     TxnIdMismatch { current: TxnId, got: TxnId },
     #[error("invalid row handle: {reason}")]
-    InvalidRowHandle { reason: String },
+    InvalidTxnLiveRowId { reason: String },
     #[error("invalid index id passed {index}")]
     InvalidIndex { index: u64 },
     #[error("invalid index key for index {index}: expected {expected} values, got {got}")]
@@ -91,8 +91,8 @@ pub enum ValidationError {
 /// Public facing row value
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RowView {
-    pub row_id: RowId,
-    pub values: Vec<CellValue>,
+    pub row_id: WireRowId,
+    pub values: Vec<WireValue>,
 }
 
 type ColName = ir::Path;
@@ -216,7 +216,7 @@ impl Table {
     }
 
     /// Row id at a given physical row index.
-    pub(crate) fn row_id_at(&self, row_idx: usize, packer: &IdPacker) -> Option<RowId> {
+    pub(crate) fn row_id_at(&self, row_idx: usize, packer: &IdPacker) -> Option<WireRowId> {
         self.row_ids
             .get(row_idx)
             .map(|packed| packer.unpack_row_id(packed))
@@ -229,7 +229,7 @@ impl Table {
         row_idx: usize,
         col_idx: usize,
         packer: &IdPacker,
-    ) -> Option<CellValue> {
+    ) -> Option<WireValue> {
         self.cols
             .get(col_idx)
             .and_then(|col| col.get(row_idx, packer))
@@ -262,7 +262,7 @@ impl Table {
 #[derive(Debug, PartialEq, Eq)]
 pub struct SeekKey {
     pub(crate) column: usize,
-    pub(crate) value: CellValue,
+    pub(crate) value: WireValue,
 }
 
 impl Table {
@@ -279,7 +279,7 @@ impl Table {
 
     /// O(N * log S) as first find out the index from the row_id, and then do a
     /// lookup on each column
-    pub(crate) fn packed_row_at(&self, row_id: PackedRowId) -> Option<Vec<PackedCell>> {
+    pub(crate) fn packed_row_at(&self, row_id: PackedRowId) -> Option<Vec<PackedValue>> {
         let row_idx = self.row_ids.position(row_id).ok()?;
         (0..self.schema.columns.len())
             .map(|col_idx| {
@@ -298,7 +298,7 @@ impl Table {
         &self,
         key: &[SeekKey],
         id_packer: &IdPacker,
-    ) -> Result<impl Iterator<Item = RowId>, ValidationError> {
+    ) -> Result<impl Iterator<Item = WireRowId>, ValidationError> {
         if let Some(column) = key
             .iter()
             .map(|part| part.column)
@@ -325,9 +325,9 @@ impl Table {
     pub(crate) fn index_seek(
         &self,
         index: IndexId,
-        key: &[CellValue],
+        key: &[WireValue],
         id_packer: &IdPacker,
-    ) -> Result<impl Iterator<Item = RowId>, ValidationError> {
+    ) -> Result<impl Iterator<Item = WireRowId>, ValidationError> {
         let table_index = self
             .indexes
             .get(index)
@@ -359,7 +359,7 @@ impl Table {
     pub(crate) fn index_seek_packed(
         &self,
         index: IndexId,
-        key: &[PackedCell],
+        key: &[PackedValue],
     ) -> Result<impl Iterator<Item = PackedRowId>, ValidationError> {
         let table_index = self
             .indexes
@@ -388,7 +388,7 @@ impl Table {
     pub(crate) fn index_lookup(
         &self,
         index: IndexId,
-        key: &[CellValue],
+        key: &[WireValue],
         id_packer: &IdPacker,
     ) -> Result<bool, ValidationError> {
         Ok(self.index_seek(index, key, id_packer)?.next().is_some())
@@ -412,7 +412,7 @@ impl Table {
     /// Checks schema and primary-key constraints against rows already stored.
     pub(crate) fn validate_insert(
         &self,
-        values: &[CellValue],
+        values: &[WireValue],
         dict: &IdPacker,
     ) -> Result<(), ValidationError> {
         // duplicated as txn::add(), but this is cheap enough we can afford to
@@ -454,7 +454,7 @@ impl Table {
     /// Values at primary-key columns for this row.
     /// A primary key definition would occur in tables that do not end up in Query
     /// An empty primary key means the table would have at most one row.
-    pub fn primary_key_values(&self, values: &[CellValue]) -> Option<Vec<CellValue>> {
+    pub fn primary_key_values(&self, values: &[WireValue]) -> Option<Vec<WireValue>> {
         self.schema.primary_key.as_ref().and_then(|pk| {
             if pk.is_empty() {
                 Some(Vec::new())
@@ -627,7 +627,7 @@ impl Table {
             }
 
             let new_row_id = rowing.canonical_id(&old_row_id, id_packer);
-            let old_cells: Vec<PackedCell> = self
+            let old_cells: Vec<PackedValue> = self
                 .cols
                 .iter()
                 .map(|column| {
@@ -663,14 +663,14 @@ impl Table {
 
     /// Rewrite every id cell to its canonical id, leaving other cells alone.
     fn canonicalise_cells(
-        values: &[PackedCell],
+        values: &[PackedValue],
         rowing: &Rowing,
         id_packer: &IdPacker,
-    ) -> Vec<PackedCell> {
+    ) -> Vec<PackedValue> {
         values
             .iter()
             .map(|cell| match cell {
-                PackedCell::Id(id) => PackedCell::Id(rowing.canonical_id(id, id_packer)),
+                PackedValue::Id(id) => PackedValue::Id(rowing.canonical_id(id, id_packer)),
                 other => other.clone(),
             })
             .collect()
@@ -678,12 +678,12 @@ impl Table {
 
     /// ids referred by this row.
     #[expect(dead_code)]
-    fn referenced_ids(values: &[PackedCell]) -> impl Iterator<Item = PackedRowId> {
+    fn referenced_ids(values: &[PackedValue]) -> impl Iterator<Item = PackedRowId> {
         values
             .iter()
             .enumerate()
             .filter_map(|(i, cell)| match cell {
-                PackedCell::Id(id) if !values[..i].contains(cell) => Some(*id),
+                PackedValue::Id(id) if !values[..i].contains(cell) => Some(*id),
                 _ => None,
             })
     }
@@ -697,7 +697,7 @@ impl Table {
     /// Only does primary key check, but no other validation.
     pub(super) fn insert_row(
         &mut self,
-        values: Vec<PackedCell>,
+        values: Vec<PackedValue>,
         row_id: PackedRowId,
         rowing: &mut Rowing,
     ) -> Result<(), ValidationError> {
@@ -741,7 +741,7 @@ impl Table {
     }
 
     /// Place a row in columnar storage and every index, with no validation
-    fn insert_packed(&mut self, values: Vec<PackedCell>, row_id: PackedRowId) {
+    fn insert_packed(&mut self, values: Vec<PackedValue>, row_id: PackedRowId) {
         debug_assert_eq!(values.len(), self.schema.columns.len());
 
         for index in &mut self.indexes {
@@ -763,7 +763,7 @@ impl Table {
     }
 
     /// Take a row out of columnar storage and every index, returning its cells
-    fn remove_packed(&mut self, row_id: PackedRowId) -> Vec<PackedCell> {
+    fn remove_packed(&mut self, row_id: PackedRowId) -> Vec<PackedValue> {
         let row_idx = self
             .row_ids
             .position(row_id)
@@ -797,7 +797,7 @@ impl Table {
         values
     }
 
-    fn project_index_key(index: &TableIndex, values: &[PackedCell]) -> Vec<PackedCell> {
+    fn project_index_key(index: &TableIndex, values: &[PackedValue]) -> Vec<PackedValue> {
         index
             .key_cols()
             .iter()

--- a/packages/coln-store/src/table/sorted.rs
+++ b/packages/coln-store/src/table/sorted.rs
@@ -133,7 +133,7 @@ impl Store {
 }
 
 impl<'a> SortedTableSnapshot for SortedTable<'a> {
-    type Value = table::CellValue;
+    type Value = table::WireValue;
 
     /// Number of columns, including rowid column
     fn arity(&self) -> usize {

--- a/packages/coln-store/src/table/table_ref.rs
+++ b/packages/coln-store/src/table/table_ref.rs
@@ -6,7 +6,7 @@ use crate::id_packer::IdPacker;
 use crate::ir;
 use crate::ir::Schema;
 use crate::table::index::{IndexId, IndexMeta};
-use crate::table::{WireValue, WireRowId, RowView, SeekKey, Table, TableOid, ValidationError};
+use crate::table::{RowView, SeekKey, Table, TableOid, ValidationError, WireRowId, WireValue};
 
 /// A [`Table`] together with the store-wide hash dictionary, for read-only
 /// access. This is what [`Store`](crate::store::Store) accessors hand out, so

--- a/packages/coln-store/src/table/table_ref.rs
+++ b/packages/coln-store/src/table/table_ref.rs
@@ -6,7 +6,7 @@ use crate::id_packer::IdPacker;
 use crate::ir;
 use crate::ir::Schema;
 use crate::table::index::{IndexId, IndexMeta};
-use crate::table::{CellValue, RowId, RowView, SeekKey, Table, TableOid, ValidationError};
+use crate::table::{WireValue, WireRowId, RowView, SeekKey, Table, TableOid, ValidationError};
 
 /// A [`Table`] together with the store-wide hash dictionary, for read-only
 /// access. This is what [`Store`](crate::store::Store) accessors hand out, so
@@ -42,11 +42,11 @@ impl<'a> TableRef<'a> {
         self.table.cols.len() + 1
     }
 
-    pub fn row_id_at(self, row_idx: usize) -> Option<RowId> {
+    pub fn row_id_at(self, row_idx: usize) -> Option<WireRowId> {
         self.table.row_id_at(row_idx, self.id_packer)
     }
 
-    pub fn cell_at(self, row_idx: usize, col_idx: usize) -> Option<CellValue> {
+    pub fn cell_at(self, row_idx: usize, col_idx: usize) -> Option<WireValue> {
         self.table.cell_at(row_idx, col_idx, self.id_packer)
     }
 
@@ -54,7 +54,7 @@ impl<'a> TableRef<'a> {
         self.table.row_at(row_idx, self.id_packer)
     }
 
-    pub fn row_position(self, row_id: RowId) -> Option<usize> {
+    pub fn row_position(self, row_id: WireRowId) -> Option<usize> {
         let row_id = self.id_packer.lookup_row_id(row_id)?;
         self.table.row_idx(row_id)
     }
@@ -67,15 +67,15 @@ impl<'a> TableRef<'a> {
         self.table.indexes_meta()
     }
 
-    pub fn seek(self, key: &[SeekKey]) -> Result<impl Iterator<Item = RowId>, ValidationError> {
+    pub fn seek(self, key: &[SeekKey]) -> Result<impl Iterator<Item = WireRowId>, ValidationError> {
         self.table.seek(key, self.id_packer)
     }
 
     pub fn index_seek(
         self,
         index: IndexId,
-        key: &[CellValue],
-    ) -> Result<impl Iterator<Item = RowId>, ValidationError> {
+        key: &[WireValue],
+    ) -> Result<impl Iterator<Item = WireRowId>, ValidationError> {
         self.table.index_seek(index, key, self.id_packer)
     }
 
@@ -83,7 +83,7 @@ impl<'a> TableRef<'a> {
         self.table.lookup(key, self.id_packer)
     }
 
-    pub fn index_lookup(self, index: IndexId, key: &[CellValue]) -> Result<bool, ValidationError> {
+    pub fn index_lookup(self, index: IndexId, key: &[WireValue]) -> Result<bool, ValidationError> {
         self.table.index_lookup(index, key, self.id_packer)
     }
 
@@ -95,11 +95,11 @@ impl<'a> TableRef<'a> {
         self.table.validate_column_count(got)
     }
 
-    pub fn validate_insert(self, values: &[CellValue]) -> Result<(), ValidationError> {
+    pub fn validate_insert(self, values: &[WireValue]) -> Result<(), ValidationError> {
         self.table.validate_insert(values, self.id_packer)
     }
 
-    pub fn primary_key_values(self, values: &[CellValue]) -> Option<Vec<CellValue>> {
+    pub fn primary_key_values(self, values: &[WireValue]) -> Option<Vec<WireValue>> {
         self.table.primary_key_values(values)
     }
 }

--- a/packages/coln-store/src/table/tests.rs
+++ b/packages/coln-store/src/table/tests.rs
@@ -8,15 +8,15 @@ use crate::ir::{self, Path};
 use crate::ir::{BuiltinTy, ColType};
 use crate::op::Op;
 
-fn test_row_id(counter: u32) -> RowId {
-    RowId {
+fn test_row_id(counter: u32) -> WireRowId {
+    WireRowId {
         commit: CommitHash([0; 32]),
         counter,
     }
 }
 
-fn row_id_from(commit_byte: u8, counter: u32) -> RowId {
-    RowId {
+fn row_id_from(commit_byte: u8, counter: u32) -> WireRowId {
+    WireRowId {
         commit: CommitHash([commit_byte; 32]),
         counter,
     }
@@ -66,11 +66,11 @@ impl TestTable {
         self.table.row_count()
     }
 
-    fn row_id_at(&self, row_idx: usize) -> Option<RowId> {
+    fn row_id_at(&self, row_idx: usize) -> Option<WireRowId> {
         self.table.row_id_at(row_idx, &self.dict)
     }
 
-    fn cell_at(&self, row_idx: usize, col_idx: usize) -> Option<CellValue> {
+    fn cell_at(&self, row_idx: usize, col_idx: usize) -> Option<WireValue> {
         self.table.cell_at(row_idx, col_idx, &self.dict)
     }
 
@@ -78,17 +78,17 @@ impl TestTable {
         self.table.row_at(row_idx, &self.dict)
     }
 
-    fn row_position(&self, row_id: RowId) -> Option<usize> {
+    fn row_position(&self, row_id: WireRowId) -> Option<usize> {
         let row_id = self.dict.lookup_row_id(row_id)?;
         self.table.row_idx(row_id)
     }
 
     /// Rows the table records as referring to `child`, in row id order.
-    fn referring_rows(&self, child: RowId) -> Vec<RowId> {
+    fn referring_rows(&self, child: WireRowId) -> Vec<WireRowId> {
         let Some(child) = self.dict.lookup_row_id(child) else {
             return Vec::new();
         };
-        let mut rows: Vec<RowId> = self
+        let mut rows: Vec<WireRowId> = self
             .table
             .rebuild_index
             .get(&child)
@@ -102,11 +102,11 @@ impl TestTable {
         rows
     }
 
-    fn validate_insert(&self, values: &[CellValue]) -> Result<(), ValidationError> {
+    fn validate_insert(&self, values: &[WireValue]) -> Result<(), ValidationError> {
         self.table.validate_insert(values, &self.dict)
     }
 
-    fn insert_row(&mut self, values: Vec<CellValue>, row_id: RowId) {
+    fn insert_row(&mut self, values: Vec<WireValue>, row_id: WireRowId) {
         let row_id = self.dict.pack_row_id(row_id);
         let values = values
             .into_iter()
@@ -132,7 +132,7 @@ impl TestTable {
         self.table.stage_update(PackedOp::Add { row_id, values });
     }
 
-    fn stage_delete(&mut self, row_id: RowId) {
+    fn stage_delete(&mut self, row_id: WireRowId) {
         let row_id = self.dict.pack_row_id(row_id);
         self.table.stage_update(PackedOp::Delete { row_id });
     }
@@ -177,25 +177,25 @@ fn rollback_removes_applied_rows_and_index_entries() {
     let existing = test_row_id(0);
     let first_added = test_row_id(1);
     let second_added = test_row_id(2);
-    tbl.insert_row(vec![CellValue::Int(1)], existing);
+    tbl.insert_row(vec![WireValue::Int(1)], existing);
 
     let snapshot = tbl.table.snapshot();
     tbl.stage_update(Op::Add {
         row_id: first_added,
         table: 0,
-        values: vec![CellValue::Int(2)],
+        values: vec![WireValue::Int(2)],
     });
     tbl.stage_update(Op::Add {
         row_id: second_added,
         table: 0,
-        values: vec![CellValue::Int(3)],
+        values: vec![WireValue::Int(3)],
     });
     tbl.apply_staged_ops()
         .expect("the added rows have distinct keys");
 
     assert_eq!(tbl.row_count(), 3);
     assert_eq!(
-        tbl.validate_insert(&[CellValue::Int(2)]),
+        tbl.validate_insert(&[WireValue::Int(2)]),
         Err(ValidationError::DuplicatePrimaryKey)
     );
 
@@ -205,8 +205,8 @@ fn rollback_removes_applied_rows_and_index_entries() {
     assert_eq!(tbl.row_id_at(0), Some(existing));
     assert_eq!(tbl.row_position(first_added), None);
     assert_eq!(tbl.row_position(second_added), None);
-    assert!(tbl.validate_insert(&[CellValue::Int(2)]).is_ok());
-    assert!(tbl.validate_insert(&[CellValue::Int(3)]).is_ok());
+    assert!(tbl.validate_insert(&[WireValue::Int(2)]).is_ok());
+    assert!(tbl.validate_insert(&[WireValue::Int(3)]).is_ok());
     assert!(tbl.table.undo_log.is_none());
 }
 
@@ -221,8 +221,8 @@ fn staged_delete_removes_row_and_undo_restores_it() {
     );
     let kept = test_row_id(0);
     let removed = test_row_id(1);
-    tbl.insert_row(vec![CellValue::Int(1)], kept);
-    tbl.insert_row(vec![CellValue::Int(2)], removed);
+    tbl.insert_row(vec![WireValue::Int(1)], kept);
+    tbl.insert_row(vec![WireValue::Int(2)], removed);
 
     let snapshot = tbl.table.snapshot();
     tbl.stage_delete(removed);
@@ -232,16 +232,16 @@ fn staged_delete_removes_row_and_undo_restores_it() {
     assert_eq!(tbl.row_count(), 1);
     assert_eq!(tbl.row_position(removed), None);
     // The primary key index gave up the key, so it is free to reuse.
-    assert!(tbl.validate_insert(&[CellValue::Int(2)]).is_ok());
+    assert!(tbl.validate_insert(&[WireValue::Int(2)]).is_ok());
 
     tbl.table.rollback(snapshot);
 
     assert_eq!(tbl.row_count(), 2);
     assert_eq!(tbl.row_position(kept), Some(0));
     let idx = tbl.row_position(removed).expect("row is restored");
-    assert_eq!(tbl.cell_at(idx, 0), Some(CellValue::Int(2)));
+    assert_eq!(tbl.cell_at(idx, 0), Some(WireValue::Int(2)));
     assert_eq!(
-        tbl.validate_insert(&[CellValue::Int(2)]),
+        tbl.validate_insert(&[WireValue::Int(2)]),
         Err(ValidationError::DuplicatePrimaryKey)
     );
 }
@@ -259,8 +259,8 @@ fn rebuild_index_tracks_rows_referring_to_an_id() {
     let pair = test_row_id(0);
     let doubled = test_row_id(1);
 
-    tbl.insert_row(vec![CellValue::Id(a), CellValue::Id(b)], pair);
-    tbl.insert_row(vec![CellValue::Id(a), CellValue::Id(a)], doubled);
+    tbl.insert_row(vec![WireValue::Id(a), WireValue::Id(b)], pair);
+    tbl.insert_row(vec![WireValue::Id(a), WireValue::Id(a)], doubled);
 
     // `doubled` refers to `a` twice but is recorded against it once, so a
     // rebuild pass restages it once rather than deleting it twice.
@@ -290,7 +290,7 @@ fn full_rebuild_rewrites_stale_id_cells() {
     let canonical_child = row_id_from(1, 0);
     let stale_child = row_id_from(2, 0);
     let owner = test_row_id(0);
-    tbl.insert_row(vec![CellValue::Id(stale_child)], owner);
+    tbl.insert_row(vec![WireValue::Id(stale_child)], owner);
 
     let stale_child = tbl.dict.lookup_row_id(stale_child).unwrap();
     let canonical_child = tbl.dict.pack_row_id(canonical_child);
@@ -302,7 +302,7 @@ fn full_rebuild_rewrites_stale_id_cells() {
 
     assert_eq!(tbl.row_count(), 1);
     assert_eq!(tbl.row_id_at(0), Some(owner));
-    assert_eq!(tbl.cell_at(0, 0), Some(CellValue::Id(row_id_from(1, 0))));
+    assert_eq!(tbl.cell_at(0, 0), Some(WireValue::Id(row_id_from(1, 0))));
 }
 
 #[test]
@@ -311,8 +311,8 @@ fn full_rebuild_collapses_a_displaced_row_onto_its_canonical_row() {
         TestTable::with_structural_index(Path::from("term"), int_schema(&["value"], None));
     let canonical = row_id_from(1, 0);
     let displaced = row_id_from(2, 0);
-    tbl.insert_row(vec![CellValue::Int(7)], displaced);
-    tbl.insert_row(vec![CellValue::Int(7)], canonical);
+    tbl.insert_row(vec![WireValue::Int(7)], displaced);
+    tbl.insert_row(vec![WireValue::Int(7)], canonical);
     tbl.rowing.apply_unions(&tbl.dict);
 
     tbl.table.rebuild_full(&tbl.rowing, &tbl.dict);
@@ -320,7 +320,7 @@ fn full_rebuild_collapses_a_displaced_row_onto_its_canonical_row() {
 
     assert_eq!(tbl.row_count(), 1);
     assert_eq!(tbl.row_id_at(0), Some(canonical));
-    assert_eq!(tbl.cell_at(0, 0), Some(CellValue::Int(7)));
+    assert_eq!(tbl.cell_at(0, 0), Some(WireValue::Int(7)));
 }
 
 /// Rollback replays the undo log through the same insert path, so the
@@ -332,7 +332,7 @@ fn rollback_restores_rebuild_index_entries() {
     let a = row_id_from(1, 0);
     let b = row_id_from(1, 1);
     let row = test_row_id(0);
-    tbl.insert_row(vec![CellValue::Id(a), CellValue::Id(b)], row);
+    tbl.insert_row(vec![WireValue::Id(a), WireValue::Id(b)], row);
 
     let snapshot = tbl.table.snapshot();
     tbl.stage_delete(row);
@@ -356,7 +356,7 @@ fn commit_snapshot_keeps_rows_and_discards_undo_log() {
     tbl.stage_update(Op::Add {
         row_id,
         table: 0,
-        values: vec![CellValue::Int(7)],
+        values: vec![WireValue::Int(7)],
     });
     tbl.apply_staged_ops()
         .expect("a table without a primary key accepts the row");
@@ -376,7 +376,7 @@ fn rollback_discards_updates_staged_after_snapshot() {
     tbl.stage_update(Op::Add {
         row_id: test_row_id(0),
         table: 0,
-        values: vec![CellValue::Int(7)],
+        values: vec![WireValue::Int(7)],
     });
     tbl.table.rollback(snapshot);
 
@@ -399,10 +399,10 @@ fn empty_primary_key_rejects_second_row() {
     };
     let mut tbl = TestTable::new(Path::from("singleton"), schema);
 
-    tbl.insert_row(vec![CellValue::Int(0)], test_row_id(0));
+    tbl.insert_row(vec![WireValue::Int(0)], test_row_id(0));
     assert_eq!(tbl.row_count(), 1);
 
-    let values1 = vec![CellValue::Int(1)];
+    let values1 = vec![WireValue::Int(1)];
     let err = tbl.validate_insert(&values1).unwrap_err();
     assert_eq!(err, ValidationError::DuplicatePrimaryKey);
     assert_eq!(tbl.row_count(), 1);
@@ -432,7 +432,7 @@ fn row_read_helpers_return_row_id_and_cells() {
 
     let row_id = test_row_id(0);
     tbl.insert_row(
-        vec![CellValue::Int(7), CellValue::Str("x".to_string())],
+        vec![WireValue::Int(7), WireValue::Str("x".to_string())],
         row_id,
     );
 
@@ -440,19 +440,19 @@ fn row_read_helpers_return_row_id_and_cells() {
         tbl.row_at(0),
         Some(RowView {
             row_id,
-            values: vec![CellValue::Int(7), CellValue::Str("x".to_string())],
+            values: vec![WireValue::Int(7), WireValue::Str("x".to_string())],
         })
     );
     assert_eq!(tbl.row_id_at(0), Some(row_id));
-    assert_eq!(tbl.cell_at(0, 0), Some(CellValue::Int(7)));
-    assert_eq!(tbl.cell_at(0, 1), Some(CellValue::Str("x".to_string())));
+    assert_eq!(tbl.cell_at(0, 0), Some(WireValue::Int(7)));
+    assert_eq!(tbl.cell_at(0, 1), Some(WireValue::Str("x".to_string())));
     let packed = tbl
         .dict
         .lookup_row_id(row_id)
         .expect("insert packed the row id");
     assert_eq!(
         tbl.table.packed_row_at(packed),
-        Some(vec![PackedCell::Int(7), PackedCell::Str("x".to_string())])
+        Some(vec![PackedValue::Int(7), PackedValue::Str("x".to_string())])
     );
     assert_eq!(tbl.row_at(1), None);
     assert_eq!(tbl.row_id_at(1), None);
@@ -471,14 +471,14 @@ fn packed_row_ids_round_trip_across_commits() {
         (row_id_from(1, 2), row_id_from(2, 1), row_id_from(3, 7)),
     ];
     for (rid, src, dst) in rows {
-        tbl.insert_row(vec![CellValue::Id(src), CellValue::Id(dst)], rid);
+        tbl.insert_row(vec![WireValue::Id(src), WireValue::Id(dst)], rid);
     }
 
     for (rid, src, dst) in rows {
         let idx = tbl.row_position(rid).expect("row is stored");
         assert_eq!(tbl.row_id_at(idx), Some(rid));
-        assert_eq!(tbl.cell_at(idx, 0), Some(CellValue::Id(src)));
-        assert_eq!(tbl.cell_at(idx, 1), Some(CellValue::Id(dst)));
+        assert_eq!(tbl.cell_at(idx, 0), Some(WireValue::Id(src)));
+        assert_eq!(tbl.cell_at(idx, 1), Some(WireValue::Id(dst)));
     }
 
     // Four distinct commit hashes, each interned exactly once.
@@ -511,10 +511,10 @@ fn rows_stay_sorted_by_row_id() {
         (row_id_from(1, 2), 4),
     ];
     for (rid, v) in rows {
-        tbl.insert_row(vec![CellValue::Int(v)], rid);
+        tbl.insert_row(vec![WireValue::Int(v)], rid);
     }
 
-    let stored: Vec<RowId> = (0..tbl.row_count())
+    let stored: Vec<WireRowId> = (0..tbl.row_count())
         .map(|idx| tbl.row_id_at(idx).expect("row id"))
         .collect();
     assert_eq!(
@@ -531,7 +531,7 @@ fn rows_stay_sorted_by_row_id() {
     // Cells moved together with their row ids.
     for (rid, v) in rows {
         let idx = tbl.row_position(rid).expect("row is stored");
-        assert_eq!(tbl.cell_at(idx, 0), Some(CellValue::Int(v)));
+        assert_eq!(tbl.cell_at(idx, 0), Some(WireValue::Int(v)));
     }
 
     // Absent ids: known commit with unused counter, and unknown commit.
@@ -549,19 +549,19 @@ fn primary_key_detects_duplicates_in_id_columns() {
 
     let src = row_id_from(3, 7);
     tbl.insert_row(
-        vec![CellValue::Id(src), CellValue::Id(row_id_from(4, 8))],
+        vec![WireValue::Id(src), WireValue::Id(row_id_from(4, 8))],
         row_id_from(1, 0),
     );
 
-    let duplicate = vec![CellValue::Id(src), CellValue::Id(row_id_from(4, 9))];
+    let duplicate = vec![WireValue::Id(src), WireValue::Id(row_id_from(4, 9))];
     assert_eq!(
         tbl.validate_insert(&duplicate),
         Err(ValidationError::DuplicatePrimaryKey)
     );
 
     let unseen_commit = vec![
-        CellValue::Id(row_id_from(9, 7)),
-        CellValue::Id(row_id_from(4, 8)),
+        WireValue::Id(row_id_from(9, 7)),
+        WireValue::Id(row_id_from(4, 8)),
     ];
     assert!(tbl.validate_insert(&unseen_commit).is_ok());
 }
@@ -591,19 +591,19 @@ fn multi_column_primary_key_checks_all_columns() {
 
     let rows = [(3, 1), (1, 2), (1, 1), (2, 1), (2, 2)];
     for (i, (a, b)) in rows.into_iter().enumerate() {
-        let values = vec![CellValue::Int(a), CellValue::Int(b), CellValue::Int(0)];
+        let values = vec![WireValue::Int(a), WireValue::Int(b), WireValue::Int(0)];
         tbl.validate_insert(&values).expect("unique pair");
         tbl.insert_row(values, test_row_id(i as u32));
     }
 
     for (a, b) in rows {
-        let dup = vec![CellValue::Int(a), CellValue::Int(b), CellValue::Int(9)];
+        let dup = vec![WireValue::Int(a), WireValue::Int(b), WireValue::Int(9)];
         assert_eq!(
             tbl.validate_insert(&dup),
             Err(ValidationError::DuplicatePrimaryKey)
         );
     }
-    let fresh = vec![CellValue::Int(3), CellValue::Int(2), CellValue::Int(0)];
+    let fresh = vec![WireValue::Int(3), WireValue::Int(2), WireValue::Int(0)];
     assert!(tbl.validate_insert(&fresh).is_ok());
 }
 
@@ -623,17 +623,17 @@ fn string_primary_key_detects_duplicates() {
     let mut tbl = TestTable::new(Path::from("named"), schema);
 
     for (i, name) in ["b", "a", "c"].into_iter().enumerate() {
-        let values = vec![CellValue::Str(name.to_string())];
+        let values = vec![WireValue::Str(name.to_string())];
         tbl.validate_insert(&values).expect("unique name");
         tbl.insert_row(values, test_row_id(i as u32));
     }
 
     assert_eq!(
-        tbl.validate_insert(&[CellValue::Str("a".to_string())]),
+        tbl.validate_insert(&[WireValue::Str("a".to_string())]),
         Err(ValidationError::DuplicatePrimaryKey)
     );
     assert!(
-        tbl.validate_insert(&[CellValue::Str("d".to_string())])
+        tbl.validate_insert(&[WireValue::Str("d".to_string())])
             .is_ok()
     );
 }
@@ -677,7 +677,7 @@ fn pk_insert_benchmark() {
     let start = std::time::Instant::now();
     for i in 0..n {
         let row_id = test_row_id(i as u32);
-        let values = vec![CellValue::Id(row_id), CellValue::Int(i)];
+        let values = vec![WireValue::Id(row_id), WireValue::Int(i)];
         tbl.validate_insert(&values).expect("keys are unique");
         tbl.insert_row(values, row_id);
     }
@@ -690,25 +690,25 @@ fn pk_insert_benchmark() {
 fn table_performs_index_lookup() {
     let schema = int_schema(&["indexed", "plain"], Some(&["indexed"]));
     let mut tbl = TestTable::new(Path::from("lookup"), schema);
-    tbl.insert_row(vec![CellValue::Int(7), CellValue::Int(70)], test_row_id(0));
-    tbl.insert_row(vec![CellValue::Int(8), CellValue::Int(80)], test_row_id(1));
+    tbl.insert_row(vec![WireValue::Int(7), WireValue::Int(70)], test_row_id(0));
+    tbl.insert_row(vec![WireValue::Int(8), WireValue::Int(80)], test_row_id(1));
 
     let index = tbl.table.primary_index().expect("primary-key index");
     assert_eq!(
         tbl.table
-            .index_lookup(index, &[CellValue::Int(7)], &tbl.dict),
+            .index_lookup(index, &[WireValue::Int(7)], &tbl.dict),
         Ok(true)
     );
     assert_eq!(
         tbl.table
-            .index_lookup(index, &[CellValue::Int(9)], &tbl.dict),
+            .index_lookup(index, &[WireValue::Int(9)], &tbl.dict),
         Ok(false)
     );
     assert_eq!(
         tbl.table.lookup(
             &[SeekKey {
                 column: 1,
-                value: CellValue::Int(80),
+                value: WireValue::Int(80),
             }],
             &tbl.dict,
         ),
@@ -718,7 +718,7 @@ fn table_performs_index_lookup() {
         tbl.table.lookup(
             &[SeekKey {
                 column: 1,
-                value: CellValue::Int(90),
+                value: WireValue::Int(90),
             }],
             &tbl.dict,
         ),
@@ -734,7 +734,7 @@ fn table_index_lookup_non_existing_index() {
     let tbl = TestTable::new(Path::from("lookup"), schema);
 
     assert_eq!(
-        tbl.table.index_lookup(99, &[CellValue::Int(7)], &tbl.dict),
+        tbl.table.index_lookup(99, &[WireValue::Int(7)], &tbl.dict),
         Err(ValidationError::InvalidIndex { index: 99 })
     );
 }
@@ -749,7 +749,7 @@ fn table_index_lookup_incorrect_key() {
 
     assert_eq!(
         tbl.table
-            .index_lookup(index, &[CellValue::Int(7), CellValue::Int(8)], &tbl.dict,),
+            .index_lookup(index, &[WireValue::Int(7), WireValue::Int(8)], &tbl.dict,),
         Err(ValidationError::InvalidIndexKey {
             index,
             expected: 1,
@@ -768,14 +768,14 @@ fn table_index_non_index_give_same_results() {
     let mut tbl = TestTable::new(Path::from("lookup"), schema);
     for value in [7, 8] {
         let row_id = test_row_id(tbl.row_count() as u32);
-        tbl.insert_row(vec![CellValue::Int(value), CellValue::Int(value)], row_id);
+        tbl.insert_row(vec![WireValue::Int(value), WireValue::Int(value)], row_id);
     }
     let index = tbl.table.primary_index().expect("primary-key index");
 
     for value in [7, 9] {
         let indexed = tbl
             .table
-            .index_seek(index, &[CellValue::Int(value)], &tbl.dict)
+            .index_seek(index, &[WireValue::Int(value)], &tbl.dict)
             .expect("valid index lookup")
             .collect::<Vec<_>>();
         let scanned = tbl
@@ -783,7 +783,7 @@ fn table_index_non_index_give_same_results() {
             .seek(
                 &[SeekKey {
                     column: 1,
-                    value: CellValue::Int(value),
+                    value: WireValue::Int(value),
                 }],
                 &tbl.dict,
             )
@@ -816,11 +816,11 @@ fn debug_dumps_rows() {
     let mut tbl = TestTable::new(Path::from("debug.table"), schema);
 
     tbl.insert_row(
-        vec![CellValue::Int(7), CellValue::Str("x".to_string())],
+        vec![WireValue::Int(7), WireValue::Str("x".to_string())],
         test_row_id(0),
     );
     tbl.insert_row(
-        vec![CellValue::Int(8), CellValue::Str("y".to_string())],
+        vec![WireValue::Int(8), WireValue::Str("y".to_string())],
         test_row_id(1),
     );
 

--- a/packages/coln-store/src/table/undo.rs
+++ b/packages/coln-store/src/table/undo.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::table::{PackedCell, PackedRowId};
+use crate::table::{PackedValue, PackedRowId};
 
 // Undo operations for each variant in the `Op` enum.
 #[derive(Debug)]
@@ -12,6 +12,6 @@ pub(super) enum UndoOp {
     }, // undo add means delete the row_id
     UndoDelete {
         row_id: PackedRowId,
-        values: Vec<PackedCell>,
+        values: Vec<PackedValue>,
     }, // undo delete means add back the row
 }

--- a/packages/coln-store/src/table/undo.rs
+++ b/packages/coln-store/src/table/undo.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-use crate::table::{PackedValue, PackedRowId};
+use crate::table::{PackedRowId, PackedValue};
 
 // Undo operations for each variant in the `Op` enum.
 #[derive(Debug)]

--- a/packages/coln-store/src/txn/inner.rs
+++ b/packages/coln-store/src/txn/inner.rs
@@ -68,15 +68,15 @@ impl TxnInner {
         Ok(temp_id)
     }
 
-    pub(super) fn add(
+    pub(super) fn add<V: Into<TxnLiveValue>>(
         &mut self,
         store: &Store,
         table: &ir::Path,
-        values: Vec<TxnLiveValue>,
+        values: Vec<V>,
     ) -> Result<TxnLiveRowId, StoreError> {
         let txn_values = values
             .into_iter()
-            .map(|v| v.to_txn_cell_value(self.tx_id))
+            .map(|v| v.into().to_txn_cell_value(self.tx_id))
             .collect::<Result<Vec<TxnWireValue>, _>>()?;
         let temp_id = self.add_cell_values(store, table, txn_values)?;
         let handle = TxnLiveRowId::from_pending(self.tx_id, temp_id.0);

--- a/packages/coln-store/src/txn/inner.rs
+++ b/packages/coln-store/src/txn/inner.rs
@@ -11,7 +11,7 @@ use crate::{
     commit::{Commit, author::Author, hash::CommitHash, wire::CommitData},
     store::{Store, error::StoreError},
     table::ValidationError,
-    txn::{PendingOp, RowHandle, TempRowId, TxnCellValue, TxnId, TxnValue, timestamp::Timestamp},
+    txn::{PendingOp, TxnLiveRowId, TempRowId, TxnWireValue, TxnId, TxnLiveValue, timestamp::Timestamp},
 };
 
 static NEXT_TX_ID: AtomicU64 = AtomicU64::new(1);
@@ -27,7 +27,7 @@ pub(crate) struct TxnInner {
     timestamp: Timestamp,
     message: Option<String>,
     tx_id: TxnId,
-    pending_handles: Vec<RowHandle>,
+    pending_handles: Vec<TxnLiveRowId>,
 }
 
 impl TxnInner {
@@ -51,7 +51,7 @@ impl TxnInner {
         &mut self,
         store: &Store,
         table: &ir::Path,
-        values: Vec<TxnCellValue>,
+        values: Vec<TxnWireValue>,
     ) -> Result<TempRowId, StoreError> {
         let t = store.table_at(table).ok_or(ValidationError::UnknownTable {
             path: table.clone(),
@@ -70,14 +70,14 @@ impl TxnInner {
         &mut self,
         store: &Store,
         table: &ir::Path,
-        values: Vec<TxnValue>,
-    ) -> Result<RowHandle, StoreError> {
+        values: Vec<TxnLiveValue>,
+    ) -> Result<TxnLiveRowId, StoreError> {
         let txn_values = values
             .into_iter()
             .map(|v| v.to_txn_cell_value(self.tx_id))
-            .collect::<Result<Vec<TxnCellValue>, _>>()?;
+            .collect::<Result<Vec<TxnWireValue>, _>>()?;
         let temp_id = self.add_cell_values(store, table, txn_values)?;
-        let handle = RowHandle::from_pending(self.tx_id, temp_id.0);
+        let handle = TxnLiveRowId::from_pending(self.tx_id, temp_id.0);
         self.pending_handles.push(handle.clone());
         Ok(handle)
     }
@@ -88,12 +88,12 @@ impl TxnInner {
         &mut self,
         store: &Store,
         table: &ir::Path,
-        values: Vec<TxnCellValue>,
+        values: Vec<TxnWireValue>,
     ) -> Result<TempRowId, StoreError> {
         self.add_cell_values(store, table, values)
     }
 
-    fn invalidate_handles(pending_handles: Vec<RowHandle>, reason: &str) {
+    fn invalidate_handles(pending_handles: Vec<TxnLiveRowId>, reason: &str) {
         pending_handles
             .into_iter()
             .for_each(|h| h.invalidate(reason));
@@ -102,7 +102,7 @@ impl TxnInner {
     /// Finalize handles to the id the store actually kept: a row that was
     /// deduplicated against an existing class finalizes to that class's
     /// canonical id, not to the never-stored raw id.
-    fn finalize_handles(pending_handles: Vec<RowHandle>, h: CommitHash, store: &Store) {
+    fn finalize_handles(pending_handles: Vec<TxnLiveRowId>, h: CommitHash, store: &Store) {
         pending_handles.into_iter().for_each(|handle| {
             handle.finalize(h, |rid| store.canonical_row_id(rid).unwrap_or(rid))
         });

--- a/packages/coln-store/src/txn/inner.rs
+++ b/packages/coln-store/src/txn/inner.rs
@@ -11,7 +11,9 @@ use crate::{
     commit::{Commit, author::Author, hash::CommitHash, wire::CommitData},
     store::{Store, error::StoreError},
     table::ValidationError,
-    txn::{PendingOp, TxnLiveRowId, TempRowId, TxnWireValue, TxnId, TxnLiveValue, timestamp::Timestamp},
+    txn::{
+        PendingOp, TempRowId, TxnId, TxnLiveRowId, TxnLiveValue, TxnWireValue, timestamp::Timestamp,
+    },
 };
 
 static NEXT_TX_ID: AtomicU64 = AtomicU64::new(1);

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use inner::TxnInner;
-pub(crate) use row_handle::{PendingOp, TxnWireRowId, TempRowId, TxnWireValue};
-pub use row_handle::{TxnLiveRowId, TxnId, TxnLiveValue, liven, liven_all};
+pub(crate) use row_handle::{PendingOp, TempRowId, TxnWireRowId, TxnWireValue};
+pub use row_handle::{TxnId, TxnLiveRowId, TxnLiveValue, liven, liven_all};
 
 pub struct Transaction<'a> {
     inner: TxnInner,
@@ -102,7 +102,7 @@ impl OwnedTransaction {
 mod tests {
     use super::*;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, Schema};
-    use crate::table::{WireValue, ValidationError};
+    use crate::table::{ValidationError, WireValue};
 
     fn table_schema(columns: Vec<ColumnEntry>, primary_key: Option<Vec<Path>>) -> Schema {
         Schema {
@@ -186,7 +186,8 @@ mod tests {
 
         let mut tx = store.transaction();
         let node_temp = tx.add(&nodes, vec![]).expect("add node");
-        tx.add(&edges, vec![TxnLiveValue::Id(node_temp)]).expect("add edge");
+        tx.add(&edges, vec![TxnLiveValue::Id(node_temp)])
+            .expect("add edge");
         let commit = tx.commit().expect("commit");
 
         let node_id = store
@@ -227,7 +228,8 @@ mod tests {
         assert_eq!(node_id.commit, first_commit);
 
         let mut tx = store.transaction();
-        tx.add(&edges, vec![TxnLiveValue::Id(node)]).expect("add edge");
+        tx.add(&edges, vec![TxnLiveValue::Id(node)])
+            .expect("add edge");
         tx.commit().expect("commit edge");
 
         let edge = store.table_at(&edges).expect("Edges");

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -31,8 +31,6 @@ impl<'a> Transaction<'a> {
         }
     }
 
-    // TODO this API is a bit awkward to use, clients have to call .into() all
-    // the time on their values
     pub fn add<V: Into<TxnLiveValue>>(
         &mut self,
         table: &ir::Path,

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use inner::TxnInner;
 pub(crate) use row_handle::{PendingOp, TempRowId, TxnWireRowId, TxnWireValue};
-pub use row_handle::{TxnId, TxnLiveRowId, TxnLiveValue, liven_all};
+pub use row_handle::{TxnId, TxnLiveRowId, TxnLiveValue, empty_row};
 
 pub struct Transaction<'a> {
     inner: TxnInner,
@@ -33,10 +33,10 @@ impl<'a> Transaction<'a> {
 
     // TODO this API is a bit awkward to use, clients have to call .into() all
     // the time on their values
-    pub fn add(
+    pub fn add<V: Into<TxnLiveValue>>(
         &mut self,
         table: &ir::Path,
-        values: Vec<TxnLiveValue>,
+        values: Vec<V>,
     ) -> Result<TxnLiveRowId, StoreError> {
         self.inner.add(self.store, table, values)
     }
@@ -75,10 +75,10 @@ impl OwnedTransaction {
         }
     }
 
-    pub fn add(
+    pub fn add<V: Into<TxnLiveValue>>(
         &mut self,
         table: &ir::Path,
-        values: Vec<TxnLiveValue>,
+        values: Vec<V>,
     ) -> Result<TxnLiveRowId, StoreError> {
         self.inner.add(&self.store, table, values)
     }
@@ -100,9 +100,11 @@ impl OwnedTransaction {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, Schema};
     use crate::table::{ValidationError, WireValue};
+    use crate::txn::row_handle::empty_row;
 
     fn table_schema(columns: Vec<ColumnEntry>, primary_key: Option<Vec<Path>>) -> Schema {
         Schema {
@@ -138,7 +140,7 @@ mod tests {
             .expect("create table");
 
         let mut tx = OwnedTransaction::new(store);
-        tx.add(&path, vec![42_i32.into()]).expect("add");
+        tx.add(&path, vec![42_i32]).expect("add");
 
         let (_hash, committed) = tx.commit().expect("commit");
         assert_eq!(committed.table_at(&path).expect("T").row_count(), 1);
@@ -154,15 +156,13 @@ mod tests {
             .expect("create table");
 
         let mut tx = OwnedTransaction::new(store);
-        let err = tx
-            .add(&Path::from("missing"), vec![1_i32.into()])
-            .unwrap_err();
+        let err = tx.add(&Path::from("missing"), vec![1_i32]).unwrap_err();
         assert!(matches!(
             err,
             StoreError::Validation(ValidationError::UnknownTable { .. })
         ));
 
-        let err = tx.add(&path, vec![1_i32.into(), 2_i32.into()]).unwrap_err();
+        let err = tx.add(&path, vec![1_i32, 2_i32]).unwrap_err();
         assert!(matches!(
             err,
             StoreError::Validation(ValidationError::ColumnCount { .. })
@@ -185,7 +185,7 @@ mod tests {
             .expect("create edges table");
 
         let mut tx = store.transaction();
-        let node_temp = tx.add(&nodes, vec![]).expect("add node");
+        let node_temp = tx.add(&nodes, empty_row()).expect("add node");
         tx.add(&edges, vec![TxnLiveValue::Id(node_temp)])
             .expect("add edge");
         let commit = tx.commit().expect("commit");
@@ -221,7 +221,7 @@ mod tests {
             .expect("create edges table");
 
         let mut tx = store.transaction();
-        let node = tx.add(&nodes, vec![]).expect("add node");
+        let node = tx.add(&nodes, empty_row()).expect("add node");
         let first_commit = tx.commit().expect("commit node");
 
         let node_id = node.row_id().expect("node handle finalized");
@@ -251,7 +251,7 @@ mod tests {
             )
             .expect("create edges table");
         let mut tx = store.transaction();
-        let node = tx.add(&nodes, vec![]).expect("add node");
+        let node = tx.add(&nodes, empty_row()).expect("add node");
         tx.abort();
         let err = node.row_id().expect_err("abort invalidates handle");
         assert!(matches!(
@@ -285,8 +285,9 @@ mod tests {
             .expect("create edges table");
 
         let mut tx = store.transaction();
-        let node = tx.add(&nodes, vec![]).expect("add first node");
-        tx.add(&nodes, vec![]).expect("add duplicate singleton row");
+        let node = tx.add(&nodes, empty_row()).expect("add first node");
+        tx.add(&nodes, empty_row())
+            .expect("add duplicate singleton row");
         let err = tx
             .commit()
             .expect_err("duplicate singleton row should fail");
@@ -326,13 +327,13 @@ mod tests {
         store.set_structural_index_for_test(&term, true);
 
         let mut tx = store.transaction();
-        let first = tx.add(&term, vec![7_i32.into()]).expect("add first term");
+        let first = tx.add(&term, vec![7_i32]).expect("add first term");
         tx.commit().expect("commit first term");
 
         // Structurally equal row: deduplicates into the first row's class.
         // Which id wins the merge depends on the commit hash ordering.
         let mut tx = store.transaction();
-        let second = tx.add(&term, vec![7_i32.into()]).expect("add equal term");
+        let second = tx.add(&term, vec![7_i32]).expect("add equal term");
         tx.commit().expect("commit equal term");
 
         let stored = store
@@ -366,7 +367,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root commit").hash();
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![1i32.into()]).expect("add first row");
+        tx.add(&path, vec![1i32]).expect("add first row");
         let first = tx.commit().expect("first commit");
 
         assert!(store.commits().contains(&first));
@@ -377,7 +378,7 @@ mod tests {
         );
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![2i32.into()]).expect("add second row");
+        tx.add(&path, vec![2i32]).expect("add second row");
         let second = tx.commit().expect("second commit");
 
         assert!(store.commits().contains(&second));

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -15,7 +15,7 @@ use crate::{
 
 use inner::TxnInner;
 pub(crate) use row_handle::{PendingOp, TempRowId, TxnWireRowId, TxnWireValue};
-pub use row_handle::{TxnId, TxnLiveRowId, TxnLiveValue, liven, liven_all};
+pub use row_handle::{TxnId, TxnLiveRowId, TxnLiveValue, liven_all};
 
 pub struct Transaction<'a> {
     inner: TxnInner,
@@ -366,7 +366,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root commit").hash();
 
         let mut tx = store.transaction();
-        tx.add(&path, liven_all(vec![WireValue::Int(1)]))
+        tx.add(&path, vec![1i32.into()])
             .expect("add first row");
         let first = tx.commit().expect("first commit");
 
@@ -378,7 +378,7 @@ mod tests {
         );
 
         let mut tx = store.transaction();
-        tx.add(&path, liven_all(vec![WireValue::Int(2)]))
+        tx.add(&path, vec![2i32.into()])
             .expect("add second row");
         let second = tx.commit().expect("second commit");
 

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -14,8 +14,8 @@ use crate::{
 };
 
 use inner::TxnInner;
-pub(crate) use row_handle::{PendingOp, RowRef, TempRowId, TxnCellValue};
-pub use row_handle::{RowHandle, TxnId, TxnValue};
+pub(crate) use row_handle::{PendingOp, TxnWireRowId, TempRowId, TxnWireValue};
+pub use row_handle::{TxnLiveRowId, TxnId, TxnLiveValue, liven, liven_all};
 
 pub struct Transaction<'a> {
     inner: TxnInner,
@@ -36,8 +36,8 @@ impl<'a> Transaction<'a> {
     pub fn add(
         &mut self,
         table: &ir::Path,
-        values: Vec<TxnValue>,
-    ) -> Result<RowHandle, StoreError> {
+        values: Vec<TxnLiveValue>,
+    ) -> Result<TxnLiveRowId, StoreError> {
         self.inner.add(self.store, table, values)
     }
 
@@ -46,7 +46,7 @@ impl<'a> Transaction<'a> {
     pub(crate) fn add_internal(
         &mut self,
         table: &ir::Path,
-        values: Vec<TxnCellValue>,
+        values: Vec<TxnWireValue>,
     ) -> Result<TempRowId, StoreError> {
         self.inner.add_internal(self.store, table, values)
     }
@@ -78,8 +78,8 @@ impl OwnedTransaction {
     pub fn add(
         &mut self,
         table: &ir::Path,
-        values: Vec<TxnValue>,
-    ) -> Result<RowHandle, StoreError> {
+        values: Vec<TxnLiveValue>,
+    ) -> Result<TxnLiveRowId, StoreError> {
         self.inner.add(&self.store, table, values)
     }
 
@@ -102,7 +102,7 @@ impl OwnedTransaction {
 mod tests {
     use super::*;
     use crate::ir::{BuiltinTy, ColType, ColumnEntry, EntityVariant, Path, Schema};
-    use crate::table::{CellValue, ValidationError};
+    use crate::table::{WireValue, ValidationError};
 
     fn table_schema(columns: Vec<ColumnEntry>, primary_key: Option<Vec<Path>>) -> Schema {
         Schema {
@@ -138,7 +138,7 @@ mod tests {
             .expect("create table");
 
         let mut tx = OwnedTransaction::new(store);
-        tx.add(&path, vec![42_i64.into()]).expect("add");
+        tx.add(&path, vec![42_i32.into()]).expect("add");
 
         let (_hash, committed) = tx.commit().expect("commit");
         assert_eq!(committed.table_at(&path).expect("T").row_count(), 1);
@@ -155,14 +155,14 @@ mod tests {
 
         let mut tx = OwnedTransaction::new(store);
         let err = tx
-            .add(&Path::from("missing"), vec![1_i64.into()])
+            .add(&Path::from("missing"), vec![1_i32.into()])
             .unwrap_err();
         assert!(matches!(
             err,
             StoreError::Validation(ValidationError::UnknownTable { .. })
         ));
 
-        let err = tx.add(&path, vec![1_i64.into(), 2_i64.into()]).unwrap_err();
+        let err = tx.add(&path, vec![1_i32.into(), 2_i32.into()]).unwrap_err();
         assert!(matches!(
             err,
             StoreError::Validation(ValidationError::ColumnCount { .. })
@@ -186,7 +186,7 @@ mod tests {
 
         let mut tx = store.transaction();
         let node_temp = tx.add(&nodes, vec![]).expect("add node");
-        tx.add(&edges, vec![node_temp.into()]).expect("add edge");
+        tx.add(&edges, vec![TxnLiveValue::Id(node_temp)]).expect("add edge");
         let commit = tx.commit().expect("commit");
 
         let node_id = store
@@ -201,7 +201,7 @@ mod tests {
         assert_eq!(node_id.counter, 0);
         assert_eq!(edge_id.commit, commit);
         assert_eq!(edge_id.counter, 1);
-        assert_eq!(edge.cell_at(0, 0), Some(CellValue::Id(node_id)));
+        assert_eq!(edge.cell_at(0, 0), Some(WireValue::Id(node_id)));
     }
 
     #[test]
@@ -227,11 +227,11 @@ mod tests {
         assert_eq!(node_id.commit, first_commit);
 
         let mut tx = store.transaction();
-        tx.add(&edges, vec![node.into()]).expect("add edge");
+        tx.add(&edges, vec![TxnLiveValue::Id(node)]).expect("add edge");
         tx.commit().expect("commit edge");
 
         let edge = store.table_at(&edges).expect("Edges");
-        assert_eq!(edge.cell_at(0, 0), Some(CellValue::Id(node_id)));
+        assert_eq!(edge.cell_at(0, 0), Some(WireValue::Id(node_id)));
     }
 
     #[test]
@@ -254,15 +254,15 @@ mod tests {
         let err = node.row_id().expect_err("abort invalidates handle");
         assert!(matches!(
             err,
-            StoreError::Validation(ValidationError::InvalidRowHandle { .. })
+            StoreError::Validation(ValidationError::InvalidTxnLiveRowId { .. })
         ));
         let mut tx = store.transaction();
         let err = tx
-            .add(&edges, vec![node.into()])
+            .add(&edges, vec![TxnLiveValue::Id(node)])
             .expect_err("aborted handle cannot be reused");
         assert!(matches!(
             err,
-            StoreError::Validation(ValidationError::InvalidRowHandle { .. })
+            StoreError::Validation(ValidationError::InvalidTxnLiveRowId { .. })
         ));
         assert_eq!(store.table_at(&nodes).expect("Nodes").row_count(), 0);
     }
@@ -296,16 +296,16 @@ mod tests {
         let err = node.row_id().expect_err("failed commit invalidates handle");
         assert!(matches!(
             err,
-            StoreError::Validation(ValidationError::InvalidRowHandle { .. })
+            StoreError::Validation(ValidationError::InvalidTxnLiveRowId { .. })
         ));
 
         let mut tx = store.transaction();
         let err = tx
-            .add(&edges, vec![node.into()])
+            .add(&edges, vec![TxnLiveValue::Id(node)])
             .expect_err("invalid handle cannot be reused");
         assert!(matches!(
             err,
-            StoreError::Validation(ValidationError::InvalidRowHandle { .. })
+            StoreError::Validation(ValidationError::InvalidTxnLiveRowId { .. })
         ));
     }
 
@@ -324,13 +324,13 @@ mod tests {
         store.set_structural_index_for_test(&term, true);
 
         let mut tx = store.transaction();
-        let first = tx.add(&term, vec![7_i64.into()]).expect("add first term");
+        let first = tx.add(&term, vec![7_i32.into()]).expect("add first term");
         tx.commit().expect("commit first term");
 
         // Structurally equal row: deduplicates into the first row's class.
         // Which id wins the merge depends on the commit hash ordering.
         let mut tx = store.transaction();
-        let second = tx.add(&term, vec![7_i64.into()]).expect("add equal term");
+        let second = tx.add(&term, vec![7_i32.into()]).expect("add equal term");
         tx.commit().expect("commit equal term");
 
         let stored = store
@@ -364,7 +364,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root commit").hash();
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![CellValue::Int(1).into()])
+        tx.add(&path, liven_all(vec![WireValue::Int(1)]))
             .expect("add first row");
         let first = tx.commit().expect("first commit");
 
@@ -376,7 +376,7 @@ mod tests {
         );
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![CellValue::Int(2).into()])
+        tx.add(&path, liven_all(vec![WireValue::Int(2).into()]))
             .expect("add second row");
         let second = tx.commit().expect("second commit");
 

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -366,8 +366,7 @@ mod tests {
         let root = store.commits().root_commit().expect("root commit").hash();
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![1i32.into()])
-            .expect("add first row");
+        tx.add(&path, vec![1i32.into()]).expect("add first row");
         let first = tx.commit().expect("first commit");
 
         assert!(store.commits().contains(&first));
@@ -378,8 +377,7 @@ mod tests {
         );
 
         let mut tx = store.transaction();
-        tx.add(&path, vec![2i32.into()])
-            .expect("add second row");
+        tx.add(&path, vec![2i32.into()]).expect("add second row");
         let second = tx.commit().expect("second commit");
 
         assert!(store.commits().contains(&second));

--- a/packages/coln-store/src/txn/mod.rs
+++ b/packages/coln-store/src/txn/mod.rs
@@ -378,7 +378,7 @@ mod tests {
         );
 
         let mut tx = store.transaction();
-        tx.add(&path, liven_all(vec![WireValue::Int(2).into()]))
+        tx.add(&path, liven_all(vec![WireValue::Int(2)]))
             .expect("add second row");
         let second = tx.commit().expect("second commit");
 

--- a/packages/coln-store/src/txn/row_handle.rs
+++ b/packages/coln-store/src/txn/row_handle.rs
@@ -47,9 +47,9 @@ pub struct TxnLiveRowId {
     state: Rc<RefCell<TxnLiveRowIdState>>,
 }
 
-impl Into<TxnLiveValue> for TxnLiveRowId {
-    fn into(self) -> TxnLiveValue {
-        TxnLiveValue::Id(self)
+impl From<TxnLiveRowId> for TxnLiveValue {
+    fn from(i: TxnLiveRowId) -> TxnLiveValue {
+        TxnLiveValue::Id(i)
     }
 }
 

--- a/packages/coln-store/src/txn/row_handle.rs
+++ b/packages/coln-store/src/txn/row_handle.rs
@@ -8,7 +8,8 @@ use crate::{
     commit::hash::CommitHash,
     op::Op,
     store::error::StoreError,
-    table::{CellValue, RowId, TableOid, ValidationError},
+    table::{WireValue, WireRowId, TableOid, ValidationError},
+    value::Value
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -31,30 +32,36 @@ impl From<u64> for TxnId {
 }
 
 #[derive(Clone, Debug)]
-enum RowHandleState {
+enum TxnLiveRowIdState {
     Pending { tx_id: TxnId, counter: u32 },
-    Existing(RowId),
+    Existing(WireRowId),
     Invalid(String),
 }
 
-/// A RowHandle abstracts away the difference between a pending id and an existing
+/// A TxnLiveRowId abstracts away the difference between a pending id and an existing
 /// rowid. It is a reference counted handle that can be shared and will be automatically
 /// converted from a temp rowid to a rowid on successful commit.
 #[derive(Clone, Debug)]
-pub struct RowHandle {
+pub struct TxnLiveRowId {
     // ? Arc
-    state: Rc<RefCell<RowHandleState>>,
+    state: Rc<RefCell<TxnLiveRowIdState>>,
 }
 
-impl RowHandle {
-    pub fn row_id(&self) -> Result<RowId, StoreError> {
+impl Into<TxnLiveValue> for TxnLiveRowId {
+    fn into(self) -> TxnLiveValue {
+        TxnLiveValue::Id(self)
+    }
+}
+
+impl TxnLiveRowId {
+    pub fn row_id(&self) -> Result<WireRowId, StoreError> {
         match &*self.state.borrow() {
-            RowHandleState::Existing(row_id) => Ok(*row_id),
-            RowHandleState::Pending { .. } => Err(ValidationError::InvalidRowHandle {
+            TxnLiveRowIdState::Existing(row_id) => Ok(*row_id),
+            TxnLiveRowIdState::Pending { .. } => Err(ValidationError::InvalidTxnLiveRowId {
                 reason: "row handle is still pending".to_string(),
             }
             .into()),
-            RowHandleState::Invalid(reason) => Err(ValidationError::InvalidRowHandle {
+            TxnLiveRowIdState::Invalid(reason) => Err(ValidationError::InvalidTxnLiveRowId {
                 reason: reason.clone(),
             }
             .into()),
@@ -65,125 +72,89 @@ impl RowHandle {
     #[doc(hidden)]
     pub fn pending_ids(&self) -> Result<(u64, u32), StoreError> {
         match *self.state.borrow() {
-            RowHandleState::Pending { tx_id, counter } => Ok((tx_id.as_u64(), counter)),
-            _ => Err(ValidationError::InvalidRowHandle {
+            TxnLiveRowIdState::Pending { tx_id, counter } => Ok((tx_id.as_u64(), counter)),
+            _ => Err(ValidationError::InvalidTxnLiveRowId {
                 reason: "not txn id on existing ids or invalid handles".to_string(),
             }
             .into()),
         }
     }
 
-    pub(crate) fn canonicalise(&self, new_row_id: RowId) -> Result<(), StoreError> {
+    pub(crate) fn canonicalise(&self, new_row_id: WireRowId) -> Result<(), StoreError> {
         let mut state = self.state.borrow_mut();
         match &*state {
-            RowHandleState::Existing(..) => {
-                *state = RowHandleState::Existing(new_row_id);
+            TxnLiveRowIdState::Existing(..) => {
+                *state = TxnLiveRowIdState::Existing(new_row_id);
                 Ok(())
             }
-            _ => Err(ValidationError::InvalidRowHandle {
+            _ => Err(ValidationError::InvalidTxnLiveRowId {
                 reason: "cannot replace row id on a non finalised rowhandle".to_string(),
             }
             .into()),
         }
     }
 
-    pub(crate) fn to_txn_cell_value(&self, current_tx: TxnId) -> Result<TxnCellValue, StoreError> {
+    pub(crate) fn to_txn_cell_value(&self, current_tx: TxnId) -> Result<TxnWireValue, StoreError> {
         match &*self.state.borrow() {
-            RowHandleState::Existing(row_id) => Ok(TxnCellValue::Id(RowRef::Existing(*row_id))),
-            RowHandleState::Pending { tx_id, counter } if *tx_id == current_tx => {
-                Ok(TxnCellValue::Id(RowRef::Pending(TempRowId::from(*counter))))
+            TxnLiveRowIdState::Existing(row_id) => Ok(TxnWireValue::Id(TxnWireRowId::Existing(*row_id))),
+            TxnLiveRowIdState::Pending { tx_id, counter } if *tx_id == current_tx => {
+                Ok(TxnWireValue::Id(TxnWireRowId::Pending(TempRowId::from(*counter))))
             }
-            RowHandleState::Pending { tx_id, .. } => Err(ValidationError::TxnIdMismatch {
+            TxnLiveRowIdState::Pending { tx_id, .. } => Err(ValidationError::TxnIdMismatch {
                 current: current_tx,
                 got: *tx_id,
             }
             .into()),
-            RowHandleState::Invalid(reason) => Err(ValidationError::InvalidRowHandle {
+            TxnLiveRowIdState::Invalid(reason) => Err(ValidationError::InvalidTxnLiveRowId {
                 reason: reason.clone(),
             }
             .into()),
         }
     }
 
-    pub(crate) fn finalize(&self, commit: CommitHash, resolve: impl Fn(RowId) -> RowId) {
+    pub(crate) fn finalize(&self, commit: CommitHash, resolve: impl Fn(WireRowId) -> WireRowId) {
         let mut state = self.state.borrow_mut();
-        if let RowHandleState::Pending { counter, .. } = *state {
-            *state = RowHandleState::Existing(resolve(RowId { commit, counter }));
+        if let TxnLiveRowIdState::Pending { counter, .. } = *state {
+            *state = TxnLiveRowIdState::Existing(resolve(WireRowId { commit, counter }));
         }
     }
 
     pub(crate) fn invalidate(&self, reason: &str) {
-        *self.state.borrow_mut() = RowHandleState::Invalid(reason.into());
+        *self.state.borrow_mut() = TxnLiveRowIdState::Invalid(reason.into());
     }
 
     #[doc(hidden)]
     pub fn from_pending(tx_id: TxnId, counter: u32) -> Self {
-        let state = Rc::new(RefCell::new(RowHandleState::Pending { tx_id, counter }));
-        RowHandle { state }
+        let state = Rc::new(RefCell::new(TxnLiveRowIdState::Pending { tx_id, counter }));
+        TxnLiveRowId { state }
     }
 
     #[doc(hidden)]
-    pub fn from_existing(row_id: RowId) -> Self {
-        let state = Rc::new(RefCell::new(RowHandleState::Existing(row_id)));
-        RowHandle { state }
+    pub fn from_existing(row_id: WireRowId) -> Self {
+        let state = Rc::new(RefCell::new(TxnLiveRowIdState::Existing(row_id)));
+        TxnLiveRowId { state }
     }
 }
 
-#[derive(Clone)]
-pub enum TxnValue {
-    Id(RowHandle),
-    Int(i64),
-    Str(String),
-}
 
-impl TxnValue {
-    pub(crate) fn to_txn_cell_value(&self, current_tx: TxnId) -> Result<TxnCellValue, StoreError> {
+pub type TxnLiveValue = Value<TxnLiveRowId>;
+
+impl TxnLiveValue {
+    pub(crate) fn to_txn_cell_value(&self, current_tx: TxnId) -> Result<TxnWireValue, StoreError> {
         match self {
-            TxnValue::Id(handle) => handle.to_txn_cell_value(current_tx),
-            TxnValue::Int(value) => Ok(TxnCellValue::Int(*value)),
-            TxnValue::Str(value) => Ok(TxnCellValue::Str(value.clone())),
+            TxnLiveValue::Id(handle) => handle.to_txn_cell_value(current_tx),
+            TxnLiveValue::Int(value) => Ok(TxnWireValue::Int(*value)),
+            TxnLiveValue::Str(value) => Ok(TxnWireValue::Str(value.clone())),
         }
     }
 }
 
-impl From<RowHandle> for TxnValue {
-    fn from(value: RowHandle) -> Self {
-        TxnValue::Id(value)
-    }
+pub fn liven(v: WireValue) -> TxnLiveValue {
+    v.map_owned(TxnLiveRowId::from_existing)
 }
 
-impl From<RowId> for TxnValue {
-    fn from(value: RowId) -> Self {
-        TxnValue::Id(RowHandle::from_existing(value))
-    }
-}
-
-impl From<i64> for TxnValue {
-    fn from(value: i64) -> Self {
-        TxnValue::Int(value)
-    }
-}
-
-impl From<String> for TxnValue {
-    fn from(value: String) -> Self {
-        TxnValue::Str(value)
-    }
-}
-
-impl From<&str> for TxnValue {
-    fn from(value: &str) -> Self {
-        TxnValue::Str(value.to_owned())
-    }
-}
-
-impl From<CellValue> for TxnValue {
-    fn from(value: CellValue) -> Self {
-        match value {
-            CellValue::Id(id) => TxnValue::Id(RowHandle::from_existing(id)),
-            CellValue::Int(value) => TxnValue::Int(value),
-            CellValue::Str(value) => TxnValue::Str(value),
-        }
-    }
+pub fn liven_all(vs: Vec<WireValue>) -> Vec<TxnLiveValue> {
+    vs.into_iter().map(liven).collect()
 }
 
 /// A temporary row ID that is valid only within a transaction.
@@ -191,8 +162,8 @@ impl From<CellValue> for TxnValue {
 pub(crate) struct TempRowId(pub(crate) u32);
 
 impl TempRowId {
-    pub(crate) fn resolve(self, commit: CommitHash) -> RowId {
-        RowId {
+    pub(crate) fn resolve(self, commit: CommitHash) -> WireRowId {
+        WireRowId {
             commit,
             counter: self.0,
         }
@@ -211,96 +182,34 @@ impl From<u32> for TempRowId {
 
 /// A reference to an existing row or a pending row in the current transaction.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
-pub(crate) enum RowRef {
-    Existing(RowId),
+pub(crate) enum TxnWireRowId {
+    Existing(WireRowId),
     Pending(TempRowId),
 }
 
-impl RowRef {
-    fn resolve(&self, commit: CommitHash) -> RowId {
+impl TxnWireRowId {
+    fn resolve(&self, commit: CommitHash) -> WireRowId {
         match self {
-            RowRef::Existing(row_id) => *row_id,
-            RowRef::Pending(temp_id) => temp_id.resolve(commit),
+            TxnWireRowId::Existing(row_id) => *row_id,
+            TxnWireRowId::Pending(temp_id) => temp_id.resolve(commit),
         }
     }
 }
 
-impl From<RowId> for RowRef {
-    fn from(value: RowId) -> Self {
-        RowRef::Existing(value)
+impl From<WireRowId> for TxnWireRowId {
+    fn from(value: WireRowId) -> Self {
+        TxnWireRowId::Existing(value)
     }
 }
 
-impl From<TempRowId> for RowRef {
+impl From<TempRowId> for TxnWireRowId {
     fn from(value: TempRowId) -> Self {
-        RowRef::Pending(value)
+        TxnWireRowId::Pending(value)
     }
 }
 
-// TODO should clean this up, who uses txncellvalue and it should have a better name
-/// The internal transaction representation derived from `TxnValue`.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub(crate) enum TxnCellValue {
-    Id(RowRef),
-    Int(i64),
-    Str(String),
-}
 
-impl TxnCellValue {
-    fn resolve(&self, commit: CommitHash) -> CellValue {
-        match self {
-            TxnCellValue::Id(row_ref) => CellValue::Id(row_ref.resolve(commit)),
-            TxnCellValue::Int(value) => CellValue::Int(*value),
-            TxnCellValue::Str(value) => CellValue::Str(value.clone()),
-        }
-    }
-}
-
-impl From<RowRef> for TxnCellValue {
-    fn from(value: RowRef) -> Self {
-        TxnCellValue::Id(value)
-    }
-}
-
-impl From<RowId> for TxnCellValue {
-    fn from(value: RowId) -> Self {
-        TxnCellValue::Id(RowRef::Existing(value))
-    }
-}
-
-impl From<TempRowId> for TxnCellValue {
-    fn from(value: TempRowId) -> Self {
-        TxnCellValue::Id(RowRef::Pending(value))
-    }
-}
-
-impl From<i64> for TxnCellValue {
-    fn from(value: i64) -> Self {
-        TxnCellValue::Int(value)
-    }
-}
-
-impl From<String> for TxnCellValue {
-    fn from(value: String) -> Self {
-        TxnCellValue::Str(value)
-    }
-}
-
-impl From<&str> for TxnCellValue {
-    fn from(value: &str) -> Self {
-        TxnCellValue::Str(value.to_owned())
-    }
-}
-
-impl From<CellValue> for TxnCellValue {
-    fn from(value: CellValue) -> Self {
-        match value {
-            CellValue::Id(id) => TxnCellValue::Id(RowRef::Existing(id)),
-            CellValue::Int(value) => TxnCellValue::Int(value),
-            CellValue::Str(value) => TxnCellValue::Str(value),
-        }
-    }
-}
+pub type TxnWireValue = Value<TxnWireRowId>;
 
 /// An operation staged within a transaction.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -308,7 +217,7 @@ pub(crate) enum PendingOp {
     Add {
         row_id: TempRowId,
         table: TableOid,
-        values: Vec<TxnCellValue>,
+        values: Vec<TxnWireValue>,
     },
 }
 
@@ -322,7 +231,7 @@ impl PendingOp {
             } => Op::Add {
                 row_id: row_id.resolve(commit),
                 table: *table,
-                values: values.iter().map(|value| value.resolve(commit)).collect(),
+                values: values.iter().map(|value| value.map(|i| i.resolve(commit))).collect(),
             },
         }
     }

--- a/packages/coln-store/src/txn/row_handle.rs
+++ b/packages/coln-store/src/txn/row_handle.rs
@@ -150,12 +150,14 @@ impl TxnLiveValue {
     }
 }
 
-pub fn liven(v: WireValue) -> TxnLiveValue {
-    v.map_owned(TxnLiveRowId::from_existing)
+impl From<WireValue> for TxnLiveValue {
+    fn from(value: WireValue) -> Self {
+        value.map_owned(TxnLiveRowId::from_existing)
+    }
 }
 
-pub fn liven_all(vs: Vec<WireValue>) -> Vec<TxnLiveValue> {
-    vs.into_iter().map(liven).collect()
+pub fn empty_row() -> Vec<TxnLiveValue> {
+    Vec::new()
 }
 
 /// A temporary row ID that is valid only within a transaction.

--- a/packages/coln-store/src/txn/row_handle.rs
+++ b/packages/coln-store/src/txn/row_handle.rs
@@ -8,8 +8,8 @@ use crate::{
     commit::hash::CommitHash,
     op::Op,
     store::error::StoreError,
-    table::{WireValue, WireRowId, TableOid, ValidationError},
-    value::Value
+    table::{TableOid, ValidationError, WireRowId, WireValue},
+    value::Value,
 };
 
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
@@ -96,10 +96,12 @@ impl TxnLiveRowId {
 
     pub(crate) fn to_txn_cell_value(&self, current_tx: TxnId) -> Result<TxnWireValue, StoreError> {
         match &*self.state.borrow() {
-            TxnLiveRowIdState::Existing(row_id) => Ok(TxnWireValue::Id(TxnWireRowId::Existing(*row_id))),
-            TxnLiveRowIdState::Pending { tx_id, counter } if *tx_id == current_tx => {
-                Ok(TxnWireValue::Id(TxnWireRowId::Pending(TempRowId::from(*counter))))
+            TxnLiveRowIdState::Existing(row_id) => {
+                Ok(TxnWireValue::Id(TxnWireRowId::Existing(*row_id)))
             }
+            TxnLiveRowIdState::Pending { tx_id, counter } if *tx_id == current_tx => Ok(
+                TxnWireValue::Id(TxnWireRowId::Pending(TempRowId::from(*counter))),
+            ),
             TxnLiveRowIdState::Pending { tx_id, .. } => Err(ValidationError::TxnIdMismatch {
                 current: current_tx,
                 got: *tx_id,
@@ -135,7 +137,6 @@ impl TxnLiveRowId {
         TxnLiveRowId { state }
     }
 }
-
 
 pub type TxnLiveValue = Value<TxnLiveRowId>;
 
@@ -208,7 +209,6 @@ impl From<TempRowId> for TxnWireRowId {
     }
 }
 
-
 pub type TxnWireValue = Value<TxnWireRowId>;
 
 /// An operation staged within a transaction.
@@ -231,7 +231,10 @@ impl PendingOp {
             } => Op::Add {
                 row_id: row_id.resolve(commit),
                 table: *table,
-                values: values.iter().map(|value| value.map(|i| i.resolve(commit))).collect(),
+                values: values
+                    .iter()
+                    .map(|value| value.map(|i| i.resolve(commit)))
+                    .collect(),
             },
         }
     }

--- a/packages/coln-store/src/value.rs
+++ b/packages/coln-store/src/value.rs
@@ -2,7 +2,7 @@
 pub enum Value<I> {
     Id(I),
     Int(i32),
-    Str(String)
+    Str(String),
 }
 
 impl<I> Value<I> {
@@ -10,7 +10,7 @@ impl<I> Value<I> {
         match self {
             Value::Id(i) => Value::Id(f(i)),
             Value::Int(i) => Value::Int(*i),
-            Value::Str(s) => Value::Str(s.clone())
+            Value::Str(s) => Value::Str(s.clone()),
         }
     }
 
@@ -18,7 +18,7 @@ impl<I> Value<I> {
         match self {
             Value::Id(i) => Value::Id(f(i)),
             Value::Int(i) => Value::Int(i),
-            Value::Str(s) => Value::Str(s)
+            Value::Str(s) => Value::Str(s),
         }
     }
 }

--- a/packages/coln-store/src/value.rs
+++ b/packages/coln-store/src/value.rs
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
 #[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
 pub enum Value<I> {
     Id(I),

--- a/packages/coln-store/src/value.rs
+++ b/packages/coln-store/src/value.rs
@@ -1,0 +1,42 @@
+#[derive(Clone, Debug, Eq, PartialEq, Hash, PartialOrd, Ord)]
+pub enum Value<I> {
+    Id(I),
+    Int(i32),
+    Str(String)
+}
+
+impl<I> Value<I> {
+    pub fn map<J, F: Fn(&I) -> J>(&self, f: F) -> Value<J> {
+        match self {
+            Value::Id(i) => Value::Id(f(i)),
+            Value::Int(i) => Value::Int(*i),
+            Value::Str(s) => Value::Str(s.clone())
+        }
+    }
+
+    pub fn map_owned<J, F: Fn(I) -> J>(self, f: F) -> Value<J> {
+        match self {
+            Value::Id(i) => Value::Id(f(i)),
+            Value::Int(i) => Value::Int(i),
+            Value::Str(s) => Value::Str(s)
+        }
+    }
+}
+
+impl<I> From<i32> for Value<I> {
+    fn from(value: i32) -> Self {
+        Value::Int(value)
+    }
+}
+
+impl<I> From<String> for Value<I> {
+    fn from(value: String) -> Self {
+        Value::Str(value)
+    }
+}
+
+impl<I> From<&str> for Value<I> {
+    fn from(value: &str) -> Self {
+        Value::Str(value.into())
+    }
+}

--- a/packages/coln-store/tests/test_path.rs
+++ b/packages/coln-store/tests/test_path.rs
@@ -9,7 +9,7 @@ use coln_store::{
     commit::{hash::CommitHash, pst},
     store::{Store, error::StoreError},
     table::{WireRowId, WireValue},
-    txn::liven_all,
+    txn::empty_row,
     value::Value,
 };
 use tracing_subscriber::EnvFilter;
@@ -49,13 +49,13 @@ fn add_basic_data_to_path(store: &mut Store) -> Result<(), StoreError> {
     let ge = Path::from("Path.G.E");
 
     let mut tx = store.transaction();
-    let gid1 = tx.add(&graphs, vec![])?;
-    let gid2 = tx.add(&graphs, vec![])?;
-    tx.add(&g0, vec![gid2.clone().into()])?;
-    tx.add(&g1, vec![gid2.clone().into()])?;
-    let v1 = tx.add(&gv, vec![gid1.clone().into()])?;
-    let v2 = tx.add(&gv, vec![gid1.clone().into()])?;
-    tx.add(&ge, vec![gid1.into(), v1.into(), v2.into()])?;
+    let gid1 = tx.add(&graphs, empty_row())?;
+    let gid2 = tx.add(&graphs, empty_row())?;
+    tx.add(&g0, vec![gid2.clone()])?;
+    tx.add(&g1, vec![gid2.clone()])?;
+    let v1 = tx.add(&gv, vec![gid1.clone()])?;
+    let v2 = tx.add(&gv, vec![gid1.clone()])?;
+    tx.add(&ge, vec![gid1, v1, v2])?;
     tx.commit()?;
 
     Ok(())
@@ -73,7 +73,7 @@ fn add_vertex_to_graph(store: &mut Store, graph_row: usize) -> Result<CommitHash
     );
 
     let mut tx = store.transaction();
-    tx.add(&gv, liven_all(vec![graph]))?;
+    tx.add(&gv, vec![graph])?;
     tx.commit()
 }
 
@@ -94,7 +94,7 @@ fn add_extra_edge_to_first_graph(store: &mut Store) -> Result<CommitHash, StoreE
     );
 
     let mut txn = store.transaction();
-    txn.add(&ge, liven_all(vec![graph, v1, v2]))?;
+    txn.add(&ge, vec![graph, v1, v2])?;
     txn.commit()
 }
 
@@ -233,7 +233,7 @@ fn test_missing_graph_witness_rejects_batch_without_mutation() {
     assert_eq!(g1.row_count(), 0);
 
     let mut tx = store.transaction();
-    tx.add(&Path::from("Path.Graphs"), vec![])
+    tx.add(&Path::from("Path.Graphs"), empty_row())
         .expect("add graph row");
     let err = tx.commit().expect_err("missing g0 and g1");
     assert!(matches!(err, StoreError::Rule(_)));
@@ -285,8 +285,7 @@ fn test_fk() {
         counter: u32::MAX,
     });
     let mut tx = store.transaction();
-    tx.add(&ge, liven_all(vec![gid, vid, dummy_vid]))
-        .expect("add edge");
+    tx.add(&ge, vec![gid, vid, dummy_vid]).expect("add edge");
     let err = tx.commit().expect_err("missing v2");
 
     assert!(matches!(err, StoreError::Rule(_)));
@@ -325,7 +324,7 @@ fn test_divergent_commits_merge_between_stores() {
     // make two commits different
     {
         let mut tx = base.transaction();
-        tx.add(&Path::from("Path.Graphs"), vec![])
+        tx.add(&Path::from("Path.Graphs"), empty_row())
             .expect("add a graph");
         tx.commit().expect("commit second graph");
     }

--- a/packages/coln-store/tests/test_path.rs
+++ b/packages/coln-store/tests/test_path.rs
@@ -8,7 +8,9 @@ use coln_flir_rs::ir::{self, FlatRealm, Path};
 use coln_store::{
     commit::{hash::CommitHash, pst},
     store::{Store, error::StoreError},
-    table::{WireRowId, WireValue}, txn::liven_all, value::Value,
+    table::{WireRowId, WireValue},
+    txn::liven_all,
+    value::Value,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -62,11 +64,13 @@ fn add_basic_data_to_path(store: &mut Store) -> Result<(), StoreError> {
 fn add_vertex_to_graph(store: &mut Store, graph_row: usize) -> Result<CommitHash, StoreError> {
     let graphs = Path::from("Path.Graphs");
     let gv = Path::from("Path.G.V");
-    let graph = Value::Id(store
-        .table_at(&graphs)
-        .expect("Path.Graphs table")
-        .row_id_at(graph_row)
-        .expect("graph row"));
+    let graph = Value::Id(
+        store
+            .table_at(&graphs)
+            .expect("Path.Graphs table")
+            .row_id_at(graph_row)
+            .expect("graph row"),
+    );
 
     let mut tx = store.transaction();
     tx.add(&gv, liven_all(vec![graph]))?;
@@ -81,11 +85,13 @@ fn add_extra_edge_to_first_graph(store: &mut Store) -> Result<CommitHash, StoreE
     let tv = store.table_at(&gv).expect("Path.G.V table");
     let v1 = Value::Id(tv.row_id_at(0).expect("vertex 1"));
     let v2 = Value::Id(tv.row_id_at(1).expect("vertex 2"));
-    let graph = Value::Id(store
-        .table_at(&graphs)
-        .expect("Path.Graphs table")
-        .row_id_at(0)
-        .expect("first graph row"));
+    let graph = Value::Id(
+        store
+            .table_at(&graphs)
+            .expect("Path.Graphs table")
+            .row_id_at(0)
+            .expect("first graph row"),
+    );
 
     let mut txn = store.transaction();
     txn.add(&ge, liven_all(vec![graph, v1, v2]))?;
@@ -259,16 +265,20 @@ fn test_fk() {
     let ge = Path::from("Path.G.E");
 
     add_basic_data_to_path(&mut store).expect("add valid baseline data");
-    let gid = Value::Id(store
-        .table_at(&graphs)
-        .expect("Path.Graphs table")
-        .row_id_at(0)
-        .expect("graph row"));
-    let vid = Value::Id(store
-        .table_at(&gv)
-        .expect("Path.G.V table")
-        .row_id_at(0)
-        .expect("vertex row"));
+    let gid = Value::Id(
+        store
+            .table_at(&graphs)
+            .expect("Path.Graphs table")
+            .row_id_at(0)
+            .expect("graph row"),
+    );
+    let vid = Value::Id(
+        store
+            .table_at(&gv)
+            .expect("Path.G.V table")
+            .row_id_at(0)
+            .expect("vertex row"),
+    );
 
     let dummy_vid = Value::Id(WireRowId {
         commit: CommitHash([0xff; 32]),

--- a/packages/coln-store/tests/test_path.rs
+++ b/packages/coln-store/tests/test_path.rs
@@ -6,10 +6,9 @@ use std::{collections::BTreeSet, path::PathBuf, sync::Once};
 
 use coln_flir_rs::ir::{self, FlatRealm, Path};
 use coln_store::{
-    commit::hash::CommitHash,
-    commit::pst,
+    commit::{hash::CommitHash, pst},
     store::{Store, error::StoreError},
-    table::{CellValue, RowId},
+    table::{WireRowId, WireValue}, txn::liven_all, value::Value,
 };
 use tracing_subscriber::EnvFilter;
 
@@ -63,14 +62,14 @@ fn add_basic_data_to_path(store: &mut Store) -> Result<(), StoreError> {
 fn add_vertex_to_graph(store: &mut Store, graph_row: usize) -> Result<CommitHash, StoreError> {
     let graphs = Path::from("Path.Graphs");
     let gv = Path::from("Path.G.V");
-    let graph = store
+    let graph = Value::Id(store
         .table_at(&graphs)
         .expect("Path.Graphs table")
         .row_id_at(graph_row)
-        .expect("graph row");
+        .expect("graph row"));
 
     let mut tx = store.transaction();
-    tx.add(&gv, vec![graph.into()])?;
+    tx.add(&gv, liven_all(vec![graph]))?;
     tx.commit()
 }
 
@@ -80,16 +79,16 @@ fn add_extra_edge_to_first_graph(store: &mut Store) -> Result<CommitHash, StoreE
     let ge = Path::from("Path.G.E");
 
     let tv = store.table_at(&gv).expect("Path.G.V table");
-    let v1 = tv.row_id_at(0).expect("vertex 1");
-    let v2 = tv.row_id_at(1).expect("vertex 2");
-    let graph = store
+    let v1 = Value::Id(tv.row_id_at(0).expect("vertex 1"));
+    let v2 = Value::Id(tv.row_id_at(1).expect("vertex 2"));
+    let graph = Value::Id(store
         .table_at(&graphs)
         .expect("Path.Graphs table")
         .row_id_at(0)
-        .expect("first graph row");
+        .expect("first graph row"));
 
     let mut txn = store.transaction();
-    txn.add(&ge, vec![graph.into(), v1.into(), v2.into()])?;
+    txn.add(&ge, liven_all(vec![graph, v1, v2]))?;
     txn.commit()
 }
 
@@ -196,14 +195,14 @@ fn test_add_edge_referencing_vertices_from_previous_commit() {
     assert_eq!(edges.row_count(), 2);
     assert_eq!(
         edges.row_id_at(1).expect("second edge row"),
-        RowId {
+        WireRowId {
             commit: edge_commit,
             counter: 0,
         }
     );
-    assert_eq!(edges.cell_at(1, 0), Some(CellValue::Id(graph)));
-    assert_eq!(edges.cell_at(1, 1), Some(CellValue::Id(v1)));
-    assert_eq!(edges.cell_at(1, 2), Some(CellValue::Id(v2)));
+    assert_eq!(edges.cell_at(1, 0), Some(WireValue::Id(graph)));
+    assert_eq!(edges.cell_at(1, 1), Some(WireValue::Id(v1)));
+    assert_eq!(edges.cell_at(1, 2), Some(WireValue::Id(v2)));
 }
 
 #[test]
@@ -260,23 +259,23 @@ fn test_fk() {
     let ge = Path::from("Path.G.E");
 
     add_basic_data_to_path(&mut store).expect("add valid baseline data");
-    let gid = store
+    let gid = Value::Id(store
         .table_at(&graphs)
         .expect("Path.Graphs table")
         .row_id_at(0)
-        .expect("graph row");
-    let vid = store
+        .expect("graph row"));
+    let vid = Value::Id(store
         .table_at(&gv)
         .expect("Path.G.V table")
         .row_id_at(0)
-        .expect("vertex row");
+        .expect("vertex row"));
 
-    let dummy_vid = RowId {
+    let dummy_vid = Value::Id(WireRowId {
         commit: CommitHash([0xff; 32]),
         counter: u32::MAX,
-    };
+    });
     let mut tx = store.transaction();
-    tx.add(&ge, vec![gid.into(), vid.into(), dummy_vid.into()])
+    tx.add(&ge, liven_all(vec![gid, vid, dummy_vid]))
         .expect("add edge");
     let err = tx.commit().expect_err("missing v2");
 

--- a/packages/coln-store/tests/test_subduction.rs
+++ b/packages/coln-store/tests/test_subduction.rs
@@ -81,7 +81,7 @@ fn row_values(store: &Store) -> BTreeSet<(CommitHash, u32, i32)> {
 
 fn add_row(store: &mut Store, value: i32) -> Result<CommitHash, Box<dyn Error>> {
     let mut tx = store.transaction();
-    tx.add(&Path::from("T"), vec![value.into()])?;
+    tx.add(&Path::from("T"), vec![value])?;
     tx.commit().map_err(Into::into)
 }
 
@@ -197,7 +197,7 @@ async fn subduction_sync_coln_chunks() -> Result<(), Box<dyn Error>> {
     type TestTransport = MessageTransport<ChannelTransport>;
 
     let (left_sd, _left_handler, left_listener, left_manager) =
-        SubductionBuilder::<_, _, _, _, _, 256>::new()
+        SubductionBuilder::<_, _, _, _, _>::new()
             .signer(MemorySigner::from_bytes(&[1; 32]))
             .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
             .spawner(ChannelTokioSpawn)
@@ -205,7 +205,7 @@ async fn subduction_sync_coln_chunks() -> Result<(), Box<dyn Error>> {
             .build::<Sendable, TestTransport>();
 
     let (right_sd, _right_handler, right_listener, right_manager) =
-        SubductionBuilder::<_, _, _, _, _, 256>::new()
+        SubductionBuilder::<_, _, _, _, _>::new()
             .signer(MemorySigner::from_bytes(&[2; 32]))
             .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
             .spawner(ChannelTokioSpawn)
@@ -330,7 +330,7 @@ async fn subduction_websocket_sync_coln_chunks() -> Result<(), Box<dyn Error>> {
     let server_peer_id = PeerId::from(server_signer.verifying_key());
 
     let (server_sd, _server_handler, server_listener, server_manager) =
-        SubductionBuilder::<_, _, _, _, _, 256>::new()
+        SubductionBuilder::<_, _, _, _, _>::new()
             .signer(server_signer)
             .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
             .spawner(TrackedTokioSpawn::default())
@@ -352,7 +352,7 @@ async fn subduction_websocket_sync_coln_chunks() -> Result<(), Box<dyn Error>> {
 
     let left_signer = MemorySigner::from_bytes(&[11; 32]);
     let (left_sd, _left_handler, left_listener, left_manager) =
-        SubductionBuilder::<_, _, _, _, _, 256>::new()
+        SubductionBuilder::<_, _, _, _, _>::new()
             .signer(left_signer.clone())
             .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
             .spawner(WebSocketTokioSpawn)
@@ -364,7 +364,7 @@ async fn subduction_websocket_sync_coln_chunks() -> Result<(), Box<dyn Error>> {
 
     let right_signer = MemorySigner::from_bytes(&[12; 32]);
     let (right_sd, _right_handler, right_listener, right_manager) =
-        SubductionBuilder::<_, _, _, _, _, 256>::new()
+        SubductionBuilder::<_, _, _, _, _>::new()
             .signer(right_signer.clone())
             .storage(MemoryStorage::new(), Arc::new(OpenPolicy))
             .spawner(WebSocketTokioSpawn)

--- a/packages/coln-store/tests/test_subduction.rs
+++ b/packages/coln-store/tests/test_subduction.rs
@@ -7,7 +7,7 @@ use std::{collections::BTreeSet, error::Error, net::SocketAddr, sync::Arc, time:
 use coln_flir_rs::ir::{
     BuiltinTy, ColType, ColumnEntry, EntityVariant, FlatRealm, Path, Schema, TableEntry,
 };
-use coln_store::{commit::hash::CommitHash, store::Store, table::CellValue};
+use coln_store::{commit::hash::CommitHash, store::Store, table::WireValue};
 use future_form::Sendable;
 use sedimentree_core::{
     blob::{Blob, verified::VerifiedBlobMeta},
@@ -65,13 +65,13 @@ fn sedimentree_id(store: &Store) -> SedimentreeId {
     SedimentreeId::new(root_hash(store).0)
 }
 
-fn row_values(store: &Store) -> BTreeSet<(CommitHash, u32, i64)> {
+fn row_values(store: &Store) -> BTreeSet<(CommitHash, u32, i32)> {
     let table = store.table_at(&Path::from("T")).expect("T table");
     (0..table.row_count())
         .map(|row| {
             let id = table.row_id_at(row).expect("row id");
             let value = match table.cell_at(row, 0).expect("cell") {
-                CellValue::Int(value) => value,
+                WireValue::Int(value) => value,
                 other => panic!("expected int cell, got {other:?}"),
             };
             (id.commit, id.counter, value)
@@ -79,7 +79,7 @@ fn row_values(store: &Store) -> BTreeSet<(CommitHash, u32, i64)> {
         .collect()
 }
 
-fn add_row(store: &mut Store, value: i64) -> Result<CommitHash, Box<dyn Error>> {
+fn add_row(store: &mut Store, value: i32) -> Result<CommitHash, Box<dyn Error>> {
     let mut tx = store.transaction();
     tx.add(&Path::from("T"), vec![value.into()])?;
     tx.commit().map_err(Into::into)


### PR DESCRIPTION
This pull request unifies the various "value" enums into a single generic enum that looks like

```
enum Value<I> {
  Id(I)
  Int(i32)
  Str(String)
}
```

Unfortunately, this means that some of the conversions that used to be done with `.into` have to be a little more explicit, because we can't implement a generic `From<I>`.

We also rename the various `RowId` variants to be a bit more consistent. The renaming is across the following axes

- `Txn` vs no `Txn` -- row ids that might appear temporarily as part of a transaction, or permanent row ids
- `Live` vs. `Wire` vs. `Packed` -- `Live` is row ids created as part of a transaction that automatically turn into permanent row ids after the transaction is done (which we will remove soon), `Wire` is row ids in the wire format (e.g. with commit hash), and `Packed` is row ids in the packed format (e.g. with commit id produced by an IdMapper).

So what used to be `RowId` is now `WireRowId`, what used to be `RowHandle` is `TxnLiveRowId`, what used to be `RowRef` is `TxnWireRowId`, `PackedRowId` remains the same.

As a convenience, we have type aliases `type XXXValue = Value<XXXRowId>`, so `WireValue = Value<WireRowId>`, and so on.