### PR TITLE
Wire up the batch backend into Pipeline::batch()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1052,7 +1052,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrow",
- "coln-integrator",
 ]
 
 [[package]]

--- a/packages/coln-batch/Cargo.toml
+++ b/packages/coln-batch/Cargo.toml
@@ -10,4 +10,3 @@ readme = "README.md"
 [dependencies]
 anyhow = { workspace = true }
 arrow = { version = "56", default-features = false, features = ["ipc"] }
-coln-integrator = { path = "../coln-integrator" }

--- a/packages/coln-query/Cargo.toml
+++ b/packages/coln-query/Cargo.toml
@@ -44,6 +44,10 @@ size-of = {
   ]
 }
 thiserror = { workspace = true }
+# The batch backend lowers plans into coln-batch Datalog programs and
+# executes them with its engine. Data flows store -> pipeline -> batch,
+# so this direction creates no cycle.
+coln-batch = { path = "../coln-batch" }
 
 [dev-dependencies]
 # Import coln-flir-rs again but with the test-utils feature flag to have
@@ -52,11 +56,6 @@ coln-flir-rs = { path = "../coln-flir-rs", features = ["test-utils"] }
 # This is a self-referential dev-dependency to have the feature-gated
 # test-utils be available in this crate's integration tests, too.
 coln-query = { path = ".", features = ["test-utils"] }
-# Dev-only for now: the production dependency direction between
-# coln-query and coln-batch is still to be settled (real data
-# reaches coln-query through coln-integrator and coln-store, so a
-# regular dependency here would be a cycle).
-coln-batch = { path = "../coln-batch" }
 criterion = { workspace = true }
 
 [features]

--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -901,15 +901,11 @@ mod test {
         Ok(())
     }
 
