### PR TITLE
Add typed values to the batch engine

### DIFF
--- a/packages/coln-batch/README.md
+++ b/packages/coln-batch/README.md
@@ -1,14 +1,23 @@
 # coln-batch
 
-The batch query engine for Coln. This first slice evaluates conjunctive
-queries (joins with equality, set semantics) over `u64` relations, with
-two interchangeable executors that are differential-tested against a
-brute-force oracle.
+The batch query engine for Coln. It evaluates conjunctive queries (joins
+with equality, set semantics) and recursive Datalog programs over typed
+relations, with two interchangeable executors that are
+differential-tested against a brute-force oracle.
+
+Values are typed at the boundary (unsigned and signed integers,
+booleans, characters, strings) and stored as normalized `u64` keys
+inside: integers by arithmetic, strings through a dictionary shared by
+all relations of a catalog. The join machinery compares keys only, so
+every type runs through the same code at integer speed. See the
+rustdoc of `types.rs` for the encoding.
 
 ## Layout
 
-- `relation.rs` is the in-memory relation type (`u64` columns,
-  column-major).
+- `types.rs` defines the scalar types, values, schemas, the string
+  dictionary and the key encoding.
+- `relation.rs` is the in-memory relation type (a schema plus key
+  columns, column-major), with typed construction and decoding.
 - `generate.rs` and `rng.rs` build deterministic test workloads, a
   cyclic triangle join and the acyclic e-matching pattern `f(α, g(α))`.
 - `io.rs` saves and loads relations as Arrow IPC files, the test-data
@@ -18,7 +27,8 @@ brute-force oracle.
   checker (`check_contract`) that future storage back ends can run
   against their own indexes. The trait's rustdoc is the contract.
 - `query.rs` represents conjunctive queries as data, atoms over named
-  relations, deliberately mirroring FLIR's rule shape, plus a catalog.
+  relations, deliberately mirroring FLIR's rule shape, plus a catalog
+  that owns the dictionary and type-checks queries.
 - `binary_join.rs` and `generic_join.rs` are the two executors, a
   classic hash-join chain and a worst-case-optimal generic join.
 - `reference.rs` is the brute-force oracle that defines correct results
@@ -26,7 +36,8 @@ brute-force oracle.
 - `rule.rs` and `fixpoint.rs` evaluate recursive Datalog programs to
   their least fixpoint with semi-naive iteration; a naive re-evaluation
   strategy serves as the recursion oracle. Either query executor can
-  drive the rule bodies.
+  drive the rule bodies. Derived relations get their schemas inferred
+  from the rules, or declared through an empty relation in the catalog.
 
 ## Examples
 
@@ -57,10 +68,14 @@ cargo run -p coln-batch --example demo --release
 
 Three layers. Unit tests per module, differential tests (both executors
 must agree with the oracle, `tests/differential.rs`), and randomized
-differential tests over generated query shapes
+differential tests over generated query shapes and column types
 (`tests/random_queries.rs`). Recursion is differential-tested as well,
 semi-naive against naive re-evaluation, with either executor
-underneath (`tests/fixpoint.rs`).
+underneath (`tests/fixpoint.rs`, `tests/random_programs.rs`). Types are
+tested by transport (`tests/typed.rs`): the same queries and programs
+run over every scalar type, and the typed results must be the image of
+the `u64` results; mixed-type queries and the edge values of every type
+ride along.
 
 ```sh
 cargo test -p coln-batch                                 # fast suite

--- a/packages/coln-batch/examples/demo.rs
+++ b/packages/coln-batch/examples/demo.rs
@@ -20,6 +20,7 @@ use std::time::Instant;
 use anyhow::Result;
 use coln_batch::query::{Catalog, Query};
 use coln_batch::relation::Relation;
+use coln_batch::types::Dictionary;
 use coln_batch::{binary_join, fixtures, generate, generic_join, io};
 
 fn main() -> Result<()> {
@@ -85,8 +86,8 @@ fn demo(
     let mut catalog = Catalog::new();
     for rel in &relations {
         let path = dir.join(format!("{}.arrow", rel.name));
-        io::save_relation(rel, &path)?;
-        let loaded = io::load_relation(&rel.name, &path)?;
+        io::save_relation(rel, &Dictionary::new(), &path)?;
+        let loaded = io::load_relation(&rel.name, &path, catalog.dictionary_mut())?;
         anyhow::ensure!(&loaded == rel, "{}: reloaded relation differs", rel.name);
         println!("      {:<4} saved and reloaded, identical", loaded.name);
         catalog.insert(loaded);
@@ -101,7 +102,10 @@ fn demo(
         generic.len()
     );
     for i in 0..generic.len().min(3) {
-        println!("      sample row: {:?}", generic.row(i));
+        println!(
+            "      sample row: {:?}",
+            generic.row_values(i, catalog.dictionary())?
+        );
     }
 
     println!("[4] cross-checks:");

--- a/packages/coln-batch/src/binary_join.rs
+++ b/packages/coln-batch/src/binary_join.rs
@@ -13,31 +13,34 @@
 //!
 //! Data is read exclusively through the [`SortedTable`] trait (a plain
 //! scan here — hash joins need no ordering), so any storage back end works.
+//! Like every executor it works on keys (see [`crate::types`]).
 
 use std::collections::HashMap;
 
 use anyhow::Result;
 
-use crate::query::{Catalog, Query, Term, VarId};
+use crate::query::{Catalog, KeyTerm, Query, VarId};
 use crate::relation::Relation;
 use crate::table::{ArrowSortedTable, SortedTable};
+use crate::types::Key;
 
 /// Evaluate `query` against `catalog` with a chain of hash joins. Returns
 /// the projected result, sorted and deduplicated (set semantics).
 pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
-    catalog.check(query)?;
-    let empty = |query: &Query| {
-        Relation::from_flat_rows("result", query.head_names(), query.head.len(), &[])
+    let prepared = catalog.prepare(query)?;
+    let Some(key_atoms) = prepared.atoms else {
+        return Ok(Relation::empty("result", prepared.schema));
     };
+    let schema = prepared.schema;
 
-    // Intermediate result: `n_rows` rows of `width` values; `bound[v]`
+    // Intermediate result: `n_rows` rows of `width` keys; `bound[v]`
     // gives the column of variable v. Starts as a single zero-width row.
     let mut bound: Vec<Option<usize>> = vec![None; query.num_vars()];
     let mut width = 0usize;
     let mut n_rows = 1usize;
-    let mut data: Vec<u64> = Vec::new();
+    let mut data: Vec<Key> = Vec::new();
 
-    for atom in &query.atoms {
+    for atom in &key_atoms {
         let rel = catalog.get(&atom.relation)?;
         let identity: Vec<usize> = (0..rel.arity()).collect();
         // TODO(perf): from_relation sorts O(N log N) even though the hash
@@ -46,15 +49,15 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         let table = ArrowSortedTable::from_relation(rel, identity)?;
 
         // Classify the atom's columns.
-        let mut lit_checks: Vec<(usize, u64)> = Vec::new(); // (atom col, value)
+        let mut lit_checks: Vec<(usize, Key)> = Vec::new(); // (atom col, key)
         let mut key_pairs: Vec<(usize, usize)> = Vec::new(); // (interm. col, atom col)
         let mut new_vars: Vec<(VarId, usize)> = Vec::new(); // (var, atom col)
         let mut intra_eq: Vec<(usize, usize)> = Vec::new(); // repeated var in atom
         let mut first_col: HashMap<VarId, usize> = HashMap::new();
         for (c, term) in atom.terms.iter().enumerate() {
             match term {
-                Term::Lit(x) => lit_checks.push((c, *x)),
-                Term::Var(v) => {
+                KeyTerm::Lit(x) => lit_checks.push((c, *x)),
+                KeyTerm::Var(v) => {
                     if let Some(&c0) = first_col.get(v) {
                         intra_eq.push((c0, c));
                     } else {
@@ -72,7 +75,7 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         // TODO(perf): the per-row `key` Vecs here and in the probe loop
         // below are hot-loop allocations; reuse one buffer when
         // performance work starts.
-        let mut index: HashMap<Vec<u64>, Vec<usize>> = HashMap::new();
+        let mut index: HashMap<Vec<Key>, Vec<usize>> = HashMap::new();
         for r in 0..table.len() {
             if lit_checks.iter().any(|&(c, x)| table.value(r, c) != x) {
                 continue;
@@ -83,7 +86,7 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
             {
                 continue;
             }
-            let key: Vec<u64> = key_pairs.iter().map(|&(_, c)| table.value(r, c)).collect();
+            let key: Vec<Key> = key_pairs.iter().map(|&(_, c)| table.value(r, c)).collect();
             index.entry(key).or_default().push(r);
         }
 
@@ -91,17 +94,17 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         // pure existence filter.
         if key_pairs.is_empty() && new_vars.is_empty() {
             if index.is_empty() {
-                return Ok(empty(query));
+                return Ok(Relation::empty("result", schema));
             }
             continue;
         }
 
         // Probe.
         let new_width = width + new_vars.len();
-        let mut out: Vec<u64> = Vec::new();
+        let mut out: Vec<Key> = Vec::new();
         for i in 0..n_rows {
             let row = &data[i * width..(i + 1) * width];
-            let key: Vec<u64> = key_pairs.iter().map(|&(icol, _)| row[icol]).collect();
+            let key: Vec<Key> = key_pairs.iter().map(|&(icol, _)| row[icol]).collect();
             if let Some(matches) = index.get(&key) {
                 for &r in matches {
                     out.extend_from_slice(row);
@@ -119,7 +122,7 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         data = out;
         n_rows = data.len() / width;
         if n_rows == 0 {
-            return Ok(empty(query));
+            return Ok(Relation::empty("result", schema));
         }
     }
 
@@ -129,23 +132,20 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         .iter()
         .map(|&v| bound[v].expect("head variable bound (validated)"))
         .collect();
-    let mut out: Vec<u64> = Vec::with_capacity(n_rows * head_cols.len());
+    let mut out: Vec<Key> = Vec::with_capacity(n_rows * head_cols.len());
     for i in 0..n_rows {
         let row = &data[i * width..(i + 1) * width];
         for &c in &head_cols {
             out.push(row[c]);
         }
     }
-    Ok(
-        Relation::from_flat_rows("result", query.head_names(), query.head.len(), &out)
-            .sorted_dedup(),
-    )
+    Ok(Relation::from_flat_rows("result", schema, &out).sorted_dedup())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query::Atom;
+    use crate::query::{Atom, Term};
 
     #[test]
     fn two_atom_chain() {

--- a/packages/coln-batch/src/fixpoint.rs
+++ b/packages/coln-batch/src/fixpoint.rs
@@ -33,6 +33,7 @@ use anyhow::Result;
 use crate::query::{Catalog, Query};
 use crate::relation::Relation;
 use crate::rule::{CompiledProgram, Program, delta_name};
+use crate::types::Schema;
 
 /// A query executor, e.g. `generic_join::execute` or
 /// `binary_join::execute`.
@@ -55,7 +56,7 @@ impl FixpointStats {
 
 pub struct FixpointResult {
     /// The input EDB plus the final IDB relations — ready for follow-up
-    /// queries.
+    /// queries. Its dictionary also holds the program's string literals.
     pub catalog: Catalog,
     pub stats: FixpointStats,
 }
@@ -71,24 +72,22 @@ pub fn naive(program: &Program, edb: &Catalog, exec: Exec) -> Result<FixpointRes
 }
 
 fn evaluate(program: &Program, edb: &Catalog, exec: Exec, semi: bool) -> Result<FixpointResult> {
-    let compiled = program.compile(edb)?;
+    // The working catalog: the EDB, the totals of every derived relation
+    // and, for semi-naive rounds, their deltas. Compiling interns the
+    // program's literals into its dictionary.
+    let mut work = edb.clone();
+    let compiled = program.compile(&mut work)?;
 
     // Initial totals: existing facts for IDB relations count as already
     // derived; otherwise start empty.
     let mut totals: BTreeMap<String, Relation> = BTreeMap::new();
-    for (name, col_names) in &compiled.idb_schemas {
+    for (name, schema) in &compiled.idb_schemas {
         let rel = match edb.get(name) {
             Ok(initial) => initial.clone().sorted_dedup(),
-            Err(_) => Relation::new(
-                name.clone(),
-                col_names.clone(),
-                vec![Vec::new(); col_names.len()],
-            ),
+            Err(_) => Relation::empty(name.clone(), schema.clone()),
         };
         totals.insert(name.clone(), rel);
     }
-
-    let mut work = edb.clone();
     for rel in totals.values() {
         work.insert(rel.clone());
     }
@@ -128,6 +127,7 @@ fn evaluate(program: &Program, edb: &Catalog, exec: Exec, semi: bool) -> Result<
     }
 
     let mut catalog = edb.clone();
+    *catalog.dictionary_mut() = work.dictionary().clone();
     for rel in totals.values() {
         catalog.insert(rel.clone());
     }
@@ -145,8 +145,7 @@ fn derive_full(
         let result = exec(&rule.query, work)?;
         accumulate(
             &mut staging,
-            compiled,
-            rule.materialize_head(&result, cols(compiled, rule)),
+            rule.materialize_head(&result, schema(compiled, rule)),
         );
     }
     Ok(staging)
@@ -165,15 +164,14 @@ fn derive_from_deltas(
             let result = exec(&query, work)?;
             accumulate(
                 &mut staging,
-                compiled,
-                rule.materialize_head(&result, cols(compiled, rule)),
+                rule.materialize_head(&result, schema(compiled, rule)),
             );
         }
     }
     Ok(staging)
 }
 
-fn cols<'a>(compiled: &'a CompiledProgram, rule: &crate::rule::LoweredRule) -> &'a [String] {
+fn schema<'a>(compiled: &'a CompiledProgram, rule: &crate::rule::LoweredRule) -> &'a Schema {
     &compiled.idb_schemas[&rule.head_relation]
 }
 
@@ -181,24 +179,11 @@ fn empty_staging(compiled: &CompiledProgram) -> BTreeMap<String, Relation> {
     compiled
         .idb_schemas
         .iter()
-        .map(|(name, col_names)| {
-            (
-                name.clone(),
-                Relation::new(
-                    name.clone(),
-                    col_names.clone(),
-                    vec![Vec::new(); col_names.len()],
-                ),
-            )
-        })
+        .map(|(name, schema)| (name.clone(), Relation::empty(name.clone(), schema.clone())))
         .collect()
 }
 
-fn accumulate(
-    staging: &mut BTreeMap<String, Relation>,
-    _compiled: &CompiledProgram,
-    derived: Relation,
-) {
+fn accumulate(staging: &mut BTreeMap<String, Relation>, derived: Relation) {
     let entry = staging
         .get_mut(&derived.name)
         .expect("head relation is a known IDB relation");

--- a/packages/coln-batch/src/fixtures.rs
+++ b/packages/coln-batch/src/fixtures.rs
@@ -79,6 +79,43 @@ pub fn triangle_catalog(nodes: u64, noise_edges: usize, planted: usize, seed: u6
     cat
 }
 
+/// Two hops along edges with the same label, a typed join on a string
+/// column:
+///
+/// ```text
+/// Q(x, z, l) ← edge(x, y, l, w1), edge(y, z, l, w2)
+/// ```
+///
+/// Variable order: l, y, x, z, w1, w2.
+pub fn labeled_two_hop_query() -> Query {
+    let (l, y, x, z, w1, w2) = (0, 1, 2, 3, 4, 5);
+    Query {
+        var_names: ["l", "y", "x", "z", "w1", "w2"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        atoms: vec![
+            Atom {
+                relation: "edge".into(),
+                terms: vec![Term::Var(x), Term::Var(y), Term::Var(l), Term::Var(w1)],
+            },
+            Atom {
+                relation: "edge".into(),
+                terms: vec![Term::Var(y), Term::Var(z), Term::Var(l), Term::Var(w2)],
+            },
+        ],
+        head: vec![x, z, l],
+    }
+}
+
+/// Catalog with generated data for [`labeled_two_hop_query`].
+pub fn labeled_catalog(nodes: u64, edges: usize, labels: &[&str], seed: u64) -> Catalog {
+    let mut cat = Catalog::new();
+    let rel = generate::labeled_edges(nodes, edges, labels, seed, cat.dictionary_mut());
+    cat.insert(rel);
+    cat
+}
+
 /// The classic recursive program:
 ///
 /// ```text
@@ -136,6 +173,51 @@ pub fn ancestor_dag_catalog(nodes: u64, edges: usize, seed: u64) -> Catalog {
     cat
 }
 
+/// Reachability along edges of one label, a typed recursive program:
+///
+/// ```text
+/// reach(x, y, l) ← edge(x, y, l, w)
+/// reach(x, z, l) ← reach(x, y, l), edge(y, z, l, w)
+/// ```
+pub fn labeled_reach_program() -> Program {
+    let (x, y, z, l, w) = (0, 1, 2, 3, 4);
+    Program {
+        rules: vec![
+            Rule {
+                var_names: vec!["x".into(), "y".into(), "l".into(), "w".into()],
+                head: Atom {
+                    relation: "reach".into(),
+                    terms: vec![Term::Var(0), Term::Var(1), Term::Var(2)],
+                },
+                body: vec![Atom {
+                    relation: "edge".into(),
+                    terms: vec![Term::Var(0), Term::Var(1), Term::Var(2), Term::Var(3)],
+                }],
+            },
+            Rule {
+                var_names: ["x", "y", "z", "l", "w"]
+                    .into_iter()
+                    .map(String::from)
+                    .collect(),
+                head: Atom {
+                    relation: "reach".into(),
+                    terms: vec![Term::Var(x), Term::Var(z), Term::Var(l)],
+                },
+                body: vec![
+                    Atom {
+                        relation: "reach".into(),
+                        terms: vec![Term::Var(x), Term::Var(y), Term::Var(l)],
+                    },
+                    Atom {
+                        relation: "edge".into(),
+                        terms: vec![Term::Var(y), Term::Var(z), Term::Var(l), Term::Var(w)],
+                    },
+                ],
+            },
+        ],
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -147,5 +229,16 @@ mod tests {
 
         let cat = triangle_catalog(50, 100, 5, 1);
         cat.check(&triangle_query()).unwrap();
+
+        let cat = labeled_catalog(20, 60, &["road", "rail"], 1);
+        let typing = cat.check(&labeled_two_hop_query()).unwrap();
+        assert_eq!(
+            typing.head_schema(&labeled_two_hop_query()).types(),
+            vec![
+                crate::types::ScalarType::Uint,
+                crate::types::ScalarType::Uint,
+                crate::types::ScalarType::String
+            ]
+        );
     }
 }

--- a/packages/coln-batch/src/generate.rs
+++ b/packages/coln-batch/src/generate.rs
@@ -15,6 +15,7 @@
 
 use crate::relation::Relation;
 use crate::rng::SplitMix64;
+use crate::types::{Column, Dictionary, ScalarType, Schema, Value};
 
 /// Triangle workload — the canonical *cyclic* join:
 ///
@@ -119,6 +120,46 @@ pub fn dag(nodes: u64, edges: usize, seed: u64) -> Relation {
     Relation::new("parent", ["parent", "child"], vec![src, dst]).sorted_dedup()
 }
 
+/// The schema of [`labeled_edges`]: `edge(src: uint, dst: uint,
+/// label: string, weight: iint)`.
+pub fn labeled_edges_schema() -> Schema {
+    Schema::new([
+        Column::new("src", ScalarType::Uint),
+        Column::new("dst", ScalarType::Uint),
+        Column::new("label", ScalarType::String),
+        Column::new("weight", ScalarType::Iint),
+    ])
+}
+
+/// A typed workload: `edges` random edges over `nodes` vertices, each
+/// carrying one of `labels` and a signed weight in `-9..=9`. Exercises
+/// every kind of key at once: identity (uint), sign-flipped (iint) and
+/// dictionary (string). Strings are interned into `dict`.
+pub fn labeled_edges(
+    nodes: u64,
+    edges: usize,
+    labels: &[&str],
+    seed: u64,
+    dict: &mut Dictionary,
+) -> Relation {
+    assert!(nodes >= 1, "labeled_edges needs at least one node");
+    assert!(!labels.is_empty(), "labeled_edges needs at least one label");
+    let mut rng = SplitMix64::new(seed);
+    let rows = (0..edges).map(|_| {
+        let label = labels[rng.below(labels.len() as u64) as usize];
+        let weight = rng.below(19) as i64 - 9;
+        vec![
+            Value::Uint(rng.below(nodes)),
+            Value::Uint(rng.below(nodes)),
+            Value::from(label),
+            Value::Iint(weight),
+        ]
+    });
+    Relation::from_rows("edge", labeled_edges_schema(), rows, dict)
+        .expect("generated rows match the schema")
+        .sorted_dedup()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -185,5 +226,21 @@ mod tests {
             }
         }
         assert!(found >= 3, "got {found}");
+    }
+
+    #[test]
+    fn labeled_edges_are_typed_and_deterministic() {
+        let mut dict = Dictionary::new();
+        let e = labeled_edges(10, 50, &["road", "rail"], 4, &mut dict);
+        assert_eq!(e.schema, labeled_edges_schema());
+        assert!(!e.is_empty() && e.len() <= 50);
+        assert_eq!(dict.len(), 2);
+        for i in 0..e.len() {
+            let row = e.row_values(i, &dict).unwrap();
+            assert!(matches!(row[2], Value::String(ref s) if s == "road" || s == "rail"));
+            assert!(matches!(row[3], Value::Iint(w) if (-9..=9).contains(&w)));
+        }
+        let mut again = Dictionary::new();
+        assert_eq!(e, labeled_edges(10, 50, &["road", "rail"], 4, &mut again));
     }
 }

--- a/packages/coln-batch/src/generic_join.rs
+++ b/packages/coln-batch/src/generic_join.rs
@@ -19,42 +19,49 @@
 //! variable columns in elimination order. [`execute`] builds those indexes
 //! in memory ([`ArrowSortedTable`]); a storage layer can serve them
 //! instead without touching this module's search logic.
+//!
+//! The search runs on keys (see [`crate::types`]); literals are encoded
+//! once up front and the result carries the typed schema of the head.
 
 use std::ops::Range;
 
 use anyhow::Result;
 
-use crate::query::{Catalog, Query, Term, VarId};
+use crate::query::{Catalog, KeyTerm, Query, VarId};
 use crate::relation::Relation;
 use crate::table::{ArrowSortedTable, SortedTable};
+use crate::types::Key;
 
 /// Evaluate `query` against `catalog` with the generic join. Returns the
 /// projected result, sorted and deduplicated (set semantics).
 pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
-    catalog.check(query)?;
+    let prepared = catalog.prepare(query)?;
+    let Some(key_atoms) = prepared.atoms else {
+        return Ok(Relation::empty("result", prepared.schema));
+    };
 
     // Build one suitably-sorted index per atom.
     // TODO(perf): sorting happens here, per query. Once the storage layer
     // serves SortedTable directly (pre-built indexes), this block becomes
     // a lookup instead of an O(N log N) build.
-    let mut atoms: Vec<AtomExec<ArrowSortedTable>> = Vec::with_capacity(query.atoms.len());
-    for atom in &query.atoms {
+    let mut atoms: Vec<AtomExec<ArrowSortedTable>> = Vec::with_capacity(key_atoms.len());
+    for atom in &key_atoms {
         let rel = catalog.get(&atom.relation)?;
 
         // Column order: literal columns first, then variable columns in
         // elimination (VarId) order; a variable's columns end up adjacent.
         let mut order: Vec<usize> = (0..atom.terms.len()).collect();
         order.sort_by_key(|&c| match atom.terms[c] {
-            Term::Lit(_) => (0, 0, c),
-            Term::Var(v) => (1, v, c),
+            KeyTerm::Lit(_) => (0, 0, c),
+            KeyTerm::Var(v) => (1, v, c),
         });
 
-        let mut lit_prefix: Vec<u64> = Vec::new();
+        let mut lit_prefix: Vec<Key> = Vec::new();
         let mut var_depths: Vec<Vec<usize>> = vec![Vec::new(); query.num_vars()];
         for (depth, &c) in order.iter().enumerate() {
             match atom.terms[c] {
-                Term::Lit(x) => lit_prefix.push(x),
-                Term::Var(v) => var_depths[v].push(depth),
+                KeyTerm::Lit(x) => lit_prefix.push(x),
+                KeyTerm::Var(v) => var_depths[v].push(depth),
             }
         }
 
@@ -75,12 +82,7 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
             r = a.table.equal_range(depth, x, r.start, r.end);
         }
         if r.is_empty() {
-            return Ok(Relation::from_flat_rows(
-                "result",
-                query.head_names(),
-                query.head.len(),
-                &[],
-            ));
+            return Ok(Relation::empty("result", prepared.schema));
         }
         ranges.push(r);
     }
@@ -99,22 +101,19 @@ pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
         participants: &participants,
         query,
     };
-    let mut binding = vec![0u64; query.num_vars()];
-    let mut out: Vec<u64> = Vec::new();
+    let mut binding = vec![0 as Key; query.num_vars()];
+    let mut out: Vec<Key> = Vec::new();
     solver.solve(0, &mut ranges, &mut binding, &mut out);
 