-    #[test]
-    fn source_leaf_inside_fixed_point_step_is_bridged() -> Result<(), anyhow::Error> {
-        // A `SourceExpr` referenced *only* inside a step body is legal: the
-        // backend wires its root input and `delta0`s it into the nested circuit,
-        // exactly as it would an outer variable — no explicit imports needed.
-        // This computes reachability: starting from the seed nodes in `plain`,
-        // follow `edges` transitively. `edges` appears nowhere but the step, so
-        // this exercises wiring a source's root input for a step-only source.
-        let plan = vec![
+    /// Reachability from the seed nodes in `plain` over `edges`,
+    /// arithmetic-free. Shared between the incremental run and its
+    /// batch twin below.
+    fn reachability_plan() -> Vec<Stmt> {
+        vec![
             // base = the seed node ids from `plain`, as a single `node` column.
             Stmt::from(VarStmt {
                 name: "base".to_string(),
@@ -948,7 +944,18 @@ mod test {
                 })),
             }),
             output_stmt("reachable"),
-        ];
+        ]
+    }
+
+    #[test]
+    fn source_leaf_inside_fixed_point_step_is_bridged() -> Result<(), anyhow::Error> {
+        // A `SourceExpr` referenced *only* inside a step body is legal: the
+        // backend wires its root input and `delta0`s it into the nested circuit,
+        // exactly as it would an outer variable — no explicit imports needed.
+        // This computes reachability: starting from the seed nodes in `plain`,
+        // follow `edges` transitively. `edges` appears nowhere but the step, so
+        // this exercises wiring a source's root input for a step-only source.
+        let plan = reachability_plan();
 
         let mut rt = Pipeline::incremental().runtime(&mut TestProgram::new(
             plan,
@@ -980,6 +987,177 @@ mod test {
             }
         );
 
+        Ok(())
+    }
+
+    /// The reachability plan on the batch backend, cross-checked against
+    /// the incremental run. The first commit from empty state makes the
+    /// incremental delta equal the full state, so both engines must
+    /// produce exactly the same rows.
+    #[test]
+    fn batch_reachability_matches_incremental() -> Result<(), anyhow::Error> {
+        let seed = || [(PlainRel::new(0, 0, 0), 1)];
+        let edges = || {
+            [
+                EdgeRel::new(0, 1, 1),
+                EdgeRel::new(1, 2, 1),
+                EdgeRel::new(2, 3, 1),
+            ]
+        };
+        let schemas = || [PlainRel::schema(), EdgeRel::schema()];
+
+        let mut batch =
+            Pipeline::batch().runtime(&mut TestProgram::new(reachability_plan(), schemas()))?;
+        assert!(batch.feed(&PlainRel::id(), rows(seed()))?);
+        assert!(batch.feed(&EdgeRel::id(), rows_with_weight(edges(), 1))?);
+        batch.commit()?;
+        let snapshot = batch.output(&SinkId::from("reachable"))?;
+        assert_eq!(snapshot.columns(), ["node"]);
+        assert_eq!(snapshot.len(), 4);
+        assert!(!snapshot.is_empty());
+
+        let mut incremental = Pipeline::incremental()
+            .runtime(&mut TestProgram::new(reachability_plan(), schemas()))?;
+        assert!(incremental.feed(&PlainRel::id(), rows(seed()))?);
+        assert!(incremental.feed(&EdgeRel::id(), rows_with_weight(edges(), 1))?);
+        incremental.commit()?;
+
+        let expected = zset! {
+            tuple!(0_u64) => 1,
+            tuple!(1_u64) => 1,
+            tuple!(2_u64) => 1,
+            tuple!(3_u64) => 1,
+        };
+        assert_eq!(snapshot.to_debug_zset(), expected);
+        assert_eq!(
+            incremental
+                .output(&SinkId::from("reachable"))?
+                .to_debug_zset(),
+            expected
+        );
+        Ok(())
+    }
+
+    /// A plain u64 join through the whole batch pipeline, cross-checked
+    /// against the incremental backend.
+    #[test]
+    fn batch_join_matches_incremental() -> Result<(), anyhow::Error> {
+        let plan = || {
+            vec![
+                Stmt::from(VarStmt {
+                    name: "edges".to_string(),
+                    initializer: Some(Expr::from(SourceExpr::new(EdgeRel::id()))),
+                }),
+                Stmt::from(VarStmt {
+                    name: "two_hops".to_string(),
+                    initializer: Some(Expr::from(EquiJoinExpr {
+                        left: Expr::from(AliasExpr {
+                            relation: Expr::from(VarExpr::new("edges")),
+                            alias: "h1".to_string(),
+                        }),
+                        right: Expr::from(AliasExpr {
+                            relation: Expr::from(VarExpr::new("edges")),
+                            alias: "h2".to_string(),
+                        }),
+                        on: vec![(
+                            Expr::from(VarExpr::new("to")),
+                            Expr::from(VarExpr::new("from")),
+                        )],
+                        attributes: Some(vec![
+                            ("start".to_string(), Expr::from(VarExpr::new("h1.from"))),
+                            ("mid".to_string(), Expr::from(VarExpr::new("h1.to"))),
+                            ("end".to_string(), Expr::from(VarExpr::new("h2.to"))),
+                        ]),
+                    })),
+                }),
+                output_stmt("two_hops"),
+            ]
+        };
+        let data = || {
+            [
+                EdgeRel::new(0, 1, 1),
+                EdgeRel::new(1, 2, 1),
+                EdgeRel::new(5, 6, 1),
+            ]
+        };
+
+        let mut batch =
+            Pipeline::batch().runtime(&mut TestProgram::new(plan(), [EdgeRel::schema()]))?;
+        assert!(batch.feed(&EdgeRel::id(), rows_with_weight(data(), 1))?);
+        batch.commit()?;
+
+        let mut incremental =
+            Pipeline::incremental().runtime(&mut TestProgram::new(plan(), [EdgeRel::schema()]))?;
+        assert!(incremental.feed(&EdgeRel::id(), rows_with_weight(data(), 1))?);
+        incremental.commit()?;
+
+        let expected = zset! { tuple!(0_u64, 1_u64, 2_u64) => 1 };
+        assert_eq!(
+            batch.output(&SinkId::from("two_hops"))?.to_debug_zset(),
+            expected
+        );
+        assert_eq!(
+            incremental
+                .output(&SinkId::from("two_hops"))?
+                .to_debug_zset(),
+            expected
+        );
+        Ok(())
+    }
+
+    /// The batch backend's value slice is unsigned integers and booleans.
+    /// Rows carrying strings fail loudly instead of computing something
+    /// wrong.
+    // TODO(Jan): support the remaining scalar types (strings first, via
+    // dictionary encoding) after the end-to-end slice is complete; then
+    // `test_standard_join` gets its batch twin, too.
+    #[test]
+    fn batch_feed_rejects_strings_for_now() -> Result<(), anyhow::Error> {
+        use crate::api::deltas::ZRow;
+        use crate::relational::relation::TupleValue;
+        use crate::scalarial::ScalarTypedValue;
+
+        let plan = vec![
+            Stmt::from(VarStmt {
+                name: "people".to_string(),
+                initializer: Some(Expr::from(SourceExpr::new(PersonRel::id()))),
+            }),
+            output_stmt("people"),
+        ];
+        let mut rt =
+            Pipeline::batch().runtime(&mut TestProgram::new(plan, [PersonRel::schema()]))?;
+        let alice = ZRow::new(
+            1,
+            TupleValue {
+                data: vec![
+                    ScalarTypedValue::Uint(0),
+                    ScalarTypedValue::String("Alice".to_string()),
+                    ScalarTypedValue::Uint(20),
+                    ScalarTypedValue::Uint(0),
+                ],
+            },
+        )
+        .expect("non-zero zweight");
+        let err = rt.feed(&PersonRel::id(), [alice]).unwrap_err();
+        assert!(err.to_string().contains("unsigned integer"), "got: {err}");
+        Ok(())
+    }
+
+    /// Reading an output before any commit is an error, and feeding a
+    /// source the plan does not use reports `false` instead of failing.
+    #[test]
+    fn batch_output_requires_commit() -> Result<(), anyhow::Error> {
+        let plan = vec![
+            Stmt::from(VarStmt {
+                name: "edges".to_string(),
+                initializer: Some(Expr::from(SourceExpr::new(EdgeRel::id()))),
+            }),
+            output_stmt("edges"),
+        ];
+        let mut rt = Pipeline::batch().runtime(&mut TestProgram::new(plan, [EdgeRel::schema()]))?;
+        assert!(!rt.feed(&PlainRel::id(), rows([(PlainRel::new(0, 0, 0), 1)]))?);
+        let err = rt.output(&SinkId::from("edges")).unwrap_err();
+        assert!(err.to_string().contains("commit"), "got: {err}");
         Ok(())
     }
 

--- a/packages/coln-query/src/relational/batch/mod.rs
+++ b/packages/coln-query/src/relational/batch/mod.rs
@@ -3,28 +3,74 @@
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 //! A batch backend optimized for efficient evaluation of non-binary joins.
+//!
+//! The non-incremental half of the pipeline. [`Backend::build`] lowers the
+//! resolved plan into one coln-batch Datalog program, [`Runtime::feed`]
+//! stages rows per source, [`Runtime::commit`] recomputes the whole result
+//! eagerly (a semi-naive fixpoint over worst-case-optimal joins), and
+//! [`Runtime::output`] hands back the full current state of a sink as a
+//! [`Snapshot`]. Where the incremental backend reports deltas, this backend
+//! reports states.
+//!
+//! Value scope of this slice: unsigned integers and booleans, mapped onto
+//! the engine's u64 universe.
+// TODO(Jan): the remaining scalar types (strings first, via dictionary
+// encoding) land after the end-to-end slice is complete.
+//!
+//! # Interim: base tables arrive by push
+//!
+//! The pipeline has one input door, [`Runtime::feed`], and it speaks
+//! deltas: rows with z-weights, pushed by the store transaction by
+//! transaction. That is what the incremental backend needs. A batch
+//! backend wants the opposite: pull the full snapshot of every base table
+//! at query time. That pull API does not exist in the pipeline yet; the
+//! store side of it does (`SortedTableSnapshot` in coln-store).
+//!
+//! Until it lands, this backend integrates the pushed deltas itself:
+//! [`Runtime::feed`] keeps a net z-weight per row and
+//! `materialize_sources` turns that into the base tables right before
+//! every recomputation. This is correct as long as the runtime sees every
+//! delta from the start, which holds for what a batch query is today: one
+//! feed-commit-output cycle over a snapshot pushed through `feed`. It is a
+//! stopgap, not the design. The store already holds these tables, copying
+//! them through `feed` is wasted work, and a runtime created later cannot
+//! catch up on deltas it never saw.
+// TODO(Jan): replace the push-side integration with the pull API once the
+// pipeline offers one. `materialize_sources` is the single seam to swap;
+// lowering, fixpoint, and output stay as they are.
 
-// Test-only until the production dependency direction between coln-query
-// and coln-batch is settled (see the dev-dependency note in Cargo.toml).
-#[cfg(test)]
 mod lowering;
 
+use std::collections::HashMap;
+use std::num::NonZeroUsize;
+
+use coln_batch::fixpoint::{self, Exec};
+use coln_batch::generic_join;
+use coln_batch::query::Catalog as BatchCatalog;
+use coln_batch::relation::Relation;
+use coln_batch::rule::Program;
+use dbsp::{OrdZSet, utils::Tup2};
+
+use self::lowering::{LoweredPlan, lower};
 use super::{Backend, Runtime};
 use crate::{
-    api::deltas::ZRow,
+    api::deltas::{ZRow, ZWeight},
     error::{BuildError, RuntimeError},
     host::resolver::ResolvedCode,
     relational::{
         catalog::SourceSchemas,
         expr::{SinkId, SourceId},
+        relation::TupleValue,
     },
-    scalarial::{ColumnScalarEngine, column::VectorizedScalarEngine},
+    scalarial::{ColumnScalarEngine, ScalarTypedValue, column::VectorizedScalarEngine},
 };
-use std::num::NonZeroUsize;
 
-/// The non-incremental backend: evaluates the plan eagerly over materialized
-/// Z-sets. Bodies are the next slice of work.
+/// The non-incremental backend: lowers the plan to a coln-batch Datalog
+/// program at build time and recomputes it eagerly on every commit.
 pub struct BatchBackend<E: ColumnScalarEngine = VectorizedScalarEngine> {
+    // Reserved for the scalar slice: computed columns and general
+    // conditions will run on this engine.
+    #[allow(dead_code)]
     scalar_engine: E,
 }
 
@@ -43,20 +89,142 @@ impl<E: ColumnScalarEngine> Backend for BatchBackend<E> {
     fn build(
         self,
         _threads: NonZeroUsize,
-        _plan: ResolvedCode,
-        _sources: SourceSchemas,
+        plan: ResolvedCode,
+        sources: SourceSchemas,
     ) -> Result<BatchRuntime, Self::Error> {
-        todo!("eager batch backend: build a RelExprVisitor over Z-sets")
+        let LoweredPlan {
+            program,
+            sources: used_sources,
+            outputs,
+            schemas,
+        } = lower(plan.as_code(), &sources)
+            .map_err(|error| BuildError::new(format!("{error:#}")))?;
+        let inputs = used_sources
+            .into_keys()
+            .map(|source| (source, HashMap::new()))
+            .collect();
+        let sinks = outputs
+            .keys()
+            .map(|sink| SinkId::from(sink.as_str()))
+            .collect();
+        Ok(BatchRuntime {
+            program,
+            outputs,
+            schemas,
+            inputs,
+            sinks,
+            results: None,
+        })
     }
 }
 
-/// Accumulated source Z-sets + the compiled plan; `commit` recomputes the result.
-pub struct BatchRuntime;
+/// Staged source rows plus the compiled program; [`Runtime::commit`]
+/// recomputes the full result from the accumulated inputs.
+pub struct BatchRuntime {
+    program: Program,
+    /// Sink id to the derived relation `output` reads.
+    outputs: HashMap<String, String>,
+    /// Column names per relation, sources and derived alike.
+    schemas: HashMap<String, Vec<String>>,
+    /// Per used source: the net z-weight of every row fed so far. This is
+    /// the interim snapshot store described in the module docs; the pull
+    /// API replaces it.
+    inputs: HashMap<String, HashMap<Vec<u64>, ZWeight>>,
+    sinks: Vec<SinkId>,
+    /// The relations of the last commit.
+    results: Option<BatchCatalog>,
+}
 
-/// The full current state of a result relation. The natural output of a batch
-/// backend.
+/// The full current state of a result relation, the natural output of a
+/// batch backend (the incremental backend reports deltas instead).
+///
+/// Rows are sorted and deduplicated: results are sets. Values come back as
+/// unsigned integers, matching the value slice the backend accepts.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Snapshot; // TBD.
+pub struct Snapshot {
+    columns: Vec<String>,
+    rows: Vec<TupleValue>,
+}
+
+impl Snapshot {
+    fn from_relation(columns: Vec<String>, relation: &Relation) -> Self {
+        let rows = (0..relation.len())
+            .map(|row| TupleValue {
+                data: relation
+                    .row(row)
+                    .into_iter()
+                    .map(ScalarTypedValue::Uint)
+                    .collect(),
+            })
+            .collect();
+        Self { columns, rows }
+    }
+
+    /// The result's column names, in tuple order.
+    pub fn columns(&self) -> &[String] {
+        &self.columns
+    }
+
+    /// The rows, sorted and deduplicated.
+    pub fn rows(&self) -> &[TupleValue] {
+        &self.rows
+    }
+
+    pub fn len(&self) -> usize {
+        self.rows.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// The snapshot as a z-set with every weight `+1`, for set-level
+    /// comparison against the incremental backend's consolidated output.
+    pub fn to_debug_zset(&self) -> OrdZSet<TupleValue> {
+        let keys = self
+            .rows
+            .iter()
+            .map(|row| Tup2(row.clone(), 1))
+            .collect::<Vec<_>>();
+        OrdZSet::from_keys((), keys)
+    }
+}
+
+impl BatchRuntime {
+    /// Build the base tables for one recomputation from the deltas fed so
+    /// far: a row is present when its net z-weight is positive.
+    ///
+    /// Interim, see the module docs. This is the one seam where the pull
+    /// API hooks in later: read the store's sorted snapshots instead of
+    /// integrating pushed deltas. Nothing downstream needs to change.
+    // TODO(Jan): swap for the pull API once the pipeline offers one.
+    fn materialize_sources(&self) -> Result<BatchCatalog, RuntimeError> {
+        let mut edb = BatchCatalog::new();
+        for (source, staged) in &self.inputs {
+            let columns = self.schemas.get(source).cloned().unwrap_or_default();
+            let mut data: Vec<Vec<u64>> = vec![Vec::new(); columns.len()];
+            for (row, weight) in staged {
+                match weight {
+                    weight if *weight < 0 => {
+                        return Err(RuntimeError::new(format!(
+                            "source '{source}': a row was deleted more often than inserted \
+                             (net weight {weight})"
+                        )));
+                    }
+                    0 => {}
+                    // Sets: duplicated insertions collapse into one row.
+                    _ => {
+                        for (column, value) in data.iter_mut().zip(row) {
+                            column.push(*value);
+                        }
+                    }
+                }
+            }
+            edb.insert(Relation::new(source.clone(), columns, data));
+        }
+        Ok(edb)
+    }
+}
 
 impl Runtime for BatchRuntime {
     type Output = Snapshot;
@@ -64,22 +232,82 @@ impl Runtime for BatchRuntime {
 
     fn feed(
         &mut self,
-        _source: &SourceId,
-        _rows: impl IntoIterator<Item = ZRow>,
+        source: &SourceId,
+        rows: impl IntoIterator<Item = ZRow>,
     ) -> Result<bool, Self::Error> {
-        todo!("eager batch feed: accumulate into source tables")
+        // Mirrors the incremental backend: a source the plan does not use
+        // is `Ok(false)`, not an error. The caller decides what that means.
+        let arity = self.schemas.get(source.as_str()).map_or(0, Vec::len);
+        let Some(staged) = self.inputs.get_mut(source.as_str()) else {
+            return Ok(false);
+        };
+        for zrow in rows {
+            let weight = zrow.zweight();
+            let row = convert_row(source, &zrow.into_row(), arity)?;
+            *staged.entry(row).or_insert(0) += weight;
+        }
+        Ok(true)
     }
 
     fn commit(&mut self) -> Result<(), Self::Error> {
-        todo!("eager batch commit: recompute the plan from accumulated inputs")
+        let edb = self.materialize_sources()?;
+        let result = fixpoint::semi_naive(&self.program, &edb, generic_join::execute as Exec)
+            .map_err(|error| RuntimeError::new(format!("{error:#}")))?;
+        self.results = Some(result.catalog);
+        Ok(())
     }
 
-    fn output(&self, _out: &SinkId) -> Result<Snapshot, Self::Error> {
-        todo!("eager batch output: read the materialized result")
+    fn output(&self, out: &SinkId) -> Result<Snapshot, Self::Error> {
+        let Some(results) = &self.results else {
+            return Err(RuntimeError::new("commit before reading an output"));
+        };
+        let Some(relation) = self.outputs.get(out.as_str()) else {
+            return Err(RuntimeError::new(format!(
+                "unknown output '{}' (print-only CLI taps are not readable)",
+                out.as_str()
+            )));
+        };
+        // The engine names rule variables generically (v0, v1, …); the
+        // plan's speaking column names live in the schema table.
+        let columns = self.schemas.get(relation).cloned().unwrap_or_default();
+        let relation = results
+            .get(relation)
+            .map_err(|error| RuntimeError::new(format!("{error:#}")))?;
+        Ok(Snapshot::from_relation(columns, relation))
     }
 
     fn list_outputs(&self) -> impl Iterator<Item = &'_ SinkId> {
-        // Apparently, todo!() does not work with impl Trait syntax..
-        std::iter::empty()
+        self.sinks.iter()
     }
+}
+
+/// Convert one staged row into the engine's u64 universe.
+///
+/// This slice accepts unsigned integers and booleans; everything else
+/// fails loudly instead of computing something wrong.
+// TODO(Jan): remaining scalar types after the end-to-end slice.
+fn convert_row(
+    source: &SourceId,
+    row: &TupleValue,
+    arity: usize,
+) -> Result<Vec<u64>, RuntimeError> {
+    if row.data.len() != arity {
+        return Err(RuntimeError::new(format!(
+            "row for source '{}' has {} values, its schema has {arity} columns",
+            source.as_str(),
+            row.data.len()
+        )));
+    }
+    row.data
+        .iter()
+        .map(|value| match value {
+            ScalarTypedValue::Uint(value) => Ok(*value),
+            ScalarTypedValue::Bool(value) => Ok(u64::from(*value)),
+            other => Err(RuntimeError::new(format!(
+                "source '{}': the batch backend supports unsigned integer and boolean \
+                 values for now, got {other:?}",
+                source.as_str()
+            ))),
+        })
+        .collect()
 }


### PR DESCRIPTION
## What

Wiring up the batch engine with @lstwn 's `Pipeline` structure.
Fills the four bodies of the batch backend so `Pipeline::batch()` runs
plans end to end: build lowers, feed stages, commit computes, output
reads. Same pipeline interface as the incremental backend, but the
batch backend recomputes everything on every commit instead of
maintaining deltas.

Heads-up: Because we do not have a `TableReaderAPI` yet, we mimic constructing the relation once for now.
This means we assume that for feed we receive all deltas and compute a snapshot once which we then use for computing.
(see below)

## Why

A batch query is one shot: build the plan, hand over the base tables,
compute, read the result. The pipeline, however, has a single input
interface, `feed`. It assumes to receive deltas: rows with z-weights, pushed by the
store transaction by transaction. That is exactly what the incremental
backend needs. A batch backend wants the opposite direction: pull the
full snapshot of every base table at query time. That pull API does not
exist in the pipeline yet. The store side of it does
(`SortedTableSnapshot` in coln-store).

This PR is arguably a hack to make an E2E test work. As we will unlikely finish the API in time.
The batch runtime accepts the pushed deltas and integrates them into a snapshot
itself. A batch query is then one feed-commit-output cycle over a
snapshot pushed through `feed`. Marked as a hack
in the code (module docs, `materialize_sources`, TODO(Jan)). Swapping it
for the pull API later touches a single function; lowering, fixpoint,
and output stay as they are.

## How

- `build` lowers the resolved plan into one coln-batch Datalog program
  (the mapping from #135) and keeps it together with the schema.
- `feed` stages the pushed rows per source and keeps a net z-weight per
  row. This is where the delta stream turns into a snapshot: +1 and -1
  for the same row cancel out. A source the plan does not use reports
  `false`, mirroring the incremental backend.
- `commit` first materializes the base tables from the net weights
  (`materialize_sources`: net weight > 0 means present, negative is a
  clear error), then recomputes the full result with a semi-naive
  fixpoint over worst-case-optimal joins. The materialization step is
  the seam the pull API will replace.
- `output` returns the new `Snapshot`: the full current state of a
  sink, sorted and deduplicated, with `to_debug_zset()` for set-level
  comparison. Batch reports states where incremental reports deltas.

## Scope of this slice

- Values: unsigned integers and booleans, mapped onto the batch engine's u64.
  Rows carrying anything else fail loudly instead of
  computing something wrong. TODO(Jan): remaining scalar types
  (strings first) after the end-to-end slice.

## Testing

Run with:

```sh
cargo test -p coln-query batch
```

- The reachability plan (recursive) and a plain u64 join run through
  both pipelines, batch and incremental, and must produce exactly the
  same rows. The first cross-engine differential.
- Error paths covered: strings in feed, output before commit, feeding
  a source the plan does not use.
- Not covered yet: retractions between commits. The demo never issues
  them, so the net-weight integration is only exercised with
  insertions.