-    Ok(
-        Relation::from_flat_rows("result", query.head_names(), query.head.len(), &out)
-            .sorted_dedup(),
-    )
+    Ok(Relation::from_flat_rows("result", prepared.schema, &out).sorted_dedup())
 }
 
 /// One atom, ready for execution: its sorted index plus the mapping from
 /// query variables to the index's sort depths.
 struct AtomExec<T: SortedTable> {
     table: T,
-    /// Values of the literal columns, by depth `0..lit_prefix.len()`.
-    lit_prefix: Vec<u64>,
+    /// Keys of the literal columns, by depth `0..lit_prefix.len()`.
+    lit_prefix: Vec<Key>,
     /// For each variable: the sort depths of its columns in this atom
     /// (adjacent by construction; empty if the variable does not occur).
     var_depths: Vec<Vec<usize>>,
@@ -133,8 +132,8 @@ impl<T: SortedTable> Solver<'_, T> {
         &self,
         v: VarId,
         ranges: &mut [Range<usize>],
-        binding: &mut [u64],
-        out: &mut Vec<u64>,
+        binding: &mut [Key],
+        out: &mut Vec<Key>,
     ) {
         if v == self.query.num_vars() {
             for &h in &self.query.head {
@@ -145,7 +144,7 @@ impl<T: SortedTable> Solver<'_, T> {
         let parts = &self.participants[v];
         debug_assert!(!parts.is_empty(), "validated: every var occurs somewhere");
 
-        let mut cand: u64 = 0;
+        let mut cand: Key = 0;
         loop {
             // Leapfrog: advance `cand` until every participating atom
             // contains it.
@@ -193,10 +192,12 @@ impl<T: SortedTable> Solver<'_, T> {
                 for (p, r) in saved {
                     ranges[p] = r;
                 }
-                if cand == u64::MAX {
+                // The key space is exhausted after the largest key, which
+                // a signed integer can legitimately encode to.
+                let Some(next) = cand.checked_add(1) else {
                     return;
-                }
-                cand += 1;
+                };
+                cand = next;
             }
         }
     }
@@ -205,7 +206,7 @@ impl<T: SortedTable> Solver<'_, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::query::Atom;
+    use crate::query::{Atom, Term};
 
     #[test]
     fn triangle_on_hand_built_graph() {
@@ -245,5 +246,36 @@ mod tests {
         assert_eq!(result.len(), 2);
         assert_eq!(result.row(0), vec![4]);
         assert_eq!(result.row(1), vec![7]);
+    }
+
+    #[test]
+    fn largest_key_terminates() {
+        // i64::MAX encodes to u64::MAX; the search must stop after it
+        // instead of wrapping around.
+        let mut cat = Catalog::new();
+        cat.insert_rows(
+            "T",
+            crate::types::Schema::new([crate::types::Column::new(
+                "a",
+                crate::types::ScalarType::Iint,
+            )]),
+            vec![vec![i64::MAX.into()], vec![i64::MIN.into()]],
+        )
+        .unwrap();
+        let q = Query {
+            var_names: vec!["x".into()],
+            atoms: vec![Atom {
+                relation: "T".into(),
+                terms: vec![Term::Var(0)],
+            }],
+            head: vec![0],
+        };
+        let result = execute(&q, &cat).unwrap();
+        assert_eq!(
+            (0..result.len())
+                .map(|i| result.value(i, 0, cat.dictionary()).unwrap())
+                .collect::<Vec<_>>(),
+            vec![i64::MIN.into(), i64::MAX.into()]
+        );
     }
 }

--- a/packages/coln-batch/src/io.rs
+++ b/packages/coln-batch/src/io.rs
@@ -8,6 +8,10 @@
 //! Hexane-backed indexes. The engine only depends on the
 //! [`crate::table::SortedTable`] trait, so swapping the substrate later
 //! does not touch the join code.
+//!
+//! Files hold decoded values (see [`Relation::to_record_batch`] for the
+//! Arrow types), so a relation saved from one catalog loads into any
+//! other; strings are re-interned into the loading catalog's dictionary.
 
 use std::fs::File;
 use std::path::Path;
@@ -17,10 +21,11 @@ use arrow::ipc::reader::FileReader;
 use arrow::ipc::writer::FileWriter;
 
 use crate::relation::Relation;
+use crate::types::Dictionary;
 
 /// Write a relation to `path` as a single-batch Arrow IPC file.
-pub fn save_relation(rel: &Relation, path: &Path) -> Result<()> {
-    let batch = rel.to_record_batch()?;
+pub fn save_relation(rel: &Relation, dict: &Dictionary, path: &Path) -> Result<()> {
+    let batch = rel.to_record_batch(dict)?;
     let file = File::create(path).with_context(|| format!("creating {}", path.display()))?;
     let schema = batch.schema();
     let mut writer = FileWriter::try_new(file, schema.as_ref())?;
@@ -31,12 +36,12 @@ pub fn save_relation(rel: &Relation, path: &Path) -> Result<()> {
 
 /// Read an Arrow IPC file back into a relation, concatenating all record
 /// batches in the file.
-pub fn load_relation(name: &str, path: &Path) -> Result<Relation> {
+pub fn load_relation(name: &str, path: &Path, dict: &mut Dictionary) -> Result<Relation> {
     let file = File::open(path).with_context(|| format!("opening {}", path.display()))?;
     let reader = FileReader::try_new(file, None)?;
     let mut result: Option<Relation> = None;
     for batch in reader {
-        let part = Relation::from_record_batch(name, &batch?)?;
+        let part = Relation::from_record_batch(name, &batch?, dict)?;
         match &mut result {
             None => result = Some(part),
             Some(acc) => {
@@ -64,12 +69,36 @@ mod tests {
     #[test]
     fn roundtrip_small() {
         let dir = tmp_dir();
+        let dict = Dictionary::new();
         let [f, g, h] = generate::triangle(1_000, 10_000, 100, 42);
         for rel in [&f, &g, &h] {
             let path = dir.join(format!("{}.arrow", rel.name));
-            save_relation(rel, &path).unwrap();
-            let back = load_relation(&rel.name, &path).unwrap();
+            save_relation(rel, &dict, &path).unwrap();
+            let back = load_relation(&rel.name, &path, &mut Dictionary::new()).unwrap();
             assert_eq!(rel, &back);
+        }
+    }
+
+    #[test]
+    fn roundtrip_typed() {
+        let dir = tmp_dir();
+        let mut dict = Dictionary::new();
+        let rel = generate::labeled_edges(20, 60, &["road", "rail"], 5, &mut dict);
+        let path = dir.join("labeled.arrow");
+        save_relation(&rel, &dict, &path).unwrap();
+
+        // Loading into a catalog whose dictionary already has other
+        // strings must reproduce the same values.
+        let mut other = Dictionary::new();
+        other.intern("unrelated");
+        let back = load_relation(&rel.name, &path, &mut other).unwrap();
+        assert_eq!(back.schema, rel.schema);
+        assert_eq!(back.len(), rel.len());
+        for i in 0..rel.len() {
+            assert_eq!(
+                back.row_values(i, &other).unwrap(),
+                rel.row_values(i, &dict).unwrap()
+            );
         }
     }
 
@@ -79,11 +108,12 @@ mod tests {
     #[ignore = "large; run explicitly (use --release)"]
     fn roundtrip_ten_million_rows() {
         let dir = tmp_dir();
+        let dict = Dictionary::new();
         let [f, _g, _h] = generate::triangle(10_000_000, 10_000_000, 100_000, 42);
         assert!(f.len() > 9_500_000, "got {}", f.len());
         let path = dir.join("R_f_10m.arrow");
-        save_relation(&f, &path).unwrap();
-        let back = load_relation("R_f", &path).unwrap();
+        save_relation(&f, &dict, &path).unwrap();
+        let back = load_relation("R_f", &path, &mut Dictionary::new()).unwrap();
         assert_eq!(f, back);
     }
 }

--- a/packages/coln-batch/src/lib.rs
+++ b/packages/coln-batch/src/lib.rs
@@ -6,19 +6,22 @@
 //!
 //! This crate is built bottom-up:
 //!
-//! 1. deterministic test-data generators for e-matching-style join
+//! 1. the value types ([`types`]): typed schemas and values at the
+//!    boundary, normalized `u64` keys inside, strings through a
+//!    dictionary,
+//! 2. deterministic test-data generators for e-matching-style join
 //!    workloads ([`generate`]),
-//! 2. Arrow IPC persistence for that test data ([`io`]),
-//! 3. the [`table::SortedTable`] interface through which the engine reads
+//! 3. Arrow IPC persistence for that test data ([`io`]),
+//! 4. the [`table::SortedTable`] interface through which the engine reads
 //!    relations, with an in-memory implementation built from Arrow data
 //!    ([`table::ArrowSortedTable`]),
-//! 4. conjunctive queries as data ([`query`], fixtures in [`fixtures`],
+//! 5. conjunctive queries as data ([`query`], fixtures in [`fixtures`],
 //!    a brute-force test oracle in [`reference`]),
-//! 5. two executors over the same query representation: a binary
+//! 6. two executors over the same query representation: a binary
 //!    hash-join chain ([`binary_join`]) and a worst-case-optimal generic
 //!    join ([`generic_join`]), differential-tested against each other and
 //!    against the oracle,
-//! 6. recursive Datalog: rules and programs ([`rule`]) evaluated to the
+//! 7. recursive Datalog: rules and programs ([`rule`]) evaluated to the
 //!    least fixpoint with semi-naive iteration ([`fixpoint`]), again
 //!    differential-tested (semi-naive vs. naive, per executor).
 
@@ -34,3 +37,4 @@ pub mod relation;
 pub mod rng;
 pub mod rule;
 pub mod table;
+pub mod types;

--- a/packages/coln-batch/src/query.rs
+++ b/packages/coln-batch/src/query.rs
@@ -7,27 +7,38 @@
 //! A [`Query`] is the engine's executable form of one rule body: a list of
 //! atoms over named relations, sharing variables. The shape deliberately
 //! mirrors FLIR (`Prop::Atom` ↔ [`Atom`], FLIR `Term` ↔ [`Term`]) without
-//! depending on it — FLIR is still stabilizing, so the adapter comes later
-//! and stays mechanical.
+//! depending on it, so the adapter from a plan stays mechanical.
 //!
 //! Example — the triangle query `Q(x,y,z) ← R_f(x,y), R_g(y,z), R_h(z,x)`
 //! is three atoms over two-column relations with variables x=0, y=1, z=2
 //! and head `[x, y, z]`. See [`crate::fixtures`] for ready-made instances.
+//!
+//! Queries are typed: a variable takes the type of the columns it stands
+//! in, all of which must agree, and a literal must match its column.
+//! [`Catalog::check`] establishes this and yields the result schema.
 
 use std::collections::HashMap;
 
 use anyhow::{Context, Result, bail};
 
 use crate::relation::Relation;
+use crate::types::{Column, Dictionary, Key, ScalarType, Schema, Value};
 
 /// A query variable, identified by its index. For the worst-case-optimal
 /// executor the variable numbering doubles as the elimination order
 pub type VarId = usize;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum Term {
     Var(VarId),
-    Lit(u64),
+    Lit(Value),
+}
+
+impl Term {
+    /// A literal term from any value type.
+    pub fn lit(value: impl Into<Value>) -> Self {
+        Term::Lit(value.into())
+    }
 }
 
 /// One occurrence of a relation in the query body. `terms` has one entry
@@ -92,10 +103,108 @@ impl Query {
     }
 }
 
-/// The data a query runs against: relations, addressed by name.
+/// The outcome of type-checking a query: one type per variable.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Typing {
+    pub var_types: Vec<ScalarType>,
+}
+
+impl Typing {
+    /// The schema of the query's result: the head variables with their
+    /// names and types.
+    pub fn head_schema(&self, query: &Query) -> Schema {
+        query
+            .head
+            .iter()
+            .map(|&v| Column::new(query.var_names[v].clone(), self.var_types[v]))
+            .collect()
+    }
+}
+
+/// Infer the type of every variable from the columns it stands in and
+/// check literals against their columns. `schema_of` resolves a relation
+/// name; a column of unknown type (`None`) constrains nothing.
+pub(crate) fn infer_var_types(
+    num_vars: usize,
+    atoms: &[Atom],
+    schema_of: impl Fn(&str) -> Result<Vec<Option<ScalarType>>>,
+) -> Result<Vec<Option<ScalarType>>> {
+    let mut var_types: Vec<Option<ScalarType>> = vec![None; num_vars];
+    let mut bound_at: Vec<Option<(String, usize)>> = vec![None; num_vars];
+    for atom in atoms {
+        let types = schema_of(&atom.relation)?;
+        if types.len() != atom.terms.len() {
+            bail!(
+                "atom over {} has {} terms, relation has arity {}",
+                atom.relation,
+                atom.terms.len(),
+                types.len()
+            );
+        }
+        for (c, (term, col_type)) in atom.terms.iter().zip(&types).enumerate() {
+            let Some(col_type) = *col_type else {
+                continue;
+            };
+            match term {
+                Term::Lit(value) => {
+                    if value.scalar_type() != col_type {
+                        bail!(
+                            "literal {value} has type {}, but column {c} of {} has type {col_type}",
+                            value.scalar_type(),
+                            atom.relation
+                        );
+                    }
+                }
+                Term::Var(v) => match var_types[*v] {
+                    None => {
+                        var_types[*v] = Some(col_type);
+                        bound_at[*v] = Some((atom.relation.clone(), c));
+                    }
+                    Some(known) if known != col_type => {
+                        let (rel, col) = bound_at[*v].clone().expect("recorded with the type");
+                        bail!(
+                            "variable {v} has type {known} from column {col} of {rel}, \
+                             but column {c} of {} has type {col_type}",
+                            atom.relation
+                        );
+                    }
+                    Some(_) => {}
+                },
+            }
+        }
+    }
+    Ok(var_types)
+}
+
+/// A term with its literal encoded to a key.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum KeyTerm {
+    Var(VarId),
+    Lit(Key),
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct KeyAtom {
+    pub relation: String,
+    pub terms: Vec<KeyTerm>,
+}
+
+/// A checked query with its literals encoded, ready to execute.
+pub(crate) struct Prepared {
+    /// Schema of the result.
+    pub schema: Schema,
+    /// The body with encoded literals, or `None` if a string literal is
+    /// unknown to the dictionary: no stored row can match it, so the
+    /// result is empty without looking at any data.
+    pub atoms: Option<Vec<KeyAtom>>,
+}
+
+/// The data a query runs against: relations, addressed by name, sharing
+/// one string [`Dictionary`].
 #[derive(Clone, Debug, Default)]
 pub struct Catalog {
     map: HashMap<String, Relation>,
+    dict: Dictionary,
 }
 
 impl Catalog {
@@ -104,8 +213,22 @@ impl Catalog {
     }
 
     /// Insert a relation under its own name, replacing any previous one.
+    /// The relation's string keys must stem from this catalog's dictionary.
     pub fn insert(&mut self, rel: Relation) {
         self.map.insert(rel.name.clone(), rel);
+    }
+
+    /// Encode typed rows into a new relation (sorted and deduplicated) and
+    /// insert it.
+    pub fn insert_rows(
+        &mut self,
+        name: impl Into<String>,
+        schema: Schema,
+        rows: impl IntoIterator<Item = Vec<Value>>,
+    ) -> Result<()> {
+        let rel = Relation::from_rows(name, schema, rows, &mut self.dict)?.sorted_dedup();
+        self.insert(rel);
+        Ok(())
     }
 
     pub fn get(&self, name: &str) -> Result<&Relation> {
@@ -114,22 +237,84 @@ impl Catalog {
             .with_context(|| format!("catalog has no relation named {name}"))
     }
 
-    /// Validate a query against this catalog: structure, relation
-    /// existence, and arity agreement.
-    pub fn check(&self, query: &Query) -> Result<()> {
+    pub fn contains(&self, name: &str) -> bool {
+        self.map.contains_key(name)
+    }
+
+    /// Names of all relations, sorted.
+    pub fn names(&self) -> Vec<&str> {
+        let mut names: Vec<&str> = self.map.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// The string dictionary shared by all relations.
+    pub fn dictionary(&self) -> &Dictionary {
+        &self.dict
+    }
+
+    pub fn dictionary_mut(&mut self) -> &mut Dictionary {
+        &mut self.dict
+    }
+
+    /// Decode a relation's rows (test and display helper).
+    pub fn rows_of(&self, name: &str) -> Result<Vec<Vec<Value>>> {
+        let rel = self.get(name)?;
+        (0..rel.len())
+            .map(|i| rel.row_values(i, &self.dict))
+            .collect()
+    }
+
+    /// Validate and type-check a query against this catalog: structure,
+    /// relation existence, arity agreement, and consistent types.
+    pub fn check(&self, query: &Query) -> Result<Typing> {
         query.validate()?;
+        let var_types = infer_var_types(query.num_vars(), &query.atoms, |name| {
+            Ok(self
+                .get(name)?
+                .schema
+                .types()
+                .into_iter()
+                .map(Some)
+                .collect())
+        })?;
+        let var_types = var_types
+            .into_iter()
+            .map(|t| t.expect("every variable occurs in some atom (validated)"))
+            .collect();
+        Ok(Typing { var_types })
+    }
+
+    /// Check the query and encode its literals.
+    pub(crate) fn prepare(&self, query: &Query) -> Result<Prepared> {
+        let typing = self.check(query)?;
+        let schema = typing.head_schema(query);
+        let mut atoms = Vec::with_capacity(query.atoms.len());
         for atom in &query.atoms {
-            let rel = self.get(&atom.relation)?;
-            if rel.arity() != atom.terms.len() {
-                bail!(
-                    "atom over {} has {} terms, relation has arity {}",
-                    atom.relation,
-                    atom.terms.len(),
-                    rel.arity()
-                );
+            let mut terms = Vec::with_capacity(atom.terms.len());
+            for term in &atom.terms {
+                terms.push(match term {
+                    Term::Var(v) => KeyTerm::Var(*v),
+                    Term::Lit(value) => match value.key_if_known(&self.dict) {
+                        Some(key) => KeyTerm::Lit(key),
+                        None => {
+                            return Ok(Prepared {
+                                schema,
+                                atoms: None,
+                            });
+                        }
+                    },
+                });
             }
+            atoms.push(KeyAtom {
+                relation: atom.relation.clone(),
+                terms,
+            });
         }
-        Ok(())
+        Ok(Prepared {
+            schema,
+            atoms: Some(atoms),
+        })
     }
 }
 
@@ -178,7 +363,7 @@ mod tests {
             var_names: vec!["x".into()],
             atoms: vec![Atom {
                 relation: "R".into(),
-                terms: vec![Term::Var(0), Term::Lit(2)],
+                terms: vec![Term::Var(0), Term::lit(2u64)],
             }],
             head: vec![0],
         };
@@ -191,5 +376,110 @@ mod tests {
         let mut wrong_arity = q.clone();
         wrong_arity.atoms[0].terms.pop();
         assert!(cat.check(&wrong_arity).is_err());
+    }
+
+    fn typed_catalog() -> Catalog {
+        let mut cat = Catalog::new();
+        cat.insert_rows(
+            "person",
+            Schema::new([
+                Column::new("id", ScalarType::Uint),
+                Column::new("name", ScalarType::String),
+                Column::new("age", ScalarType::Iint),
+            ]),
+            vec![vec![1u64.into(), "ann".into(), 30i64.into()]],
+        )
+        .unwrap();
+        cat.insert_rows(
+            "likes",
+            Schema::new([
+                Column::new("who", ScalarType::String),
+                Column::new("what", ScalarType::String),
+            ]),
+            vec![vec!["ann".into(), "tea".into()]],
+        )
+        .unwrap();
+        cat
+    }
+
+    #[test]
+    fn typing_follows_the_columns() {
+        let cat = typed_catalog();
+        // Q(id, what) ← person(id, name, 30), likes(name, what)
+        let q = Query {
+            var_names: vec!["id".into(), "name".into(), "what".into()],
+            atoms: vec![
+                Atom {
+                    relation: "person".into(),
+                    terms: vec![Term::Var(0), Term::Var(1), Term::lit(30i64)],
+                },
+                Atom {
+                    relation: "likes".into(),
+                    terms: vec![Term::Var(1), Term::Var(2)],
+                },
+            ],
+            head: vec![2, 0],
+        };
+        let typing = cat.check(&q).unwrap();
+        assert_eq!(
+            typing.var_types,
+            vec![ScalarType::Uint, ScalarType::String, ScalarType::String]
+        );
+        let schema = typing.head_schema(&q);
+        assert_eq!(schema.names(), vec!["what", "id"]);
+        assert_eq!(schema.types(), vec![ScalarType::String, ScalarType::Uint]);
+
+        let prepared = cat.prepare(&q).unwrap();
+        assert!(prepared.atoms.is_some());
+    }
+
+    #[test]
+    fn typing_rejects_mismatches() {
+        let cat = typed_catalog();
+        // A variable in a string column and a uint column.
+        let mixed = Query {
+            var_names: vec!["x".into()],
+            atoms: vec![
+                Atom {
+                    relation: "person".into(),
+                    terms: vec![Term::Var(0), Term::Var(0), Term::lit(30i64)],
+                },
+                Atom {
+                    relation: "likes".into(),
+                    terms: vec![Term::Var(0), Term::Var(0)],
+                },
+            ],
+            head: vec![0],
+        };
+        let err = cat.check(&mixed).unwrap_err().to_string();
+        assert!(err.contains("has type uint"), "{err}");
+
+        // A literal of the wrong type.
+        let bad_lit = Query {
+            var_names: vec!["x".into()],
+            atoms: vec![Atom {
+                relation: "person".into(),
+                terms: vec![Term::Var(0), Term::lit(7u64), Term::lit(30i64)],
+            }],
+            head: vec![0],
+        };
+        let err = cat.check(&bad_lit).unwrap_err().to_string();
+        assert!(err.contains("literal 7 has type uint"), "{err}");
+    }
+
+    #[test]
+    fn unknown_string_literal_is_unsatisfiable() {
+        let cat = typed_catalog();
+        let q = Query {
+            var_names: vec!["what".into()],
+            atoms: vec![Atom {
+                relation: "likes".into(),
+                terms: vec![Term::lit("nobody"), Term::Var(0)],
+            }],
+            head: vec![0],
+        };
+        let prepared = cat.prepare(&q).unwrap();
+        assert!(prepared.atoms.is_none());
+        assert_eq!(prepared.schema.types(), vec![ScalarType::String]);
     }
 }

--- a/packages/coln-batch/src/reference.rs
+++ b/packages/coln-batch/src/reference.rs
@@ -8,47 +8,49 @@
 //! Exponential in the number of atoms; intended only for small inputs,
 //! where it establishes ground truth for the real executors. The
 //! implementation is deliberately minimal so that its correctness can be
-//! verified by inspection.
+//! verified by inspection. It compares keys like the real executors;
+//! key equality is value equality within a column type.
 
 use anyhow::Result;
 
-use crate::query::{Catalog, Query, Term};
+use crate::query::{Catalog, KeyAtom, KeyTerm, Query};
 use crate::relation::Relation;
+use crate::types::Key;
 
 /// Evaluate `query` against `catalog` by exhaustive search. Returns the
 /// projected result, sorted and deduplicated (set semantics).
 pub fn execute(query: &Query, catalog: &Catalog) -> Result<Relation> {
-    catalog.check(query)?;
-    let tables: Vec<&Relation> = query
-        .atoms
+    let prepared = catalog.prepare(query)?;
+    let Some(atoms) = prepared.atoms else {
+        return Ok(Relation::empty("result", prepared.schema));
+    };
+    let tables: Vec<&Relation> = atoms
         .iter()
         .map(|a| catalog.get(&a.relation))
         .collect::<Result<_>>()?;
 
-    let mut binding: Vec<Option<u64>> = vec![None; query.num_vars()];
-    let mut out: Vec<u64> = Vec::new();
-    search(query, &tables, 0, &mut binding, &mut out);
+    let mut binding: Vec<Option<Key>> = vec![None; query.num_vars()];
+    let mut out: Vec<Key> = Vec::new();
+    search(query, &atoms, &tables, 0, &mut binding, &mut out);
 
-    Ok(
-        Relation::from_flat_rows("result", query.head_names(), query.head.len(), &out)
-            .sorted_dedup(),
-    )
+    Ok(Relation::from_flat_rows("result", prepared.schema, &out).sorted_dedup())
 }
 
 fn search(
     query: &Query,
+    atoms: &[KeyAtom],
     tables: &[&Relation],
     atom_idx: usize,
-    binding: &mut Vec<Option<u64>>,
-    out: &mut Vec<u64>,
+    binding: &mut Vec<Option<Key>>,
+    out: &mut Vec<Key>,
 ) {
-    if atom_idx == query.atoms.len() {
+    if atom_idx == atoms.len() {
         for &v in &query.head {
             out.push(binding[v].expect("head variable bound (validated)"));
         }
         return;
     }
-    let atom = &query.atoms[atom_idx];
+    let atom = &atoms[atom_idx];
     let table = tables[atom_idx];
     'rows: for r in 0..table.len() {
         // Try to unify this row with the atom's terms.
@@ -56,13 +58,13 @@ fn search(
         for (c, term) in atom.terms.iter().enumerate() {
             let value = table.cols[c][r];
             match term {
-                Term::Lit(l) => {
+                KeyTerm::Lit(l) => {
                     if value != *l {
                         undo(binding, &newly_bound);
                         continue 'rows;
                     }
                 }
-                Term::Var(v) => match binding[*v] {
+                KeyTerm::Var(v) => match binding[*v] {
                     Some(bound) => {
                         if value != bound {
                             undo(binding, &newly_bound);
@@ -76,12 +78,12 @@ fn search(
                 },
             }
         }
-        search(query, tables, atom_idx + 1, binding, out);
+        search(query, atoms, tables, atom_idx + 1, binding, out);
         undo(binding, &newly_bound);
     }
 }
 
-fn undo(binding: &mut [Option<u64>], newly_bound: &[usize]) {
+fn undo(binding: &mut [Option<Key>], newly_bound: &[usize]) {
     for &v in newly_bound {
         binding[v] = None;
     }

--- a/packages/coln-batch/src/relation.rs
+++ b/packages/coln-batch/src/relation.rs
@@ -2,38 +2,49 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-//! A named relation with `u64` columns.
+//! A named, typed relation stored as normalized keys.
 //!
-//! `Relation` is the engine's plain in-memory interchange type; Arrow
-//! `RecordBatch` is the serialization boundary (see [`crate::io`]). All
-//! values are `u64` for now: FLIR rows are row ids plus (eventually
-//! dictionary-encoded) literals, and `u64` keys are all the join machinery
-//! needs at this stage.
+//! `Relation` is the engine's plain in-memory interchange type: a
+//! [`Schema`] plus one `Vec<Key>` per column. Values are encoded on the
+//! way in ([`Relation::from_rows`]) and decoded on the way out
+//! ([`Relation::row_values`]), see [`crate::types`] for the encoding;
+//! everything in between compares keys. Arrow `RecordBatch` is the
+//! serialization boundary (see [`crate::io`]).
 
 use std::cmp::Ordering;
 use std::sync::Arc;
 
 use anyhow::{Context, Result, bail};
-use arrow::array::{Array, ArrayRef, UInt64Array};
-use arrow::datatypes::{DataType, Field, Schema};
+use arrow::array::{
+    Array, ArrayRef, BooleanArray, Int64Array, StringArray, UInt32Array, UInt64Array,
+};
+use arrow::datatypes::{DataType, Field, Schema as ArrowSchema};
 use arrow::record_batch::RecordBatch;
+
+use crate::types::{Column, Dictionary, Key, ScalarType, Schema, Value};
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Relation {
     pub name: String,
-    pub col_names: Vec<String>,
-    /// Column-major data; all columns have the same length.
-    pub cols: Vec<Vec<u64>>,
+    pub schema: Schema,
+    /// Column-major keys; all columns have the same length.
+    pub cols: Vec<Vec<Key>>,
 }
 
 impl Relation {
+    /// A relation of unsigned integer columns. Keys and values coincide
+    /// for this type, so `cols` holds the values themselves.
     pub fn new(
         name: impl Into<String>,
         col_names: impl IntoIterator<Item = impl Into<String>>,
-        cols: Vec<Vec<u64>>,
+        cols: Vec<Vec<Key>>,
     ) -> Self {
-        let col_names: Vec<String> = col_names.into_iter().map(Into::into).collect();
-        assert_eq!(col_names.len(), cols.len(), "one name per column");
+        Self::with_schema(name, Schema::uint(col_names), cols)
+    }
+
+    /// A relation over already encoded keys.
+    pub fn with_schema(name: impl Into<String>, schema: Schema, cols: Vec<Vec<Key>>) -> Self {
+        assert_eq!(schema.arity(), cols.len(), "one column per schema entry");
         if let Some(first) = cols.first() {
             assert!(
                 cols.iter().all(|c| c.len() == first.len()),
@@ -42,9 +53,47 @@ impl Relation {
         }
         Self {
             name: name.into(),
-            col_names,
+            schema,
             cols,
         }
+    }
+
+    /// An empty relation with the given schema.
+    pub fn empty(name: impl Into<String>, schema: Schema) -> Self {
+        let cols = vec![Vec::new(); schema.arity()];
+        Self::with_schema(name, schema, cols)
+    }
+
+    /// Encode typed rows. Every row must have one value per column, of
+    /// the column's type; strings are interned into `dict`.
+    pub fn from_rows(
+        name: impl Into<String>,
+        schema: Schema,
+        rows: impl IntoIterator<Item = Vec<Value>>,
+        dict: &mut Dictionary,
+    ) -> Result<Self> {
+        let name = name.into();
+        let mut cols: Vec<Vec<Key>> = vec![Vec::new(); schema.arity()];
+        for (i, row) in rows.into_iter().enumerate() {
+            if row.len() != schema.arity() {
+                bail!(
+                    "relation {name}, row {i}: {} values for {} columns",
+                    row.len(),
+                    schema.arity()
+                );
+            }
+            for (c, value) in row.iter().enumerate() {
+                let expected = schema.column_type(c);
+                if value.scalar_type() != expected {
+                    bail!(
+                        "relation {name}, row {i}, column {}: expected {expected}, got {value}",
+                        schema.name(c)
+                    );
+                }
+                cols[c].push(value.to_key(dict));
+            }
+        }
+        Ok(Self::with_schema(name, schema, cols))
     }
 
     /// Number of columns.
@@ -61,9 +110,24 @@ impl Relation {
         self.len() == 0
     }
 
-    /// The `i`-th row as a vector (test/debug helper).
-    pub fn row(&self, i: usize) -> Vec<u64> {
+    pub fn col_names(&self) -> Vec<String> {
+        self.schema.names()
+    }
+
+    /// The `i`-th row as keys.
+    pub fn row(&self, i: usize) -> Vec<Key> {
         self.cols.iter().map(|c| c[i]).collect()
+    }
+
+    /// One cell, decoded.
+    pub fn value(&self, row: usize, col: usize, dict: &Dictionary) -> Result<Value> {
+        Value::from_key(self.schema.column_type(col), self.cols[col][row], dict)
+            .with_context(|| format!("relation {}, column {}", self.name, self.schema.name(col)))
+    }
+
+    /// The `i`-th row, decoded.
+    pub fn row_values(&self, i: usize, dict: &Dictionary) -> Result<Vec<Value>> {
+        (0..self.arity()).map(|c| self.value(i, c, dict)).collect()
     }
 
     fn cmp_rows(&self, a: usize, b: usize) -> Ordering {
@@ -76,8 +140,9 @@ impl Relation {
         Ordering::Equal
     }
 
-    /// Sort rows lexicographically (all columns, left to right) and drop
-    /// duplicate rows. Relations are sets; generators may emit duplicates.
+    /// Sort rows lexicographically by key (all columns, left to right)
+    /// and drop duplicate rows. Relations are sets; generators may emit
+    /// duplicates.
     pub fn sorted_dedup(self) -> Self {
         let mut idx: Vec<usize> = (0..self.len()).collect();
         idx.sort_unstable_by(|&a, &b| self.cmp_rows(a, b));
@@ -89,18 +154,18 @@ impl Relation {
             .collect();
         Self {
             name: self.name,
-            col_names: self.col_names,
+            schema: self.schema,
             cols,
         }
     }
 
     /// Set union of two relations with the same arity. Both inputs must be
     /// sorted and deduplicated (as produced by [`Self::sorted_dedup`]); the
-    /// result keeps this relation's name and column names and is sorted and
+    /// result keeps this relation's name and schema and is sorted and
     /// deduplicated again.
     pub fn union(&self, other: &Relation) -> Relation {
         assert_eq!(self.arity(), other.arity(), "union needs equal arity");
-        let mut cols: Vec<Vec<u64>> = (0..self.arity())
+        let mut cols: Vec<Vec<Key>> = (0..self.arity())
             .map(|_| Vec::with_capacity(self.len() + other.len()))
             .collect();
         let mut push = |rel: &Relation, row: usize| {
@@ -134,14 +199,14 @@ impl Relation {
             push(other, j);
             j += 1;
         }
-        Relation::new(self.name.clone(), self.col_names.clone(), cols)
+        Relation::with_schema(self.name.clone(), self.schema.clone(), cols)
     }
 
     /// Rows of this relation that are absent from `other` (set difference).
     /// Both inputs must be sorted and deduplicated.
     pub fn minus(&self, other: &Relation) -> Relation {
         assert_eq!(self.arity(), other.arity(), "minus needs equal arity");
-        let mut cols: Vec<Vec<u64>> = (0..self.arity()).map(|_| Vec::new()).collect();
+        let mut cols: Vec<Vec<Key>> = (0..self.arity()).map(|_| Vec::new()).collect();
         let (mut i, mut j) = (0, 0);
         while i < self.len() {
             let keep = loop {
@@ -161,68 +226,175 @@ impl Relation {
             }
             i += 1;
         }
-        Relation::new(self.name.clone(), self.col_names.clone(), cols)
+        Relation::with_schema(self.name.clone(), self.schema.clone(), cols)
     }
 
-    /// Build a relation from row-major flat data (`width` values per row).
-    pub fn from_flat_rows(
-        name: impl Into<String>,
-        col_names: impl IntoIterator<Item = impl Into<String>>,
-        width: usize,
-        flat: &[u64],
-    ) -> Self {
+    /// Build a relation from row-major flat keys (`schema.arity()` values
+    /// per row).
+    pub fn from_flat_rows(name: impl Into<String>, schema: Schema, flat: &[Key]) -> Self {
+        let width = schema.arity();
         assert!(width > 0, "from_flat_rows needs at least one column");
         assert_eq!(flat.len() % width, 0, "flat data must be whole rows");
         let n = flat.len() / width;
-        let mut cols: Vec<Vec<u64>> = (0..width).map(|_| Vec::with_capacity(n)).collect();
+        let mut cols: Vec<Vec<Key>> = (0..width).map(|_| Vec::with_capacity(n)).collect();
         for row in flat.chunks_exact(width) {
             for (c, &x) in row.iter().enumerate() {
                 cols[c].push(x);
             }
         }
-        Self::new(name, col_names, cols)
+        Self::with_schema(name, schema, cols)
     }
 
-    pub fn to_record_batch(&self) -> Result<RecordBatch> {
-        let fields: Vec<Field> = self
-            .col_names
-            .iter()
-            .map(|n| Field::new(n, DataType::UInt64, false))
-            .collect();
-        let arrays: Vec<ArrayRef> = self
-            .cols
-            .iter()
-            .map(|c| Arc::new(UInt64Array::from(c.clone())) as ArrayRef)
-            .collect();
-        RecordBatch::try_new(Arc::new(Schema::new(fields)), arrays)
+    /// Decode into an Arrow batch: `Uint` becomes `UInt64`, `Iint`
+    /// `Int64`, `Bool` `Boolean`, `Char` `UInt32` (the scalar value) and
+    /// `String` `Utf8`.
+    pub fn to_record_batch(&self, dict: &Dictionary) -> Result<RecordBatch> {
+        let mut fields = Vec::with_capacity(self.arity());
+        let mut arrays: Vec<ArrayRef> = Vec::with_capacity(self.arity());
+        for (c, col) in self.schema.columns().iter().enumerate() {
+            let keys = &self.cols[c];
+            let (data_type, array): (DataType, ArrayRef) = match col.ty {
+                ScalarType::Uint => (DataType::UInt64, Arc::new(UInt64Array::from(keys.clone()))),
+                ScalarType::Iint => (
+                    DataType::Int64,
+                    Arc::new(Int64Array::from(
+                        keys.iter()
+                            .map(|&k| match Value::from_key(ScalarType::Iint, k, dict) {
+                                Ok(Value::Iint(i)) => i,
+                                _ => unreachable!("every key decodes as iint"),
+                            })
+                            .collect::<Vec<i64>>(),
+                    )),
+                ),
+                ScalarType::Bool => (
+                    DataType::Boolean,
+                    Arc::new(BooleanArray::from(
+                        keys.iter()
+                            .map(|&k| match Value::from_key(ScalarType::Bool, k, dict)? {
+                                Value::Bool(b) => Ok(b),
+                                _ => unreachable!(),
+                            })
+                            .collect::<Result<Vec<bool>>>()?,
+                    )),
+                ),
+                ScalarType::Char => (
+                    DataType::UInt32,
+                    Arc::new(UInt32Array::from(
+                        keys.iter()
+                            .map(|&k| match Value::from_key(ScalarType::Char, k, dict)? {
+                                Value::Char(ch) => Ok(u32::from(ch)),
+                                _ => unreachable!(),
+                            })
+                            .collect::<Result<Vec<u32>>>()?,
+                    )),
+                ),
+                ScalarType::String => (
+                    DataType::Utf8,
+                    Arc::new(StringArray::from(
+                        keys.iter()
+                            .map(|&k| {
+                                dict.string(k).map(str::to_owned).with_context(|| {
+                                    format!(
+                                        "relation {}, column {}: key {k} is not a dictionary code",
+                                        self.name, col.name
+                                    )
+                                })
+                            })
+                            .collect::<Result<Vec<String>>>()?,
+                    )),
+                ),
+            };
+            fields.push(Field::new(&col.name, data_type, false));
+            arrays.push(array);
+        }
+        RecordBatch::try_new(Arc::new(ArrowSchema::new(fields)), arrays)
             .with_context(|| format!("building record batch for relation {}", self.name))
     }
 
-    /// Convert an Arrow batch back into a `Relation`. All columns must be
-    /// non-nullable `UInt64`.
-    pub fn from_record_batch(name: impl Into<String>, batch: &RecordBatch) -> Result<Self> {
+    /// Encode an Arrow batch. Accepts the column types
+    /// [`Self::to_record_batch`] produces, all non-nullable; strings are
+    /// interned into `dict`.
+    pub fn from_record_batch(
+        name: impl Into<String>,
+        batch: &RecordBatch,
+        dict: &mut Dictionary,
+    ) -> Result<Self> {
         let name = name.into();
-        let mut col_names = Vec::new();
+        let mut columns = Vec::new();
         let mut cols = Vec::new();
         for (field, array) in batch.schema().fields().iter().zip(batch.columns()) {
-            let Some(array) = array.as_any().downcast_ref::<UInt64Array>() else {
-                bail!(
-                    "relation {name}, column {}: expected UInt64, got {}",
-                    field.name(),
-                    field.data_type()
-                );
-            };
             if array.null_count() > 0 {
                 bail!(
                     "relation {name}, column {}: nulls not supported",
                     field.name()
                 );
             }
-            col_names.push(field.name().clone());
-            cols.push(array.values().to_vec());
+            let (ty, keys): (ScalarType, Vec<Key>) = match field.data_type() {
+                DataType::UInt64 => (
+                    ScalarType::Uint,
+                    downcast::<UInt64Array>(array, &name, field.name())?
+                        .values()
+                        .to_vec(),
+                ),
+                DataType::Int64 => (
+                    ScalarType::Iint,
+                    downcast::<Int64Array>(array, &name, field.name())?
+                        .values()
+                        .iter()
+                        .map(|&i| Value::Iint(i).to_key(dict))
+                        .collect(),
+                ),
+                DataType::Boolean => (
+                    ScalarType::Bool,
+                    downcast::<BooleanArray>(array, &name, field.name())?
+                        .iter()
+                        .map(|b| u64::from(b.expect("no nulls")))
+                        .collect(),
+                ),
+                DataType::UInt32 => {
+                    let array = downcast::<UInt32Array>(array, &name, field.name())?;
+                    let mut keys = Vec::with_capacity(array.len());
+                    for &raw in array.values().iter() {
+                        let Some(ch) = char::from_u32(raw) else {
+                            bail!(
+                                "relation {name}, column {}: {raw} is not a character",
+                                field.name()
+                            );
+                        };
+                        keys.push(Value::Char(ch).to_key(dict));
+                    }
+                    (ScalarType::Char, keys)
+                }
+                DataType::Utf8 => (
+                    ScalarType::String,
+                    downcast::<StringArray>(array, &name, field.name())?
+                        .iter()
+                        .map(|s| dict.intern(s.expect("no nulls")))
+                        .collect(),
+                ),
+                other => bail!(
+                    "relation {name}, column {}: unsupported Arrow type {other}",
+                    field.name()
+                ),
+            };
+            columns.push(Column::new(field.name().clone(), ty));
+            cols.push(keys);
         }
-        Ok(Self::new(name, col_names, cols))
+        Ok(Self::with_schema(name, Schema::new(columns), cols))
     }
+}
+
+fn downcast<'a, T: Array + 'static>(
+    array: &'a ArrayRef,
+    relation: &str,
+    column: &str,
+) -> Result<&'a T> {
+    array.as_any().downcast_ref::<T>().with_context(|| {
+        format!(
+            "relation {relation}, column {column}: array does not match its declared type {}",
+            array.data_type()
+        )
+    })
 }
 
 /// Lexicographic comparison of row `i` of `a` with row `j` of `b`
@@ -267,11 +439,123 @@ mod tests {
         assert_eq!(r.row(2), vec![2, 10]);
     }
 
+    fn typed_schema() -> Schema {
+        Schema::new([
+            Column::new("id", ScalarType::Uint),
+            Column::new("delta", ScalarType::Iint),
+            Column::new("flag", ScalarType::Bool),
+            Column::new("initial", ScalarType::Char),
+            Column::new("name", ScalarType::String),
+        ])
+    }
+
+    fn typed_rows() -> Vec<Vec<Value>> {
+        vec![
+            vec![
+                1u64.into(),
+                (-5i64).into(),
+                true.into(),
+                'a'.into(),
+                "alice".into(),
+            ],
+            vec![
+                2u64.into(),
+                7i64.into(),
+                false.into(),
+                'b'.into(),
+                "bob".into(),
+            ],
+            vec![
+                3u64.into(),
+                0i64.into(),
+                true.into(),
+                'a'.into(),
+                "alice".into(),
+            ],
+        ]
+    }
+
     #[test]
-    fn record_batch_roundtrip() {
+    fn typed_rows_round_trip() {
+        let mut dict = Dictionary::new();
+        let rel = Relation::from_rows("people", typed_schema(), typed_rows(), &mut dict).unwrap();
+        assert_eq!(rel.len(), 3);
+        assert_eq!(dict.len(), 2, "two distinct names");
+        assert_eq!(rel.cols[4][0], rel.cols[4][2], "equal strings share a key");
+        for (i, row) in typed_rows().iter().enumerate() {
+            assert_eq!(&rel.row_values(i, &dict).unwrap(), row);
+        }
+        assert_eq!(rel.value(1, 1, &dict).unwrap(), Value::Iint(7));
+    }
+
+    #[test]
+    fn from_rows_checks_shape_and_types() {
+        let mut dict = Dictionary::new();
+        let short = vec![vec![1u64.into()]];
+        assert!(Relation::from_rows("p", typed_schema(), short, &mut dict).is_err());
+        let mut wrong = typed_rows();
+        wrong[0][1] = "not an int".into();
+        let err = Relation::from_rows("p", typed_schema(), wrong, &mut dict).unwrap_err();
+        assert!(err.to_string().contains("expected iint"), "{err}");
+    }
+
+    #[test]
+    fn record_batch_roundtrip_extremes() {
+        let mut dict = Dictionary::new();
+        let schema = typed_schema();
+        let rows = vec![
+            vec![
+                Value::Uint(u64::MAX),
+                Value::Iint(i64::MIN),
+                Value::Bool(false),
+                Value::Char('\0'),
+                Value::from(""),
+            ],
+            vec![
+                Value::Uint(0),
+                Value::Iint(i64::MAX),
+                Value::Bool(true),
+                Value::Char(char::MAX),
+                Value::from("日本語 ß \u{1F600}"),
+            ],
+        ];
+        let rel = Relation::from_rows("extremes", schema, rows.clone(), &mut dict).unwrap();
+        let batch = rel.to_record_batch(&dict).unwrap();
+        let mut fresh = Dictionary::new();
+        let back = Relation::from_record_batch("extremes", &batch, &mut fresh).unwrap();
+        for (i, row) in rows.iter().enumerate() {
+            assert_eq!(&back.row_values(i, &fresh).unwrap(), row);
+        }
+    }
+
+    #[test]
+    fn record_batch_roundtrip_uint() {
+        let dict = Dictionary::new();
         let r = Relation::new("r", ["x", "y"], vec![vec![1, 2, 3], vec![4, 5, 6]]);
-        let batch = r.to_record_batch().unwrap();
-        let back = Relation::from_record_batch("r", &batch).unwrap();
+        let batch = r.to_record_batch(&dict).unwrap();
+        let back = Relation::from_record_batch("r", &batch, &mut Dictionary::new()).unwrap();
         assert_eq!(r, back);
+    }
+
+    #[test]
+    fn record_batch_roundtrip_typed() {
+        let mut dict = Dictionary::new();
+        let rel = Relation::from_rows("people", typed_schema(), typed_rows(), &mut dict).unwrap();
+        let batch = rel.to_record_batch(&dict).unwrap();
+        assert_eq!(batch.schema().field(1).data_type(), &DataType::Int64);
+        assert_eq!(batch.schema().field(4).data_type(), &DataType::Utf8);
+
+        // Decoding into a fresh dictionary must yield the same values,
+        // even though the string codes may differ.
+        let mut other = Dictionary::new();
+        other.intern("zebra");
+        let back = Relation::from_record_batch("people", &batch, &mut other).unwrap();
+        assert_eq!(back.schema, rel.schema);
+        for i in 0..rel.len() {
+            assert_eq!(
+                back.row_values(i, &other).unwrap(),
+                rel.row_values(i, &dict).unwrap()
+            );
+        }
     }
 }

--- a/packages/coln-batch/src/rule.rs
+++ b/packages/coln-batch/src/rule.rs
@@ -13,13 +13,22 @@
 //! Relations that appear in some head are **IDB** (derived); all others
 //! are **EDB** (stored input). An IDB relation may also have initial
 //! facts in the catalog; they are treated as already-derived rows.
+//!
+//! Derived relations are typed like stored ones. Their schemas come from
+//! the catalog when initial facts exist (an empty relation with a schema
+//! is a plain declaration), otherwise they are inferred from the rules:
+//! a head variable has the type of the body columns it stands in, a head
+//! literal its own type. Inference iterates until every derived column is
+//! typed; a column no rule pins down is an error, resolved by declaring
+//! the relation in the catalog.
 
 use std::collections::BTreeMap;
 
 use anyhow::{Result, bail};
 
-use crate::query::{Atom, Catalog, Query, Term};
+use crate::query::{Atom, Catalog, Query, Term, infer_var_types};
 use crate::relation::Relation;
+use crate::types::{Column, Key, ScalarType, Schema};
 
 #[derive(Clone, Debug)]
 pub struct Rule {
@@ -44,14 +53,15 @@ pub(crate) fn delta_name(relation: &str) -> String {
 }
 
 /// One column of a rule head: either the k-th projected body variable or
-/// a literal value.
+/// a literal, encoded to its key.
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum HeadCol {
     Var(usize),
-    Lit(u64),
+    Lit(Key),
 }
 
 /// A rule lowered to an executable form.
+#[derive(Debug)]
 pub(crate) struct LoweredRule {
     /// The body as a query; its head projects the rule head's variables
     /// in order of occurrence.
@@ -72,7 +82,7 @@ impl LoweredRule {
     }
 
     /// Turn a body-query result into rows of the head relation.
-    pub fn materialize_head(&self, result: &Relation, col_names: &[String]) -> Relation {
+    pub fn materialize_head(&self, result: &Relation, schema: &Schema) -> Relation {
         let cols = self
             .head_cols
             .iter()
@@ -81,63 +91,145 @@ impl LoweredRule {
                 HeadCol::Lit(x) => vec![*x; result.len()],
             })
             .collect();
-        Relation::new(self.head_relation.clone(), col_names.to_vec(), cols).sorted_dedup()
+        Relation::with_schema(self.head_relation.clone(), schema.clone(), cols).sorted_dedup()
     }
 }
 
 /// A validated, lowered program, ready for fixpoint evaluation.
+#[derive(Debug)]
 pub(crate) struct CompiledProgram {
     pub rules: Vec<LoweredRule>,
-    /// IDB relation name → column names (from initial facts if present,
-    /// else from the first defining rule head).
-    pub idb_schemas: BTreeMap<String, Vec<String>>,
+    /// IDB relation name → schema (from initial facts if present, else
+    /// column names from the first defining rule head and inferred types).
+    pub idb_schemas: BTreeMap<String, Schema>,
+}
+
+/// A derived relation's schema while its types are being inferred.
+struct PartialSchema {
+    names: Vec<String>,
+    types: Vec<Option<ScalarType>>,
 }
 
 impl Program {
-    /// Validate against the EDB catalog and lower every rule.
-    pub(crate) fn compile(&self, edb: &Catalog) -> Result<CompiledProgram> {
+    /// Validate against the EDB catalog, infer the derived schemas, and
+    /// lower every rule. String literals are interned into the catalog's
+    /// dictionary, which is why the catalog is borrowed mutably.
+    pub(crate) fn compile(&self, edb: &mut Catalog) -> Result<CompiledProgram> {
         if self.rules.is_empty() {
             bail!("program has no rules");
         }
 
-        // Collect IDB schemas: arity from the heads, column names from
-        // initial facts or the first defining rule.
-        let mut idb_schemas: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        // Collect the derived relations: arity from the heads, column
+        // names and known types from initial facts or the first
+        // defining rule.
+        let mut partial: BTreeMap<String, PartialSchema> = BTreeMap::new();
         for rule in &self.rules {
             let name = &rule.head.relation;
             if name.starts_with(DELTA_PREFIX) {
                 bail!("relation name {name} uses the reserved prefix {DELTA_PREFIX}");
             }
-            let col_names: Vec<String> = if let Ok(initial) = edb.get(name) {
-                if initial.arity() != rule.head.terms.len() {
-                    bail!(
-                        "initial facts for {name} have arity {}, head has {}",
-                        initial.arity(),
-                        rule.head.terms.len()
-                    );
-                }
-                initial.col_names.clone()
-            } else {
-                rule.head
-                    .terms
-                    .iter()
-                    .enumerate()
-                    .map(|(i, t)| match t {
-                        Term::Var(v) => rule.var_names[*v].clone(),
-                        Term::Lit(_) => format!("c{i}"),
-                    })
-                    .collect()
-            };
-            if let Some(existing) = idb_schemas.get(name) {
-                if existing.len() != rule.head.terms.len() {
+            let arity = rule.head.terms.len();
+            if let Some(existing) = partial.get(name) {
+                if existing.names.len() != arity {
                     bail!("relation {name} is defined with inconsistent arities");
                 }
+                continue;
+            }
+            let schema = if let Ok(initial) = edb.get(name) {
+                if initial.arity() != arity {
+                    bail!(
+                        "initial facts for {name} have arity {}, head has {arity}",
+                        initial.arity()
+                    );
+                }
+                PartialSchema {
+                    names: initial.schema.names(),
+                    types: initial.schema.types().into_iter().map(Some).collect(),
+                }
             } else {
-                idb_schemas.insert(name.clone(), col_names);
+                PartialSchema {
+                    names: rule
+                        .head
+                        .terms
+                        .iter()
+                        .enumerate()
+                        .map(|(i, t)| match t {
+                            Term::Var(v) => rule.var_names[*v].clone(),
+                            Term::Lit(_) => format!("c{i}"),
+                        })
+                        .collect(),
+                    types: vec![None; arity],
+                }
+            };
+            partial.insert(name.clone(), schema);
+        }
+
+        // Infer derived column types until nothing changes. Each pass
+        // types every rule body against what is known so far and pushes
+        // the head's types into its relation.
+        loop {
+            let mut changed = false;
+            for rule in &self.rules {
+                let var_types = infer_var_types(rule.var_names.len(), &rule.body, |name| {
+                    if let Some(p) = partial.get(name) {
+                        Ok(p.types.clone())
+                    } else {
+                        Ok(edb
+                            .get(name)?
+                            .schema
+                            .types()
+                            .into_iter()
+                            .map(Some)
+                            .collect())
+                    }
+                })?;
+                let head = partial
+                    .get_mut(&rule.head.relation)
+                    .expect("collected above");
+                for (c, term) in rule.head.terms.iter().enumerate() {
+                    let ty = match term {
+                        Term::Var(v) => var_types[*v],
+                        Term::Lit(value) => Some(value.scalar_type()),
+                    };
+                    let Some(ty) = ty else { continue };
+                    match head.types[c] {
+                        None => {
+                            head.types[c] = Some(ty);
+                            changed = true;
+                        }
+                        Some(known) if known != ty => bail!(
+                            "column {} of {} is {known} but a rule derives it as {ty}",
+                            head.names[c],
+                            rule.head.relation
+                        ),
+                        Some(_) => {}
+                    }
+                }
+            }
+            if !changed {
+                break;
             }
         }
 
-        // Lower and validate each rule.
+        let mut idb_schemas: BTreeMap<String, Schema> = BTreeMap::new();
+        for (name, p) in &partial {
+            let columns: Vec<Column> = p
+                .names
+                .iter()
+                .zip(&p.types)
+                .map(|(col, ty)| match ty {
+                    Some(ty) => Ok(Column::new(col.clone(), *ty)),
+                    None => bail!(
+                        "cannot infer the type of column {col} of {name}: no rule derives it \
+                         from typed data; declare the relation in the catalog (an empty \
+                         relation with a schema suffices)"
+                    ),
+                })
+                .collect::<Result<_>>()?;
+            idb_schemas.insert(name.clone(), Schema::new(columns));
+        }
+
+        // Lower and validate each rule against the now complete schemas.
         let mut rules = Vec::with_capacity(self.rules.len());
         for rule in &self.rules {
             let mut head_vars = Vec::new();
@@ -148,7 +240,9 @@ impl Program {
                         head_cols.push(HeadCol::Var(head_vars.len()));
                         head_vars.push(*v);
                     }
-                    Term::Lit(x) => head_cols.push(HeadCol::Lit(*x)),
+                    Term::Lit(value) => {
+                        head_cols.push(HeadCol::Lit(value.to_key(edb.dictionary_mut())));
+                    }
                 }
             }
             if head_vars.is_empty() {
@@ -164,6 +258,25 @@ impl Program {
             };
             query.validate()?; // body non-empty, head vars appear in body, …
 
+            // Types of every body atom, derived and stored alike, are known
+            // now: check the body strictly.
+            infer_var_types(query.num_vars(), &query.atoms, |name| {
+                let schema = match idb_schemas.get(name) {
+                    Some(schema) => schema,
+                    None => &edb.get(name)?.schema,
+                };
+                Ok(schema.types().into_iter().map(Some).collect())
+            })?;
+
+            // Body literals are interned so the executors find their keys.
+            for atom in &query.atoms {
+                for term in &atom.terms {
+                    if let Term::Lit(value) = term {
+                        value.to_key(edb.dictionary_mut());
+                    }
+                }
+            }
+
             let mut idb_positions = Vec::new();
             for (i, atom) in rule.body.iter().enumerate() {
                 if atom.relation.starts_with(DELTA_PREFIX) {
@@ -174,26 +287,6 @@ impl Program {
                 }
                 if idb_schemas.contains_key(&atom.relation) {
                     idb_positions.push(i);
-                    // IDB arity check against the head-derived schema.
-                    if idb_schemas[&atom.relation].len() != atom.terms.len() {
-                        bail!(
-                            "atom over {} has {} terms, relation has arity {}",
-                            atom.relation,
-                            atom.terms.len(),
-                            idb_schemas[&atom.relation].len()
-                        );
-                    }
-                } else {
-                    // EDB: must exist in the catalog with matching arity.
-                    let rel = edb.get(&atom.relation)?;
-                    if rel.arity() != atom.terms.len() {
-                        bail!(
-                            "atom over {} has {} terms, relation has arity {}",
-                            atom.relation,
-                            atom.terms.len(),
-                            rel.arity()
-                        );
-                    }
                 }
             }
             rules.push(LoweredRule {
@@ -259,11 +352,13 @@ mod tests {
 
     #[test]
     fn compiles_ancestor() {
-        let compiled = ancestor_rules().compile(&edb()).unwrap();
+        let compiled = ancestor_rules().compile(&mut edb()).unwrap();
         assert_eq!(compiled.rules.len(), 2);
         assert_eq!(compiled.rules[0].idb_positions, Vec::<usize>::new());
         assert_eq!(compiled.rules[1].idb_positions, vec![1]);
-        assert_eq!(compiled.idb_schemas["ancestor"], vec!["x", "y"]);
+        let schema = &compiled.idb_schemas["ancestor"];
+        assert_eq!(schema.names(), vec!["x", "y"]);
+        assert_eq!(schema.types(), vec![ScalarType::Uint, ScalarType::Uint]);
     }
 
     #[test]
@@ -271,22 +366,181 @@ mod tests {
         // Unknown EDB relation.
         let mut p = ancestor_rules();
         p.rules[0].body[0].relation = "nope".into();
-        assert!(p.compile(&edb()).is_err());
+        assert!(p.compile(&mut edb()).is_err());
 
         // Head variable not bound in the body.
         let mut p = ancestor_rules();
         p.rules[0].head.terms[1] = Term::Var(1);
-        p.rules[0].body[0].terms[1] = Term::Lit(7);
-        assert!(p.compile(&edb()).is_err());
+        p.rules[0].body[0].terms[1] = Term::lit(7u64);
+        assert!(p.compile(&mut edb()).is_err());
 
         // Inconsistent IDB arity.
         let mut p = ancestor_rules();
         p.rules[1].head.terms.push(Term::Var(1));
-        assert!(p.compile(&edb()).is_err());
+        assert!(p.compile(&mut edb()).is_err());
 
         // Reserved prefix.
         let mut p = ancestor_rules();
         p.rules[0].head.relation = "__delta_ancestor".into();
-        assert!(p.compile(&edb()).is_err());
+        assert!(p.compile(&mut edb()).is_err());
+    }
+
+    fn typed_edb() -> Catalog {
+        let mut cat = Catalog::new();
+        cat.insert_rows(
+            "edge",
+            Schema::new([
+                Column::new("src", ScalarType::Uint),
+                Column::new("dst", ScalarType::Uint),
+                Column::new("label", ScalarType::String),
+            ]),
+            vec![vec![0u64.into(), 1u64.into(), "road".into()]],
+        )
+        .unwrap();
+        cat
+    }
+
+    /// reach(x, y, l) ← edge(x, y, l); reach(x, z, l) ← reach(x, y, l), edge(y, z, l)
+    fn labeled_reach() -> Program {
+        let (x, y, z, l) = (0, 1, 2, 3);
+        Program {
+            rules: vec![
+                Rule {
+                    var_names: vec!["x".into(), "y".into(), "l".into()],
+                    head: Atom {
+                        relation: "reach".into(),
+                        terms: vec![Term::Var(0), Term::Var(1), Term::Var(2)],
+                    },
+                    body: vec![Atom {
+                        relation: "edge".into(),
+                        terms: vec![Term::Var(0), Term::Var(1), Term::Var(2)],
+                    }],
+                },
+                Rule {
+                    var_names: vec!["x".into(), "y".into(), "z".into(), "l".into()],
+                    head: Atom {
+                        relation: "reach".into(),
+                        terms: vec![Term::Var(x), Term::Var(z), Term::Var(l)],
+                    },
+                    body: vec![
+                        Atom {
+                            relation: "reach".into(),
+                            terms: vec![Term::Var(x), Term::Var(y), Term::Var(l)],
+                        },
+                        Atom {
+                            relation: "edge".into(),
+                            terms: vec![Term::Var(y), Term::Var(z), Term::Var(l)],
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+    #[test]
+    fn infers_derived_types_through_recursion() {
+        let compiled = labeled_reach().compile(&mut typed_edb()).unwrap();
+        let schema = &compiled.idb_schemas["reach"];
+        assert_eq!(schema.names(), vec!["x", "y", "l"]);
+        assert_eq!(
+            schema.types(),
+            vec![ScalarType::Uint, ScalarType::Uint, ScalarType::String]
+        );
+    }
+
+    #[test]
+    fn infers_from_a_later_rule_and_interns_literals() {
+        // The first rule only mentions the derived relation; its types come
+        // from the second rule. The head literal "seed" enters the
+        // dictionary at compile time.
+        let mut program = labeled_reach();
+        program.rules.swap(0, 1);
+        program.rules[1].head.terms[2] = Term::lit("seed");
+        let mut edb = typed_edb();
+        let compiled = program.compile(&mut edb).unwrap();
+        assert_eq!(
+            compiled.idb_schemas["reach"].types(),
+            vec![ScalarType::Uint, ScalarType::Uint, ScalarType::String]
+        );
+        assert!(edb.dictionary().code("seed").is_some());
+        assert!(matches!(compiled.rules[1].head_cols[2], HeadCol::Lit(_)));
+    }
+
+    #[test]
+    fn rejects_type_conflicts_in_heads() {
+        // Second rule derives the label column as uint.
+        let mut program = labeled_reach();
+        program.rules[1].head.terms[2] = Term::lit(5u64);
+        let err = program.compile(&mut typed_edb()).unwrap_err().to_string();
+        assert!(
+            err.contains("is string but a rule derives it as uint"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn rejects_uninferable_columns_unless_declared() {
+        // p(x) ← p(x): nothing pins down the type of p.
+        let program = Program {
+            rules: vec![Rule {
+                var_names: vec!["x".into()],
+                head: Atom {
+                    relation: "p".into(),
+                    terms: vec![Term::Var(0)],
+                },
+                body: vec![Atom {
+                    relation: "p".into(),
+                    terms: vec![Term::Var(0)],
+                }],
+            }],
+        };
+        let err = program
+            .compile(&mut Catalog::new())
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("cannot infer the type"), "{err}");
+
+        // Declared through an empty relation in the catalog, it compiles.
+        let mut cat = Catalog::new();
+        cat.insert(Relation::empty(
+            "p",
+            Schema::new([Column::new("x", ScalarType::String)]),
+        ));
+        let compiled = program.compile(&mut cat).unwrap();
+        assert_eq!(compiled.idb_schemas["p"].types(), vec![ScalarType::String]);
+    }
+
+    #[test]
+    fn initial_facts_fix_the_schema() {
+        let mut cat = typed_edb();
+        cat.insert_rows(
+            "reach",
+            Schema::new([
+                Column::new("from", ScalarType::Uint),
+                Column::new("to", ScalarType::Uint),
+                Column::new("via", ScalarType::String),
+            ]),
+            vec![vec![7u64.into(), 8u64.into(), "rail".into()]],
+        )
+        .unwrap();
+        let compiled = labeled_reach().compile(&mut cat).unwrap();
+        assert_eq!(
+            compiled.idb_schemas["reach"].names(),
+            vec!["from", "to", "via"]
+        );
+
+        // Initial facts of the wrong type are a conflict.
+        let mut cat = typed_edb();
+        cat.insert_rows(
+            "reach",
+            Schema::uint(["from", "to", "via"]),
+            vec![vec![7u64.into(), 8u64.into(), 9u64.into()]],
+        )
+        .unwrap();
+        let err = labeled_reach().compile(&mut cat).unwrap_err().to_string();
+        assert!(
+            err.contains("is uint but a rule derives it as string"),
+            "{err}"
+        );
     }
 }

--- a/packages/coln-batch/src/table.rs
+++ b/packages/coln-batch/src/table.rs
@@ -10,6 +10,11 @@
 //! Anything that can answer its four required methods — the in-memory
 //! [`ArrowSortedTable`] below today, a Hexane-backed B-tree index later —
 //! can back the engine unchanged.
+//!
+//! Cells are exposed as **keys** (see [`crate::types`]): a `u64` per cell
+//! whose order is the natural order of the column's type, with strings
+//! standing in by dictionary code. The executors compare keys only; a
+//! back end serving typed values maps them to keys the same way.
 
 use std::cmp::Ordering;
 use std::ops::Range;
@@ -18,6 +23,7 @@ use anyhow::{Result, bail};
 use arrow::record_batch::RecordBatch;
 
 use crate::relation::Relation;
+use crate::types::{Dictionary, Key, Schema};
 
 /// Column id, in *schema* order (position in the relation's column list).
 pub type ColId = usize;
@@ -48,9 +54,9 @@ pub trait SortedTable {
         &[]
     }
 
-    /// Cell access. `row` is a position in *sorted* order (`0..len()`);
-    /// `col` is a column id in *schema* order.
-    fn value(&self, row: RowIdx, col: ColId) -> u64;
+    /// Cell access, as a key. `row` is a position in *sorted* order
+    /// (`0..len()`); `col` is a column id in *schema* order.
+    fn value(&self, row: RowIdx, col: ColId) -> Key;
 
     /// First position in `lo..hi` whose value in sort column `depth`
     /// (i.e. schema column `sort_order()[depth]`) is `>= v`.
@@ -62,7 +68,7 @@ pub trait SortedTable {
     /// The default is a binary search over [`Self::value`]; back ends with
     /// better means (galloping search, block statistics, B-tree descent)
     /// should override it.
-    fn lower_bound(&self, depth: usize, v: u64, lo: RowIdx, hi: RowIdx) -> RowIdx {
+    fn lower_bound(&self, depth: usize, v: Key, lo: RowIdx, hi: RowIdx) -> RowIdx {
         let col = self.sort_order()[depth];
         let (mut lo, mut hi) = (lo, hi);
         while lo < hi {
@@ -78,7 +84,7 @@ pub trait SortedTable {
 
     /// First position in `lo..hi` whose value in sort column `depth` is
     /// `> v`. Same precondition as [`Self::lower_bound`].
-    fn upper_bound(&self, depth: usize, v: u64, lo: RowIdx, hi: RowIdx) -> RowIdx {
+    fn upper_bound(&self, depth: usize, v: Key, lo: RowIdx, hi: RowIdx) -> RowIdx {
         let col = self.sort_order()[depth];
         let (mut lo, mut hi) = (lo, hi);
         while lo < hi {
@@ -95,7 +101,7 @@ pub trait SortedTable {
     /// The contiguous range of positions in `lo..hi` whose sort column
     /// `depth` equals `v` (empty, positioned at the insertion point, if
     /// `v` is absent). Same precondition as [`Self::lower_bound`].
-    fn equal_range(&self, depth: usize, v: u64, lo: RowIdx, hi: RowIdx) -> Range<RowIdx> {
+    fn equal_range(&self, depth: usize, v: Key, lo: RowIdx, hi: RowIdx) -> Range<RowIdx> {
         let start = self.lower_bound(depth, v, lo, hi);
         let end = self.upper_bound(depth, v, start, hi);
         start..end
@@ -103,13 +109,14 @@ pub trait SortedTable {
 }
 
 /// In-memory [`SortedTable`] built from Arrow data: sorts once at
-/// construction, then serves reads from plain `u64` column vectors.
+/// construction, then serves reads from plain key column vectors.
 #[derive(Clone, Debug)]
 pub struct ArrowSortedTable {
     name: String,
+    schema: Schema,
     sort_order: Vec<ColId>,
     /// Schema-ordered columns; rows are in sorted order.
-    cols: Vec<Vec<u64>>,
+    cols: Vec<Vec<Key>>,
 }
 
 impl ArrowSortedTable {
@@ -150,24 +157,32 @@ impl ArrowSortedTable {
             .collect();
         Ok(Self {
             name: rel.name.clone(),
+            schema: rel.schema.clone(),
             sort_order,
             cols,
         })
     }
 
-    /// Build directly from an Arrow batch (all columns non-nullable
-    /// `UInt64`).
+    /// Build directly from an Arrow batch (the column types
+    /// [`Relation::from_record_batch`] accepts); strings are interned
+    /// into `dict`.
     pub fn from_record_batch(
         name: impl Into<String>,
         batch: &RecordBatch,
         sort_order: Vec<ColId>,
+        dict: &mut Dictionary,
     ) -> Result<Self> {
-        let rel = Relation::from_record_batch(name, batch)?;
+        let rel = Relation::from_record_batch(name, batch, dict)?;
         Self::from_relation(&rel, sort_order)
     }
 
     pub fn name(&self) -> &str {
         &self.name
+    }
+
+    /// The column names and types, in schema order.
+    pub fn schema(&self) -> &Schema {
+        &self.schema
     }
 }
 
@@ -184,7 +199,7 @@ impl SortedTable for ArrowSortedTable {
         &self.sort_order
     }
 
-    fn value(&self, row: RowIdx, col: ColId) -> u64 {
+    fn value(&self, row: RowIdx, col: ColId) -> Key {
         self.cols[col][row]
     }
 }
@@ -214,7 +229,7 @@ pub fn check_contract<T: SortedTable>(t: &T) {
         for &c in key {
             assert!(c < arity, "primary key column {c} out of range");
         }
-        let mut tuples: Vec<Vec<u64>> = (0..t.len())
+        let mut tuples: Vec<Vec<Key>> = (0..t.len())
             .map(|r| key.iter().map(|&c| t.value(r, c)).collect())
             .collect();
         tuples.sort_unstable();
@@ -225,7 +240,7 @@ pub fn check_contract<T: SortedTable>(t: &T) {
             "rows must be unique under a declared primary key"
         );
     }
-    let sort_key = |row: RowIdx| -> Vec<u64> { order.iter().map(|&c| t.value(row, c)).collect() };
+    let sort_key = |row: RowIdx| -> Vec<Key> { order.iter().map(|&c| t.value(row, c)).collect() };
     for r in 1..t.len() {
         assert!(
             sort_key(r - 1) <= sort_key(r),
@@ -342,6 +357,17 @@ mod tests {
             check_contract(&ArrowSortedTable::from_relation(&rf, order).unwrap());
         }
         check_contract(&ArrowSortedTable::from_relation(&rg, vec![1, 0]).unwrap());
+    }
+
+    #[test]
+    fn contract_holds_on_typed_data() {
+        let mut dict = Dictionary::new();
+        let e = generate::labeled_edges(15, 120, &["road", "rail", "sea"], 13, &mut dict);
+        for order in [vec![0, 1, 2, 3], vec![2, 3, 0, 1], vec![3, 2, 1, 0]] {
+            let t = ArrowSortedTable::from_relation(&e, order).unwrap();
+            assert_eq!(t.schema(), &e.schema);
+            check_contract(&t);
+        }
     }
 
     #[test]

--- a/packages/coln-batch/src/types.rs
+++ b/packages/coln-batch/src/types.rs
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! The engine's value types.
+//!
+//! Every column has a [`ScalarType`] and every cell holds a [`Value`].
+//! Inside the engine a cell is stored as a **normalized key**: a `u64`
+//! whose order agrees with the natural order of the value's type. The
+//! join machinery only ever compares and sorts, so it runs on plain
+//! integers for every type alike; types matter at the boundary, where
+//! values are encoded on the way in and decoded on the way out. Decoding
+//! a key needs the column's type and, for strings, the [`Dictionary`]: a
+//! [`Relation`](crate::relation::Relation) carries the former, a
+//! [`Catalog`](crate::query::Catalog) owns the latter.
+//!
+//! Key encodings:
+//!
+//! | type     | key                                   | order preserved       |
+//! |----------|---------------------------------------|-----------------------|
+//! | `Uint`   | the value                             | yes                   |
+//! | `Iint`   | the value with its sign bit flipped   | yes                   |
+//! | `Bool`   | 0 or 1                                | yes                   |
+//! | `Char`   | the Unicode scalar value              | yes                   |
+//! | `String` | dictionary code, assigned on first use | no (insertion order) |
+//!
+//! String keys follow insertion order, not lexicographic order: a join
+//! needs equality only, and equality is what the dictionary preserves.
+//! Range predicates over strings would need an order-preserving
+//! dictionary; none are supported yet.
+
+use std::collections::HashMap;
+use std::fmt;
+
+use anyhow::{Result, bail};
+
+/// A cell as the engine stores it. See the module docs for the encoding.
+pub type Key = u64;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum ScalarType {
+    /// Unsigned 64-bit integer.
+    Uint,
+    /// Signed 64-bit integer.
+    Iint,
+    Bool,
+    /// One Unicode scalar value.
+    Char,
+    String,
+}
+
+impl fmt::Display for ScalarType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            ScalarType::Uint => "uint",
+            ScalarType::Iint => "iint",
+            ScalarType::Bool => "bool",
+            ScalarType::Char => "char",
+            ScalarType::String => "string",
+        })
+    }
+}
+
+/// A typed cell value at the engine's boundary.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Value {
+    Uint(u64),
+    Iint(i64),
+    Bool(bool),
+    Char(char),
+    String(String),
+}
+
+const SIGN_BIT: u64 = 1 << 63;
+
+impl Value {
+    pub fn scalar_type(&self) -> ScalarType {
+        match self {
+            Value::Uint(_) => ScalarType::Uint,
+            Value::Iint(_) => ScalarType::Iint,
+            Value::Bool(_) => ScalarType::Bool,
+            Value::Char(_) => ScalarType::Char,
+            Value::String(_) => ScalarType::String,
+        }
+    }
+
+    /// Encode into the key space, interning a string on first use.
+    pub fn to_key(&self, dict: &mut Dictionary) -> Key {
+        match self {
+            Value::String(s) => dict.intern(s),
+            other => other
+                .key_if_known(dict)
+                .expect("only strings depend on the dictionary"),
+        }
+    }
+
+    /// Encode without touching the dictionary. `None` for a string the
+    /// dictionary does not know: no stored cell can be equal to it.
+    pub fn key_if_known(&self, dict: &Dictionary) -> Option<Key> {
+        Some(match self {
+            Value::Uint(u) => *u,
+            Value::Iint(i) => (*i as u64) ^ SIGN_BIT,
+            Value::Bool(b) => u64::from(*b),
+            Value::Char(c) => u64::from(*c),
+            Value::String(s) => return dict.code(s),
+        })
+    }
+
+    /// Decode a key of type `ty`. Fails on keys no value of that type
+    /// encodes to, which indicates a mismatch between key and schema.
+    pub fn from_key(ty: ScalarType, key: Key, dict: &Dictionary) -> Result<Value> {
+        Ok(match ty {
+            ScalarType::Uint => Value::Uint(key),
+            ScalarType::Iint => Value::Iint((key ^ SIGN_BIT) as i64),
+            ScalarType::Bool => match key {
+                0 => Value::Bool(false),
+                1 => Value::Bool(true),
+                other => bail!("key {other} is not a boolean"),
+            },
+            ScalarType::Char => match u32::try_from(key).ok().and_then(char::from_u32) {
+                Some(c) => Value::Char(c),
+                None => bail!("key {key} is not a character"),
+            },
+            ScalarType::String => match dict.string(key) {
+                Some(s) => Value::String(s.to_owned()),
+                None => bail!("key {key} is not a dictionary code"),
+            },
+        })
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Uint(u) => write!(f, "{u}"),
+            Value::Iint(i) => write!(f, "{i}"),
+            Value::Bool(b) => write!(f, "{b}"),
+            Value::Char(c) => write!(f, "{c:?}"),
+            Value::String(s) => write!(f, "{s:?}"),
+        }
+    }
+}
+
+impl From<u64> for Value {
+    fn from(v: u64) -> Self {
+        Value::Uint(v)
+    }
+}
+
+impl From<i64> for Value {
+    fn from(v: i64) -> Self {
+        Value::Iint(v)
+    }
+}
+
+impl From<bool> for Value {
+    fn from(v: bool) -> Self {
+        Value::Bool(v)
+    }
+}
+
+impl From<char> for Value {
+    fn from(v: char) -> Self {
+        Value::Char(v)
+    }
+}
+
+impl From<&str> for Value {
+    fn from(v: &str) -> Self {
+        Value::String(v.to_owned())
+    }
+}
+
+impl From<String> for Value {
+    fn from(v: String) -> Self {
+        Value::String(v)
+    }
+}
+
+/// One column of a relation: its name and type.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Column {
+    pub name: String,
+    pub ty: ScalarType,
+}
+
+impl Column {
+    pub fn new(name: impl Into<String>, ty: ScalarType) -> Self {
+        Self {
+            name: name.into(),
+            ty,
+        }
+    }
+}
+
+/// The columns of a relation, in tuple order.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Schema {
+    columns: Vec<Column>,
+}
+
+impl Schema {
+    pub fn new(columns: impl IntoIterator<Item = Column>) -> Self {
+        Self {
+            columns: columns.into_iter().collect(),
+        }
+    }
+
+    /// A schema of unsigned integer columns with the given names.
+    pub fn uint(names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        Self::new(names.into_iter().map(|n| Column::new(n, ScalarType::Uint)))
+    }
+
+    /// Number of columns.
+    pub fn arity(&self) -> usize {
+        self.columns.len()
+    }
+
+    pub fn columns(&self) -> &[Column] {
+        &self.columns
+    }
+
+    pub fn name(&self, col: usize) -> &str {
+        &self.columns[col].name
+    }
+
+    pub fn column_type(&self, col: usize) -> ScalarType {
+        self.columns[col].ty
+    }
+
+    pub fn names(&self) -> Vec<String> {
+        self.columns.iter().map(|c| c.name.clone()).collect()
+    }
+
+    pub fn types(&self) -> Vec<ScalarType> {
+        self.columns.iter().map(|c| c.ty).collect()
+    }
+
+    /// The same columns with new names (types unchanged).
+    pub fn renamed(&self, names: impl IntoIterator<Item = impl Into<String>>) -> Self {
+        let columns: Vec<Column> = names
+            .into_iter()
+            .zip(&self.columns)
+            .map(|(name, c)| Column::new(name, c.ty))
+            .collect();
+        assert_eq!(columns.len(), self.arity(), "one name per column");
+        Self { columns }
+    }
+}
+
+impl FromIterator<Column> for Schema {
+    fn from_iter<I: IntoIterator<Item = Column>>(iter: I) -> Self {
+        Self::new(iter)
+    }
+}
+
+/// Stable string codes: every distinct string gets the next free code on
+/// first use and keeps it. Shared by all relations of a catalog, so a
+/// string column joins with any other string column by key equality.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Dictionary {
+    strings: Vec<String>,
+    codes: HashMap<String, Key>,
+}
+
+impl Dictionary {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The code of `s`, assigning a new one if the string is unknown.
+    pub fn intern(&mut self, s: &str) -> Key {
+        if let Some(&code) = self.codes.get(s) {
+            return code;
+        }
+        let code = self.strings.len() as Key;
+        self.strings.push(s.to_owned());
+        self.codes.insert(s.to_owned(), code);
+        code
+    }
+
+    /// The code of `s`, if it has one.
+    pub fn code(&self, s: &str) -> Option<Key> {
+        self.codes.get(s).copied()
+    }
+
+    /// The string behind `code`, if the code exists.
+    pub fn string(&self, code: Key) -> Option<&str> {
+        usize::try_from(code)
+            .ok()
+            .and_then(|i| self.strings.get(i))
+            .map(String::as_str)
+    }
+
+    /// Number of distinct strings.
+    pub fn len(&self) -> usize {
+        self.strings.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.strings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_type_round_trips() {
+        let mut dict = Dictionary::new();
+        let values = [
+            Value::Uint(0),
+            Value::Uint(u64::MAX),
+            Value::Iint(i64::MIN),
+            Value::Iint(-1),
+            Value::Iint(0),
+            Value::Iint(i64::MAX),
+            Value::Bool(false),
+            Value::Bool(true),
+            Value::Char('a'),
+            Value::Char('\u{10FFFF}'),
+            Value::from("alpha"),
+            Value::from(""),
+        ];
+        for v in &values {
+            let key = v.to_key(&mut dict);
+            let back = Value::from_key(v.scalar_type(), key, &dict).unwrap();
+            assert_eq!(&back, v);
+        }
+    }
+
+    #[test]
+    fn integer_keys_preserve_order() {
+        let dict = Dictionary::new();
+        let ints = [i64::MIN, -1_000, -1, 0, 1, 1_000, i64::MAX];
+        let keys: Vec<Key> = ints
+            .iter()
+            .map(|&i| Value::Iint(i).key_if_known(&dict).unwrap())
+            .collect();
+        assert!(keys.windows(2).all(|w| w[0] < w[1]), "{keys:?}");
+        assert!(Value::Bool(false).key_if_known(&dict) < Value::Bool(true).key_if_known(&dict));
+        assert!(Value::Char('a').key_if_known(&dict) < Value::Char('b').key_if_known(&dict));
+    }
+
+    #[test]
+    fn dictionary_codes_are_stable_and_shared() {
+        let mut dict = Dictionary::new();
+        let a = dict.intern("a");
+        let b = dict.intern("b");
+        assert_ne!(a, b);
+        assert_eq!(dict.intern("a"), a, "re-interning keeps the code");
+        assert_eq!(dict.code("b"), Some(b));
+        assert_eq!(dict.code("c"), None);
+        assert_eq!(dict.string(a), Some("a"));
+        assert_eq!(dict.string(99), None);
+        assert_eq!(Value::from("c").key_if_known(&dict), None);
+        assert_eq!(dict.len(), 2);
+    }
+
+    #[test]
+    fn decoding_rejects_keys_outside_the_type() {
+        let dict = Dictionary::new();
+        assert!(Value::from_key(ScalarType::Bool, 2, &dict).is_err());
+        assert!(Value::from_key(ScalarType::Char, 0xD800, &dict).is_err());
+        assert!(Value::from_key(ScalarType::String, 0, &dict).is_err());
+    }
+
+    #[test]
+    fn schema_helpers() {
+        let s = Schema::new([
+            Column::new("id", ScalarType::Uint),
+            Column::new("name", ScalarType::String),
+        ]);
+        assert_eq!(s.arity(), 2);
+        assert_eq!(s.names(), vec!["id", "name"]);
+        assert_eq!(s.column_type(1), ScalarType::String);
+        let r = s.renamed(["a", "b"]);
+        assert_eq!(r.name(0), "a");
+        assert_eq!(r.types(), s.types());
+        assert_eq!(Schema::uint(["x"]).column_type(0), ScalarType::Uint);
+    }
+}

--- a/packages/coln-batch/tests/differential.rs
+++ b/packages/coln-batch/tests/differential.rs
@@ -7,6 +7,7 @@
 
 use coln_batch::query::{Atom, Catalog, Query, Term};
 use coln_batch::relation::Relation;
+use coln_batch::types::{Column, ScalarType, Schema, Value};
 use coln_batch::{binary_join, fixtures, generic_join, reference};
 
 /// Run all three executors and require identical results.
@@ -71,7 +72,7 @@ fn hand_cases() {
     // Literal filter: Q(y) ← R(1, y)
     let lit = Query {
         var_names: vec!["y".into()],
-        atoms: vec![atom("R", vec![Term::Lit(1), Term::Var(0)])],
+        atoms: vec![atom("R", vec![Term::lit(1u64), Term::Var(0)])],
         head: vec![0],
     };
     let r = agree_with_oracle(&lit, &cat);
@@ -80,7 +81,7 @@ fn hand_cases() {
     // Literal miss: Q(y) ← R(9, y)
     let miss = Query {
         var_names: vec!["y".into()],
-        atoms: vec![atom("R", vec![Term::Lit(9), Term::Var(0)])],
+        atoms: vec![atom("R", vec![Term::lit(9u64), Term::Var(0)])],
         head: vec![0],
     };
     assert_eq!(agree_with_oracle(&miss, &cat).len(), 0);
@@ -108,7 +109,7 @@ fn hand_cases() {
         var_names: vec!["x".into()],
         atoms: vec![
             atom("U", vec![Term::Var(0)]),
-            atom("S", vec![Term::Lit(9), Term::Lit(9)]),
+            atom("S", vec![Term::lit(9u64), Term::lit(9u64)]),
         ],
         head: vec![0],
     };
@@ -117,7 +118,7 @@ fn hand_cases() {
         var_names: vec!["x".into()],
         atoms: vec![
             atom("U", vec![Term::Var(0)]),
-            atom("S", vec![Term::Lit(9), Term::Lit(8)]),
+            atom("S", vec![Term::lit(9u64), Term::lit(8u64)]),
         ],
         head: vec![0],
     };
@@ -239,6 +240,199 @@ fn fixtures_large_executors_agree() {
         eprintln!(
             "{name}: {} rows, binary join {t_binary:.2?}, generic join {t_generic:.2?}",
             binary.len()
+        );
+    }
+}
+
+/// Decoded rows of a result, sorted by value for order-independent
+/// comparison.
+fn decoded(result: &Relation, catalog: &Catalog) -> Vec<Vec<Value>> {
+    let mut rows: Vec<Vec<Value>> = (0..result.len())
+        .map(|i| result.row_values(i, catalog.dictionary()).unwrap())
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn typed_catalog() -> Catalog {
+    let mut cat = Catalog::new();
+    cat.insert_rows(
+        "person",
+        Schema::new([
+            Column::new("id", ScalarType::Uint),
+            Column::new("name", ScalarType::String),
+            Column::new("age", ScalarType::Iint),
+            Column::new("active", ScalarType::Bool),
+            Column::new("initial", ScalarType::Char),
+        ]),
+        vec![
+            vec![
+                1u64.into(),
+                "ann".into(),
+                (-5i64).into(),
+                true.into(),
+                'a'.into(),
+            ],
+            vec![
+                2u64.into(),
+                "bob".into(),
+                30i64.into(),
+                false.into(),
+                'b'.into(),
+            ],
+            vec![
+                3u64.into(),
+                "ann".into(),
+                7i64.into(),
+                true.into(),
+                'a'.into(),
+            ],
+        ],
+    )
+    .unwrap();
+    cat.insert_rows(
+        "likes",
+        Schema::new([
+            Column::new("who", ScalarType::String),
+            Column::new("what", ScalarType::String),
+        ]),
+        vec![
+            vec!["ann".into(), "tea".into()],
+            vec!["bob".into(), "tea".into()],
+            vec!["ann".into(), "jazz".into()],
+        ],
+    )
+    .unwrap();
+    cat
+}
+
+#[test]
+fn typed_hand_cases() {
+    let cat = typed_catalog();
+    let (id, name, age, active, initial, what) = (0, 1, 2, 3, 4, 5);
+    let person = |terms: Vec<Term>| atom("person", terms);
+    let all_vars = || {
+        vec![
+            Term::Var(id),
+            Term::Var(name),
+            Term::Var(age),
+            Term::Var(active),
+            Term::Var(initial),
+        ]
+    };
+
+    // Join on a string column: Q(id, what) ← person(id, name, …), likes(name, what)
+    let join = Query {
+        var_names: ["id", "name", "age", "active", "initial", "what"]
+            .into_iter()
+            .map(String::from)
+            .collect(),
+        atoms: vec![
+            person(all_vars()),
+            atom("likes", vec![Term::Var(name), Term::Var(what)]),
+        ],
+        head: vec![id, what],
+    };
+    let r = agree_with_oracle(&join, &cat);
+    assert_eq!(r.schema.types(), vec![ScalarType::Uint, ScalarType::String]);
+    let mut expected: Vec<Vec<Value>> = vec![
+        vec![1u64.into(), "tea".into()],
+        vec![1u64.into(), "jazz".into()],
+        vec![2u64.into(), "tea".into()],
+        vec![3u64.into(), "tea".into()],
+        vec![3u64.into(), "jazz".into()],
+    ];
+    expected.sort();
+    assert_eq!(decoded(&r, &cat), expected);
+
+    // Literals of every type, one per column of person; all other
+    // columns are distinct variables, the head is the id.
+    let with_literal = |col: usize, lit: Term| -> Query {
+        let mut next = 0;
+        let terms: Vec<Term> = (0..5)
+            .map(|c| {
+                if c == col {
+                    lit.clone()
+                } else {
+                    next += 1;
+                    Term::Var(next - 1)
+                }
+            })
+            .collect();
+        Query {
+            var_names: (0..next).map(|v| format!("v{v}")).collect(),
+            atoms: vec![person(terms)],
+            head: vec![0],
+        }
+    };
+    let ids = |q: &Query| decoded(&agree_with_oracle(q, &cat), &cat);
+    assert_eq!(
+        ids(&with_literal(2, Term::lit(-5i64))),
+        vec![vec![1u64.into()]]
+    );
+    assert_eq!(
+        ids(&with_literal(3, Term::lit(true))),
+        vec![vec![1u64.into()], vec![3u64.into()]]
+    );
+    assert_eq!(
+        ids(&with_literal(4, Term::lit('b'))),
+        vec![vec![2u64.into()]]
+    );
+    assert_eq!(
+        ids(&with_literal(1, Term::lit("ann"))),
+        vec![vec![1u64.into()], vec![3u64.into()]]
+    );
+
+    // A string the dictionary has never seen matches nothing.
+    let r = agree_with_oracle(&with_literal(1, Term::lit("zed")), &cat);
+    assert!(r.is_empty());
+    assert_eq!(r.schema.types(), vec![ScalarType::Uint]);
+}
+
+#[test]
+fn typed_errors_are_reported_by_every_executor() {
+    let cat = typed_catalog();
+    // x stands in a uint column and a string column.
+    let mixed = Query {
+        var_names: vec!["x".into(), "a".into(), "b".into(), "c".into()],
+        atoms: vec![atom(
+            "person",
+            vec![
+                Term::Var(0),
+                Term::Var(0),
+                Term::Var(1),
+                Term::Var(2),
+                Term::Var(3),
+            ],
+        )],
+        head: vec![0],
+    };
+    // A literal of the wrong type.
+    let bad_lit = Query {
+        var_names: vec!["who".into()],
+        atoms: vec![atom("likes", vec![Term::Var(0), Term::lit(3u64)])],
+        head: vec![0],
+    };
+    for query in [&mixed, &bad_lit] {
+        assert!(reference::execute(query, &cat).is_err());
+        assert!(binary_join::execute(query, &cat).is_err());
+        assert!(generic_join::execute(query, &cat).is_err());
+    }
+}
+
+#[test]
+fn labeled_fixture_vs_oracle() {
+    let cat = fixtures::labeled_catalog(12, 80, &["road", "rail", "sea"], 3);
+    let r = agree_with_oracle(&fixtures::labeled_two_hop_query(), &cat);
+    assert!(!r.is_empty(), "two hops with equal labels should exist");
+    assert_eq!(
+        r.schema.types(),
+        vec![ScalarType::Uint, ScalarType::Uint, ScalarType::String]
+    );
+    // Every result row decodes, and its label is one of the generator's.
+    for row in decoded(&r, &cat) {
+        assert!(
+            matches!(&row[2], Value::String(s) if ["road", "rail", "sea"].contains(&s.as_str()))
         );
     }
 }

--- a/packages/coln-batch/tests/fixpoint.rs
+++ b/packages/coln-batch/tests/fixpoint.rs
@@ -10,7 +10,8 @@ use coln_batch::fixpoint::{self, Exec};
 use coln_batch::query::{Atom, Catalog, Term};
 use coln_batch::relation::Relation;
 use coln_batch::rule::{Program, Rule};
-use coln_batch::{binary_join, fixtures, generic_join, reference};
+use coln_batch::types::Value;
+use coln_batch::{binary_join, fixtures, generate, generic_join, reference};
 
 /// Run the program under every (strategy × executor) combination and
 /// require identical IDB results; returns the semi-naive/generic one.
@@ -140,7 +141,7 @@ fn head_literals_work() {
             var_names: vec!["x".into(), "y".into()],
             head: Atom {
                 relation: "flagged".into(),
-                terms: vec![Term::Var(0), Term::Lit(1)],
+                terms: vec![Term::Var(0), Term::lit(1u64)],
             },
             body: vec![Atom {
                 relation: "parent".into(),
@@ -395,4 +396,64 @@ fn long_chain_exact_closure() {
     assert_eq!(result.stats.rounds as u64, k);
 
     agree(&program, &edb, &["ancestor"]);
+}
+
+#[test]
+fn labeled_reachability_is_typed() {
+    // Reachability along edges of one label; derived rows carry the
+    // label as a string column.
+    let mut edb = Catalog::new();
+    edb.insert_rows(
+        "edge",
+        generate::labeled_edges_schema(),
+        vec![
+            vec![0u64.into(), 1u64.into(), "road".into(), 1i64.into()],
+            vec![1u64.into(), 2u64.into(), "road".into(), (-2i64).into()],
+            vec![2u64.into(), 3u64.into(), "rail".into(), 5i64.into()],
+            vec![1u64.into(), 3u64.into(), "rail".into(), 0i64.into()],
+        ],
+    )
+    .unwrap();
+    let program = fixtures::labeled_reach_program();
+    let result = agree(&program, &edb, &["reach"]);
+
+    let mut got = result.rows_of("reach").unwrap();
+    got.sort();
+    let mut expected: Vec<Vec<Value>> = vec![
+        vec![0u64.into(), 1u64.into(), "road".into()],
+        vec![1u64.into(), 2u64.into(), "road".into()],
+        vec![0u64.into(), 2u64.into(), "road".into()],
+        vec![2u64.into(), 3u64.into(), "rail".into()],
+        vec![1u64.into(), 3u64.into(), "rail".into()],
+    ];
+    expected.sort();
+    assert_eq!(got, expected);
+}
+
+#[test]
+fn head_literals_can_be_strings() {
+    // tagged(x, "seen") ← parent(x, y): the head literal enters the
+    // dictionary at compile time and decodes on the way out.
+    let program = Program {
+        rules: vec![Rule {
+            var_names: vec!["x".into(), "y".into()],
+            head: Atom {
+                relation: "tagged".into(),
+                terms: vec![Term::Var(0), Term::lit("seen")],
+            },
+            body: vec![Atom {
+                relation: "parent".into(),
+                terms: vec![Term::Var(0), Term::Var(1)],
+            }],
+        }],
+    };
+    let edb = fixtures::ancestor_chain_catalog(3);
+    let result = agree(&program, &edb, &["tagged"]);
+    assert_eq!(
+        result.rows_of("tagged").unwrap(),
+        vec![
+            vec![Value::Uint(0), "seen".into()],
+            vec![Value::Uint(1), "seen".into()],
+        ]
+    );
 }

--- a/packages/coln-batch/tests/random_programs.rs
+++ b/packages/coln-batch/tests/random_programs.rs
@@ -5,7 +5,12 @@
 //! Randomized differential testing for recursion: generated Datalog
 //! programs over generated data, evaluated with every strategy and
 //! executor combination. All four runs must agree on every derived
-//! relation. Termination is guaranteed by the tiny value domain.
+//! relation. Termination is guaranteed by the tiny value domains.
+//!
+//! Relations carry random column types and rules are generated
+//! well-typed; every derived relation is declared in the catalog (an
+//! empty relation with a schema), as a plan would declare it, because a
+//! random program may define a relation only in terms of itself.
 //!
 //! Same reproducibility scheme as `tests/random_queries.rs`: each case
 //! seeds its own [`SplitMix64`], so a failing case number reproduces in
@@ -16,106 +21,164 @@ use coln_batch::query::{Atom, Catalog, Term};
 use coln_batch::relation::Relation;
 use coln_batch::rng::SplitMix64;
 use coln_batch::rule::{Program, Rule};
+use coln_batch::types::{Column, ScalarType, Schema, Value};
 use coln_batch::{binary_join, generic_join};
 
 const CASES: u64 = 150;
-/// Values are drawn from `0..DOMAIN`, small so joins hit often and every
-/// closure stays finite and small.
+/// Unsigned values are drawn from `0..DOMAIN`, small so joins hit often
+/// and every closure stays finite and small.
 const DOMAIN: u64 = 6;
+const WORDS: [&str; 4] = ["ant", "bee", "cat", "dog"];
+const TYPES: [ScalarType; 5] = [
+    ScalarType::Uint,
+    ScalarType::Iint,
+    ScalarType::String,
+    ScalarType::Bool,
+    ScalarType::Char,
+];
+
+fn random_value(rng: &mut SplitMix64, ty: ScalarType) -> Value {
+    match ty {
+        ScalarType::Uint => Value::Uint(rng.below(DOMAIN)),
+        ScalarType::Iint => Value::Iint(rng.below(DOMAIN) as i64 - 3),
+        ScalarType::String => Value::from(WORDS[rng.below(WORDS.len() as u64) as usize]),
+        ScalarType::Bool => Value::Bool(rng.below(2) == 1),
+        ScalarType::Char => Value::Char(char::from(b'a' + rng.below(3) as u8)),
+    }
+}
+
+/// A random schema of `arity` columns whose first column is `uint`, so
+/// every relation offers a variable for a rule head.
+fn random_schema(rng: &mut SplitMix64, arity: usize) -> Schema {
+    Schema::new((0..arity).map(|c| {
+        let ty = if c == 0 {
+            ScalarType::Uint
+        } else {
+            TYPES[rng.below(TYPES.len() as u64) as usize]
+        };
+        Column::new(format!("c{c}"), ty)
+    }))
+}
+
+fn random_rows(rng: &mut SplitMix64, schema: &Schema, max_rows: u64) -> Vec<Vec<Value>> {
+    (0..rng.below(max_rows + 1))
+        .map(|_| {
+            schema
+                .types()
+                .into_iter()
+                .map(|ty| random_value(rng, ty))
+                .collect()
+        })
+        .collect()
+}
 
 /// 1..=2 stored relations, arity 1..=2, 0..=10 rows each.
-fn random_edb(rng: &mut SplitMix64) -> (Catalog, Vec<(String, usize)>) {
+fn random_edb(rng: &mut SplitMix64) -> (Catalog, Vec<(String, Schema)>) {
     let mut cat = Catalog::new();
     let mut rels = Vec::new();
     for r in 0..1 + rng.below(2) {
         let arity = 1 + rng.below(2) as usize;
-        let rows = rng.below(11);
-        let mut cols: Vec<Vec<u64>> = vec![Vec::new(); arity];
-        for _ in 0..rows {
-            for col in cols.iter_mut() {
-                col.push(rng.below(DOMAIN));
-            }
-        }
+        let schema = random_schema(rng, arity);
+        let rows = random_rows(rng, &schema, 10);
         let name = format!("E{r}");
-        let col_names: Vec<String> = (0..arity).map(|c| format!("c{c}")).collect();
-        cat.insert(Relation::new(name.clone(), col_names, cols));
-        rels.push((name, arity));
+        cat.insert_rows(name.clone(), schema.clone(), rows).unwrap();
+        rels.push((name, schema));
     }
     (cat, rels)
 }
 
-/// 1..=2 derived relations with fixed arities and 2..=4 rules. Rule heads
+/// 1..=2 derived relations with fixed schemas and 2..=4 rules. Rule heads
 /// cycle through the derived relations so every one of them is defined;
 /// bodies mix stored and derived atoms freely.
-fn random_program(rng: &mut SplitMix64, edb: &[(String, usize)]) -> Program {
-    let idb: Vec<(String, usize)> = (0..1 + rng.below(2))
-        .map(|i| (format!("p{i}"), 1 + rng.below(2) as usize))
+fn random_program(
+    rng: &mut SplitMix64,
+    edb: &[(String, Schema)],
+) -> (Program, Vec<(String, Schema)>) {
+    let idb: Vec<(String, Schema)> = (0..1 + rng.below(2))
+        .map(|i| {
+            let arity = 1 + rng.below(2) as usize;
+            (format!("p{i}"), random_schema(rng, arity))
+        })
         .collect();
     let n_rules = idb.len().max(2 + rng.below(3) as usize);
+    let all: Vec<&(String, Schema)> = edb.iter().chain(idb.iter()).collect();
 
     let mut rules = Vec::new();
     for r in 0..n_rules {
-        let (head_name, head_arity) = idb[r % idb.len()].clone();
-        let var_pool = 1 + rng.below(3) as usize;
+        let (head_name, head_schema) = idb[r % idb.len()].clone();
+        // A typed pool of variables, types drawn from actual columns.
+        let pool: Vec<ScalarType> = (0..1 + rng.below(3))
+            .map(|_| {
+                let (_, schema) = all[rng.below(all.len() as u64) as usize];
+                schema.column_type(rng.below(schema.arity() as u64) as usize)
+            })
+            .collect();
 
         let mut atoms = Vec::new();
         for _ in 0..1 + rng.below(3) {
-            let pick = rng.below((edb.len() + idb.len()) as u64) as usize;
-            let (name, arity) = if pick < edb.len() {
-                edb[pick].clone()
-            } else {
-                idb[pick - edb.len()].clone()
-            };
-            let terms = (0..arity)
-                .map(|_| {
-                    if rng.below(5) == 0 {
-                        Term::Lit(rng.below(DOMAIN))
+            let (name, schema) = all[rng.below(all.len() as u64) as usize];
+            let terms = schema
+                .types()
+                .into_iter()
+                .map(|ty| {
+                    let candidates: Vec<usize> =
+                        (0..pool.len()).filter(|&v| pool[v] == ty).collect();
+                    if candidates.is_empty() || rng.below(5) == 0 {
+                        Term::Lit(random_value(rng, ty))
                     } else {
-                        Term::Var(rng.below(var_pool as u64) as usize)
+                        Term::Var(candidates[rng.below(candidates.len() as u64) as usize])
                     }
                 })
                 .collect();
             atoms.push(Atom {
-                relation: name,
+                relation: name.clone(),
                 terms,
             });
         }
 
         // Renumber the used variables to a dense 0..n range, as
-        // `Query::validate` requires (same trick as random_queries).
-        let mut remap: Vec<Option<usize>> = vec![None; var_pool];
-        let mut next = 0;
+        // `Query::validate` requires, keeping their types.
+        let mut remap: Vec<Option<usize>> = vec![None; pool.len()];
+        let mut var_types: Vec<ScalarType> = Vec::new();
         for atom in &mut atoms {
             for term in &mut atom.terms {
                 if let Term::Var(v) = term {
                     let id = *remap[*v].get_or_insert_with(|| {
-                        next += 1;
-                        next - 1
+                        var_types.push(pool[*v]);
+                        var_types.len() - 1
                     });
                     *term = Term::Var(id);
                 }
             }
         }
-        if next == 0 {
-            // All-literal body: force one variable so the head has one.
-            atoms[0].terms[0] = Term::Var(0);
-            next = 1;
+        // The head's first column is uint and must be a variable: make
+        // sure the body binds one (every relation's first column is uint).
+        if !var_types.contains(&ScalarType::Uint) {
+            atoms[0].terms[0] = Term::Var(var_types.len());
+            var_types.push(ScalarType::Uint);
         }
 
-        // Head of the fixed arity; the first column is always a variable
-        // so the head is never all-literal.
-        let head_terms = (0..head_arity)
-            .map(|i| {
-                if i > 0 && rng.below(5) == 0 {
-                    Term::Lit(rng.below(DOMAIN))
+        // Head of the fixed schema: a variable of the column's type where
+        // the body binds one (always for the first column), else a
+        // literal.
+        let head_terms = head_schema
+            .types()
+            .into_iter()
+            .enumerate()
+            .map(|(i, ty)| {
+                let candidates: Vec<usize> = (0..var_types.len())
+                    .filter(|&v| var_types[v] == ty)
+                    .collect();
+                if candidates.is_empty() || (i > 0 && rng.below(5) == 0) {
+                    Term::Lit(random_value(rng, ty))
                 } else {
-                    Term::Var(rng.below(next as u64) as usize)
+                    Term::Var(candidates[rng.below(candidates.len() as u64) as usize])
                 }
             })
             .collect();
 
         rules.push(Rule {
-            var_names: (0..next).map(|v| format!("v{v}")).collect(),
+            var_names: (0..var_types.len()).map(|v| format!("v{v}")).collect(),
             head: Atom {
                 relation: head_name,
                 terms: head_terms,
@@ -123,7 +186,7 @@ fn random_program(rng: &mut SplitMix64, edb: &[(String, usize)]) -> Program {
             body: atoms,
         });
     }
-    Program { rules }
+    (Program { rules }, idb)
 }
 
 #[test]
@@ -132,34 +195,22 @@ fn random_programs_all_combinations_agree() {
     for case in 0..CASES {
         let mut rng = SplitMix64::new(case);
         let (mut edb, edb_rels) = random_edb(&mut rng);
-        let program = random_program(&mut rng, &edb_rels);
+        let (program, idb) = random_program(&mut rng, &edb_rels);
 
-        // Sometimes pre-seed the first derived relation with initial
-        // facts, matching its head arity.
-        if rng.below(4) == 0 {
-            let name = program.rules[0].head.relation.clone();
-            let arity = program.rules[0].head.terms.len();
-            let rows = rng.below(4);
-            let mut cols: Vec<Vec<u64>> = vec![Vec::new(); arity];
-            for _ in 0..rows {
-                for col in cols.iter_mut() {
-                    col.push(rng.below(DOMAIN));
-                }
+        // Declare every derived relation; sometimes pre-seed the first
+        // one with initial facts.
+        for (i, (name, schema)) in idb.iter().enumerate() {
+            if i == 0 && rng.below(4) == 0 {
+                let rows = random_rows(&mut rng, schema, 3);
+                edb.insert_rows(name.clone(), schema.clone(), rows).unwrap();
+            } else {
+                edb.insert(Relation::empty(name.clone(), schema.clone()));
             }
-            let col_names: Vec<String> = (0..arity).map(|c| format!("c{c}")).collect();
-            edb.insert(Relation::new(name, col_names, cols));
         }
-
-        let mut idb_names: Vec<String> = program
-            .rules
-            .iter()
-            .map(|r| r.head.relation.clone())
-            .collect();
-        idb_names.sort();
-        idb_names.dedup();
+        let idb_names: Vec<&str> = idb.iter().map(|(name, _)| name.as_str()).collect();
 
         let run = |name: &str, r: anyhow::Result<FixpointResult>| -> Catalog {
-            r.unwrap_or_else(|e| panic!("case {case}: {name} failed: {e}"))
+            r.unwrap_or_else(|e| panic!("case {case}: {name} failed: {e}\n{program:#?}"))
                 .catalog
         };
         let base = run(
@@ -198,8 +249,18 @@ fn random_programs_all_combinations_agree() {
                 );
             }
         }
-        if idb_names.iter().any(|n| !base.get(n).unwrap().is_empty()) {
-            non_empty += 1;
+        for (name, schema) in &idb {
+            let rel = base.get(name).unwrap();
+            assert_eq!(
+                &rel.schema, schema,
+                "case {case}: {name} lost its declared schema"
+            );
+            // Every derived row decodes under the result catalog.
+            base.rows_of(name)
+                .unwrap_or_else(|e| panic!("case {case}: {name} does not decode: {e}"));
+            if !rel.is_empty() {
+                non_empty += 1;
+            }
         }
     }
     // Guard against a degenerate generator.

--- a/packages/coln-batch/tests/random_queries.rs
+++ b/packages/coln-batch/tests/random_queries.rs
@@ -8,57 +8,104 @@
 //! covering a far larger space of query shapes than hand-written
 //! fixtures.
 //!
-//! The value domain is deliberately small: matching and non-matching
-//! joins, empty relations, cross products and unsatisfied literals all
-//! occur naturally.
+//! Columns draw their types from every scalar type the engine knows, and
+//! queries are generated well-typed: a variable only stands in columns
+//! of its type, a literal matches its column. The value domains are
+//! deliberately small: matching and non-matching joins, empty relations,
+//! cross products and unsatisfied literals all occur naturally.
 //! Each case seeds its own [`SplitMix64`], so a failing case number
 //! reproduces in isolation.
 
 use coln_batch::query::{Atom, Catalog, Query, Term};
-use coln_batch::relation::Relation;
 use coln_batch::rng::SplitMix64;
+use coln_batch::types::{Column, ScalarType, Schema, Value};
 use coln_batch::{binary_join, generic_join, reference};
 
 const CASES: u64 = 250;
-/// Values are drawn from `0..DOMAIN`, small so collisions are common.
+/// Unsigned values are drawn from `0..DOMAIN`, small so collisions are
+/// common; the other types have domains of similar size.
 const DOMAIN: u64 = 8;
+const WORDS: [&str; 6] = ["ant", "bee", "cat", "dog", "eel", "fox"];
+const TYPES: [ScalarType; 5] = [
+    ScalarType::Uint,
+    ScalarType::Iint,
+    ScalarType::String,
+    ScalarType::Bool,
+    ScalarType::Char,
+];
 
-/// Random catalog: 1..=4 relations, arity 1..=3, 0..=20 rows each
-/// (zero-row relations included deliberately).
-fn random_catalog(rng: &mut SplitMix64) -> (Catalog, Vec<(String, usize)>) {
+fn random_type(rng: &mut SplitMix64) -> ScalarType {
+    TYPES[rng.below(TYPES.len() as u64) as usize]
+}
+
+/// A random value of type `ty`. Strings occasionally fall outside the
+/// stored vocabulary so unknown literals occur.
+fn random_value(rng: &mut SplitMix64, ty: ScalarType) -> Value {
+    match ty {
+        ScalarType::Uint => Value::Uint(rng.below(DOMAIN)),
+        ScalarType::Iint => Value::Iint(rng.below(DOMAIN) as i64 - 4),
+        ScalarType::String => {
+            if rng.below(12) == 0 {
+                Value::from("unknown")
+            } else {
+                Value::from(WORDS[rng.below(WORDS.len() as u64) as usize])
+            }
+        }
+        ScalarType::Bool => Value::Bool(rng.below(2) == 1),
+        ScalarType::Char => Value::Char(char::from(b'a' + rng.below(4) as u8)),
+    }
+}
+
+/// Random catalog: 1..=4 relations, arity 1..=3 with random column types,
+/// 0..=20 rows each (zero-row relations included deliberately).
+fn random_catalog(rng: &mut SplitMix64) -> (Catalog, Vec<(String, Schema)>) {
     let mut cat = Catalog::new();
     let mut rels = Vec::new();
     for r in 0..1 + rng.below(4) {
         let arity = 1 + rng.below(3) as usize;
+        let schema =
+            Schema::new((0..arity).map(|c| Column::new(format!("c{c}"), random_type(rng))));
         let rows = rng.below(21);
-        let mut cols: Vec<Vec<u64>> = vec![Vec::new(); arity];
-        for _ in 0..rows {
-            for col in cols.iter_mut() {
-                col.push(rng.below(DOMAIN));
-            }
-        }
+        let rows: Vec<Vec<Value>> = (0..rows)
+            .map(|_| {
+                schema
+                    .types()
+                    .into_iter()
+                    .map(|ty| random_value(rng, ty))
+                    .collect()
+            })
+            .collect();
         let name = format!("R{r}");
-        let col_names: Vec<String> = (0..arity).map(|c| format!("c{c}")).collect();
-        cat.insert(Relation::new(name.clone(), col_names, cols));
-        rels.push((name, arity));
+        cat.insert_rows(name.clone(), schema.clone(), rows).unwrap();
+        rels.push((name, schema));
     }
     (cat, rels)
 }
 
-/// Random query: 1..=4 atoms over the given relations, up to 4 variables,
-/// 25% literal terms. Returns `None` for the rare all-literal draw, which
-/// leaves no variable for the head.
-fn random_query(rng: &mut SplitMix64, rels: &[(String, usize)]) -> Option<Query> {
-    let var_pool = 1 + rng.below(4) as usize;
+/// Random query: 1..=4 atoms over the given relations, a typed pool of up
+/// to 4 variables, 25% literal terms. A column takes a variable of its
+/// type when the pool has one, otherwise a literal. Returns `None` for the
+/// rare all-literal draw, which leaves no variable for the head.
+fn random_query(rng: &mut SplitMix64, rels: &[(String, Schema)]) -> Option<Query> {
+    // Pool types come from actual columns, so most columns find a match.
+    let pool: Vec<ScalarType> = (0..1 + rng.below(4))
+        .map(|_| {
+            let (_, schema) = &rels[rng.below(rels.len() as u64) as usize];
+            schema.column_type(rng.below(schema.arity() as u64) as usize)
+        })
+        .collect();
     let mut atoms = Vec::new();
     for _ in 0..1 + rng.below(4) {
-        let (name, arity) = &rels[rng.below(rels.len() as u64) as usize];
-        let terms = (0..*arity)
-            .map(|_| {
-                if rng.below(4) == 0 {
-                    Term::Lit(rng.below(DOMAIN))
+        let (name, schema) = &rels[rng.below(rels.len() as u64) as usize];
+        let terms = schema
+            .types()
+            .into_iter()
+            .map(|ty| {
+                let candidates: Vec<usize> = (0..pool.len()).filter(|&v| pool[v] == ty).collect();
+                if candidates.is_empty() || rng.below(4) == 0 {
+                    Term::Lit(random_value(rng, ty))
                 } else {
-                    Term::Var(rng.below(var_pool as u64) as usize)
+                    Term::Var(candidates[rng.below(candidates.len() as u64) as usize])
                 }
             })
             .collect();
@@ -70,7 +117,7 @@ fn random_query(rng: &mut SplitMix64, rels: &[(String, usize)]) -> Option<Query>
 
     // Renumber the variables that actually occur to a dense 0..n range,
     // since `Query::validate` rejects declared-but-unused variables.
-    let mut remap: Vec<Option<usize>> = vec![None; var_pool];
+    let mut remap: Vec<Option<usize>> = vec![None; pool.len()];
     let mut next = 0;
     for atom in &mut atoms {
         for term in &mut atom.terms {
@@ -105,13 +152,15 @@ fn random_query(rng: &mut SplitMix64, rels: &[(String, usize)]) -> Option<Query>
 fn random_queries_agree_with_oracle() {
     let mut ran = 0;
     let mut non_empty = 0;
+    let mut string_results = 0;
     for case in 0..CASES {
         let mut rng = SplitMix64::new(case);
         let (cat, rels) = random_catalog(&mut rng);
         let Some(query) = random_query(&mut rng, &rels) else {
             continue;
         };
-        let oracle = reference::execute(&query, &cat).unwrap();
+        let oracle = reference::execute(&query, &cat)
+            .unwrap_or_else(|e| panic!("case {case}: oracle failed: {e}\n{query:#?}"));
         let binary = binary_join::execute(&query, &cat).unwrap();
         let generic = generic_join::execute(&query, &cat).unwrap();
         assert_eq!(
@@ -122,9 +171,21 @@ fn random_queries_agree_with_oracle() {
             oracle, generic,
             "case {case}: generic join disagrees with oracle\n{query:#?}\n{cat:#?}"
         );
+        // Every result decodes under the catalog's dictionary and schema.
+        for i in 0..oracle.len() {
+            let row = oracle.row_values(i, cat.dictionary()).unwrap();
+            assert_eq!(
+                row.iter().map(Value::scalar_type).collect::<Vec<_>>(),
+                oracle.schema.types(),
+                "case {case}: decoded row does not match the result schema"
+            );
+        }
         ran += 1;
         if !oracle.is_empty() {
             non_empty += 1;
+            if oracle.schema.types().contains(&ScalarType::String) {
+                string_results += 1;
+            }
         }
     }
     // Guard against a degenerate generator: it must neither skip most
@@ -133,5 +194,9 @@ fn random_queries_agree_with_oracle() {
     assert!(
         non_empty >= CASES / 10,
         "only {non_empty} non-empty results"
+    );
+    assert!(
+        string_results >= CASES / 40,
+        "only {string_results} non-empty results with string columns"
     );
 }

--- a/packages/coln-batch/tests/typed.rs
+++ b/packages/coln-batch/tests/typed.rs
@@ -1,0 +1,417 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Type transport: the same queries and programs, run over every scalar
+//! type the engine knows.
+//!
+//! A `u64` instance (relations, literals, expected results) is mapped
+//! cell by cell through an injective function into each type. The typed
+//! run must then produce exactly the image of the `u64` result under the
+//! same function, on every executor and every fixpoint strategy. Beyond
+//! that, one query mixes three types across its columns, and the edge
+//! values of every type (extremes, empty and non-ASCII strings) go
+//! through a join instead of only through a round trip.
+
+use coln_batch::fixpoint::{self, Exec, FixpointResult};
+use coln_batch::query::{Atom, Catalog, Query, Term};
+use coln_batch::relation::Relation;
+use coln_batch::rule::Program;
+use coln_batch::types::{Column, ScalarType, Schema, Value};
+use coln_batch::{binary_join, fixtures, generate, generic_join, reference};
+
+/// A fixpoint strategy, `semi_naive` or `naive`.
+type Strategy = fn(&Program, &Catalog, Exec) -> anyhow::Result<FixpointResult>;
+
+const TYPES: [ScalarType; 5] = [
+    ScalarType::Uint,
+    ScalarType::Iint,
+    ScalarType::Bool,
+    ScalarType::Char,
+    ScalarType::String,
+];
+
+/// An injective map from the small integers the base instances use into
+/// `ty`. Deliberately not the identity for any type, so decoding is
+/// exercised too: unsigned values count down from `u64::MAX`, signed
+/// ones start negative, characters are non-ASCII, strings carry a
+/// non-ASCII letter. Booleans have two values, so their instances draw
+/// from `0..2` only.
+fn lift(ty: ScalarType, x: u64) -> Value {
+    match ty {
+        ScalarType::Uint => Value::Uint(u64::MAX - x),
+        ScalarType::Iint => Value::Iint(x as i64 - 5),
+        ScalarType::Bool => {
+            assert!(x < 2, "boolean instances use the domain 0..2");
+            Value::Bool(x == 1)
+        }
+        ScalarType::Char => Value::Char(char::from_u32(0x1F600 + x as u32).expect("emoji range")),
+        ScalarType::String => Value::String(format!("wert {x} ß")),
+    }
+}
+
+/// The domain a base instance may use for `ty`.
+fn domain(ty: ScalarType) -> u64 {
+    if ty == ScalarType::Bool { 2 } else { 6 }
+}
+
+fn lift_row(row: &[u64], types: &[ScalarType]) -> Vec<Value> {
+    row.iter().zip(types).map(|(&x, &ty)| lift(ty, x)).collect()
+}
+
+/// Every relation of a `u64` catalog, lifted column by column into the
+/// types `types_of` assigns to it.
+fn lift_catalog(base: &Catalog, types_of: impl Fn(&str, usize) -> ScalarType) -> Catalog {
+    let mut lifted = Catalog::new();
+    for name in base.names() {
+        let rel = base.get(name).unwrap();
+        let types: Vec<ScalarType> = (0..rel.arity()).map(|c| types_of(name, c)).collect();
+        let schema = Schema::new(
+            rel.schema
+                .columns()
+                .iter()
+                .zip(&types)
+                .map(|(column, &ty)| Column::new(column.name.clone(), ty)),
+        );
+        let rows: Vec<Vec<Value>> = (0..rel.len())
+            .map(|i| lift_row(&rel.row(i), &types))
+            .collect();
+        lifted.insert_rows(name, schema, rows).unwrap();
+    }
+    lifted
+}
+
+/// A query's unsigned literals lifted into `ty`.
+fn lift_query(query: &Query, ty: ScalarType) -> Query {
+    let mut lifted = query.clone();
+    for atom in &mut lifted.atoms {
+        for term in &mut atom.terms {
+            if let Term::Lit(Value::Uint(x)) = term {
+                *term = Term::Lit(lift(ty, *x));
+            }
+        }
+    }
+    lifted
+}
+
+/// The rows of a `u64` relation lifted into `types`, sorted by value.
+fn lifted_rows(rel: &Relation, types: &[ScalarType]) -> Vec<Vec<Value>> {
+    let mut rows: Vec<Vec<Value>> = (0..rel.len())
+        .map(|i| lift_row(&rel.row(i), types))
+        .collect();
+    rows.sort();
+    rows
+}
+
+/// A typed relation decoded, sorted by value.
+fn decoded(rel: &Relation, catalog: &Catalog) -> Vec<Vec<Value>> {
+    let mut rows: Vec<Vec<Value>> = (0..rel.len())
+        .map(|i| rel.row_values(i, catalog.dictionary()).unwrap())
+        .collect();
+    rows.sort();
+    rows
+}
+
+fn atom(relation: &str, terms: Vec<Term>) -> Atom {
+    Atom {
+        relation: relation.into(),
+        terms,
+    }
+}
+
+/// Hand-built base instances with literals, over the domain `0..2` so
+/// they work for booleans as well.
+fn literal_cases() -> Vec<(&'static str, Query, Catalog)> {
+    let mut cat = Catalog::new();
+    cat.insert(Relation::new(
+        "R",
+        ["a", "b"],
+        vec![vec![0, 1, 1], vec![1, 1, 0]],
+    ));
+    cat.insert(Relation::new("U", ["a"], vec![vec![1]]));
+    let (x, y) = (0, 1);
+    vec![
+        (
+            "literal filter",
+            Query {
+                var_names: vec!["y".into()],
+                atoms: vec![atom("R", vec![Term::lit(1u64), Term::Var(0)])],
+                head: vec![0],
+            },
+            cat.clone(),
+        ),
+        (
+            "self join with a filter",
+            Query {
+                var_names: vec!["x".into(), "y".into()],
+                atoms: vec![
+                    atom("R", vec![Term::Var(x), Term::Var(y)]),
+                    atom("R", vec![Term::Var(y), Term::lit(0u64)]),
+                    atom("U", vec![Term::Var(y)]),
+                ],
+                head: vec![x, y],
+            },
+            cat.clone(),
+        ),
+        (
+            "repeated variable",
+            Query {
+                var_names: vec!["x".into()],
+                atoms: vec![atom("R", vec![Term::Var(0), Term::Var(0)])],
+                head: vec![0],
+            },
+            cat,
+        ),
+    ]
+}
+
+/// The generated fixtures, sized to the domain of `ty`.
+fn fixture_cases(ty: ScalarType) -> Vec<(&'static str, Query, Catalog)> {
+    let n = domain(ty);
+    vec![
+        (
+            "triangle",
+            fixtures::triangle_query(),
+            fixtures::triangle_catalog(n, 30, 6, 1),
+        ),
+        (
+            "f(a, g(a))",
+            fixtures::fg_query(),
+            fixtures::fg_catalog(n, 30, 6, 2),
+        ),
+    ]
+}
+
+#[test]
+fn same_query_every_type() {
+    for ty in TYPES {
+        let mut cases = literal_cases();
+        cases.extend(fixture_cases(ty));
+        for (name, query, base) in cases {
+            let expected_u64 = reference::execute(&query, &base).unwrap();
+            let types = vec![ty; expected_u64.arity()];
+            let expected = lifted_rows(&expected_u64, &types);
+
+            let lifted = lift_catalog(&base, |_, _| ty);
+            let lifted_query = lift_query(&query, ty);
+            for (executor, exec) in [
+                ("oracle", reference::execute as Exec),
+                ("binary join", binary_join::execute as Exec),
+                ("generic join", generic_join::execute as Exec),
+            ] {
+                let result = exec(&lifted_query, &lifted)
+                    .unwrap_or_else(|e| panic!("{name} over {ty}: {executor} failed: {e}"));
+                assert_eq!(
+                    result.schema.types(),
+                    types,
+                    "{name} over {ty}: {executor} result schema"
+                );
+                assert_eq!(
+                    decoded(&result, &lifted),
+                    expected,
+                    "{name} over {ty}: {executor} result"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn same_program_every_type() {
+    for ty in TYPES {
+        let n = domain(ty);
+        let program = fixtures::ancestor_program();
+        // A chain plus one initial fact that is not derivable from it.
+        let mut base = fixtures::ancestor_chain_catalog(n);
+        base.insert(Relation::new(
+            "ancestor",
+            ["x", "y"],
+            vec![vec![n - 1], vec![0]],
+        ));
+        let expected_u64 = fixpoint::semi_naive(&program, &base, generic_join::execute as Exec)
+            .unwrap()
+            .catalog;
+        let expected = lifted_rows(expected_u64.get("ancestor").unwrap(), &[ty, ty]);
+        assert!(expected.len() > 1, "the instance must derive something");
+
+        let lifted = lift_catalog(&base, |_, _| ty);
+        for (name, strategy) in [
+            ("semi-naive", fixpoint::semi_naive as Strategy),
+            ("naive", fixpoint::naive as Strategy),
+        ] {
+            for (executor, exec) in [
+                ("binary join", binary_join::execute as Exec),
+                ("generic join", generic_join::execute as Exec),
+            ] {
+                let result = strategy(&program, &lifted, exec)
+                    .unwrap_or_else(|e| panic!("{name} + {executor} over {ty}: {e}"));
+                let ancestor = result.catalog.get("ancestor").unwrap();
+                assert_eq!(ancestor.schema.types(), vec![ty, ty]);
+                assert_eq!(
+                    decoded(ancestor, &result.catalog),
+                    expected,
+                    "{name} + {executor} over {ty}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn mixed_types_in_one_query() {
+    // The triangle with x unsigned, y a string and z signed: every atom
+    // mixes two types, and every variable keeps one.
+    let types_of = |relation: &str, column: usize| match (relation, column) {
+        ("R_f", 0) | ("R_h", 1) => ScalarType::Uint,
+        ("R_f", 1) | ("R_g", 0) => ScalarType::String,
+        ("R_g", 1) | ("R_h", 0) => ScalarType::Iint,
+        _ => unreachable!(),
+    };
+    let query = fixtures::triangle_query();
+    let base = fixtures::triangle_catalog(6, 30, 6, 9);
+    let expected_u64 = reference::execute(&query, &base).unwrap();
+    let head_types = [ScalarType::Uint, ScalarType::String, ScalarType::Iint];
+    let expected = lifted_rows(&expected_u64, &head_types);
+    assert!(!expected.is_empty());
+
+    let lifted = lift_catalog(&base, types_of);
+    for (executor, exec) in [
+        ("oracle", reference::execute as Exec),
+        ("binary join", binary_join::execute as Exec),
+        ("generic join", generic_join::execute as Exec),
+    ] {
+        let result = exec(&query, &lifted).unwrap();
+        assert_eq!(result.schema.types(), head_types, "{executor}");
+        assert_eq!(decoded(&result, &lifted), expected, "{executor}");
+    }
+}
+
+/// The values at the edges of every type's range.
+fn extremes(ty: ScalarType) -> Vec<Value> {
+    match ty {
+        ScalarType::Uint => [0, 1, u64::MAX - 1, u64::MAX]
+            .into_iter()
+            .map(Value::Uint)
+            .collect(),
+        ScalarType::Iint => [i64::MIN, i64::MIN + 1, -1, 0, 1, i64::MAX - 1, i64::MAX]
+            .into_iter()
+            .map(Value::Iint)
+            .collect(),
+        ScalarType::Bool => vec![Value::Bool(false), Value::Bool(true)],
+        ScalarType::Char => [
+            '\0',
+            'a',
+            'ß',
+            '\u{D7FF}',
+            '\u{E000}',
+            '\u{1F600}',
+            char::MAX,
+        ]
+        .into_iter()
+        .map(Value::Char)
+        .collect(),
+        ScalarType::String => ["", " ", "a", "ab", "b", "ß", "日本語", "\u{1F600}", "a\0b"]
+            .into_iter()
+            .map(Value::from)
+            .chain(std::iter::once(Value::String("x".repeat(10_000))))
+            .collect(),
+    }
+}
+
+#[test]
+fn edge_values_of_every_type_join() {
+    for ty in TYPES {
+        let all = extremes(ty);
+        // U holds every other value; Q(x) ← T(x), U(x) must return exactly U.
+        let subset: Vec<Value> = all.iter().step_by(2).cloned().collect();
+        let mut cat = Catalog::new();
+        let schema = || Schema::new([Column::new("x", ty)]);
+        cat.insert_rows("T", schema(), all.iter().map(|v| vec![v.clone()]))
+            .unwrap();
+        cat.insert_rows("U", schema(), subset.iter().map(|v| vec![v.clone()]))
+            .unwrap();
+        let query = Query {
+            var_names: vec!["x".into()],
+            atoms: vec![atom("T", vec![Term::Var(0)]), atom("U", vec![Term::Var(0)])],
+            head: vec![0],
+        };
+        let mut expected: Vec<Vec<Value>> = subset.iter().map(|v| vec![v.clone()]).collect();
+        expected.sort();
+        for (executor, exec) in [
+            ("oracle", reference::execute as Exec),
+            ("binary join", binary_join::execute as Exec),
+            ("generic join", generic_join::execute as Exec),
+        ] {
+            let result = exec(&query, &cat).unwrap();
+            assert_eq!(decoded(&result, &cat), expected, "{ty}: {executor}");
+        }
+
+        // For the ordered types, the engine's key order is the value order:
+        // T sorted by key decodes in ascending value order.
+        if ty != ScalarType::String {
+            let t = cat.get("T").unwrap();
+            let sorted_by_key = t.clone().sorted_dedup();
+            let in_key_order: Vec<Value> = (0..sorted_by_key.len())
+                .map(|i| sorted_by_key.value(i, 0, cat.dictionary()).unwrap())
+                .collect();
+            let mut in_value_order = all.clone();
+            in_value_order.sort();
+            assert_eq!(
+                in_key_order, in_value_order,
+                "{ty}: key order is value order"
+            );
+        }
+    }
+}
+
+#[test]
+fn extremes_survive_arrow_and_recursion() {
+    // Every extreme value as an edge endpoint in a labeled graph, run
+    // through the typed reachability program; the labels are extreme
+    // strings, the weights extreme signed integers.
+    let labels = extremes(ScalarType::String);
+    let weights = extremes(ScalarType::Iint);
+    let mut edb = Catalog::new();
+    let rows: Vec<Vec<Value>> = (0..labels.len())
+        .map(|i| {
+            vec![
+                Value::Uint(i as u64),
+                Value::Uint(i as u64 + 1),
+                labels[i].clone(),
+                weights[i % weights.len()].clone(),
+            ]
+        })
+        .collect();
+    edb.insert_rows("edge", generate::labeled_edges_schema(), rows.clone())
+        .unwrap();
+
+    // Arrow round trip into a fresh dictionary: the same values come back.
+    let edge = edb.get("edge").unwrap();
+    let batch = edge.to_record_batch(edb.dictionary()).unwrap();
+    let mut fresh = coln_batch::types::Dictionary::new();
+    let back = Relation::from_record_batch("edge", &batch, &mut fresh).unwrap();
+    let mut back_rows: Vec<Vec<Value>> = (0..back.len())
+        .map(|i| back.row_values(i, &fresh).unwrap())
+        .collect();
+    back_rows.sort();
+    let mut fed_rows = rows.clone();
+    fed_rows.sort();
+    assert_eq!(back_rows, fed_rows);
+
+    let result = fixpoint::semi_naive(
+        &fixtures::labeled_reach_program(),
+        &edb,
+        generic_join::execute as Exec,
+    )
+    .unwrap();
+    // Every label is unique, so each edge reaches exactly its own target.
+    let reach = result.catalog.get("reach").unwrap();
+    let mut got = decoded(reach, &result.catalog);
+    let mut expected: Vec<Vec<Value>> = rows
+        .iter()
+        .map(|row| vec![row[0].clone(), row[1].clone(), row[2].clone()])
+        .collect();
+    got.sort();
+    expected.sort();
+    assert_eq!(got, expected);
+}

--- a/packages/coln-query/src/relational/batch/lowering.rs
+++ b/packages/coln-query/src/relational/batch/lowering.rs
@@ -107,7 +107,7 @@ impl Bind {
                 .get(&v)
                 .map(|nv| Term::Var(*nv))
                 .context("head column refers to a variable that does not occur in the body"),
-            Bind::Lit(x) => Ok(Term::Lit(x)),
+            Bind::Lit(x) => Ok(Term::lit(x)),
         }
     }
 }
@@ -160,12 +160,12 @@ impl Frame {
     fn substitute(&mut self, from: usize, to: Bind) {
         let to = match to {
             Bind::Var(v) => Term::Var(v),
-            Bind::Lit(x) => Term::Lit(x),
+            Bind::Lit(x) => Term::lit(x),
         };
         for atom in &mut self.atoms {
             for term in &mut atom.terms {
                 if *term == Term::Var(from) {
-                    *term = to;
+                    *term = to.clone();
                 }
             }
         }
@@ -925,7 +925,7 @@ mod tests {
         .unwrap();
 
         let head = &plan.program.rules[1].head;
-        assert_eq!(head.terms[1], Term::Lit(7));
+        assert_eq!(head.terms[1], Term::lit(7u64));
 
         let result = run(&plan, {
             let mut edb = Catalog::new();
@@ -984,7 +984,7 @@ mod tests {
         .unwrap();
 
         let body_atom = &plan.program.rules[0].body[0];
-        assert_eq!(body_atom.terms[0], Term::Lit(3));
+        assert_eq!(body_atom.terms[0], Term::lit(3u64));
 
         let result = run(&plan, {
             let mut edb = Catalog::new();


### PR DESCRIPTION
## What

The batch engine now supports signed integers, booleans, characters and                                                                                                                                                               
strings next to unsigned integers. Every column has a declared type,
and queries are type-checked against it.
Internally the engine dictionary-encodes all non-u64 values and keeps the dictionary in its catalog.
Join logic remains untouched.

## How

- Internally every value is still a u64 key. Integers map directly,
  strings are dictionary-encoded.
- The dictionary belongs to the catalog, so strings join across
  relations.
- The joins are unchanged. Only the wiring before them changes:
  encoding on the way in, decoding on the way out.
- A query with a type error (a variable in a uint column and a string
  column, a literal of the wrong type) fails before any data is read.

## Testing

- The same queries and programs run over every type and must give the
  same results as the u64 version, on every executor.
- Edge values of every type, mixed types in one query, and the random
  tests now draw column types.
  
  The tests are run via:
  `cargo test -p coln-query batch`