### PR TITLE
Forbid shadowing in more places

### DIFF
--- a/packages/coln-compiler/src/Coln/Frontend/Diagnostics.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Diagnostics.hs
@@ -16,6 +16,7 @@ data ParserCode
   | UnknownCommand
   | UnknownModifiers
   | UnknownMode
+  | DuplicateDefinition
   deriving (Eq, Ord)
 
 parserCodeTable :: Map ParserCode CodeMeta
@@ -29,4 +30,5 @@ parserCodeTable =
     , (UnknownCommand, CodeMeta 5 SError Nothing)
     , (UnknownModifiers, CodeMeta 6 SError Nothing)
     , (UnknownMode, CodeMeta 7 SError Nothing)
+    , (DuplicateDefinition, CodeMeta 7 SError Nothing)
     ]

--- a/packages/coln-compiler/src/Coln/Frontend/Diagnostics.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Diagnostics.hs
@@ -17,6 +17,7 @@ data ParserCode
   | UnknownModifiers
   | UnknownMode
   | DuplicateDefinition
+  | DuplicateField
   deriving (Eq, Ord)
 
 parserCodeTable :: Map ParserCode CodeMeta
@@ -30,5 +31,6 @@ parserCodeTable =
     , (UnknownCommand, CodeMeta 5 SError Nothing)
     , (UnknownModifiers, CodeMeta 6 SError Nothing)
     , (UnknownMode, CodeMeta 7 SError Nothing)
-    , (DuplicateDefinition, CodeMeta 7 SError Nothing)
+    , (DuplicateDefinition, CodeMeta 8 SError Nothing)
+    , (DuplicateField, CodeMeta 9 SError Nothing)
     ]

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
@@ -72,7 +72,7 @@ recordFields e parseField = go []
     seen' <- case n of
       N.Infix (N.Ident x sp) _ _ -> do
         when (x `elem` seen) $
-          failWith e sp DuplicateDefinition ("duplicate record field" <+> dpretty x)
+          failWith e sp DuplicateField ("duplicate record field" <+> dpretty x)
         pure (x : seen)
       _ -> pure seen
     (field :) <$> go seen' rest

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
@@ -5,6 +5,7 @@
 
 module Coln.Frontend.Parser.Expr where
 
+import Control.Monad (when)
 import FNotation (Ntn)
 import FNotation qualified as N
 
@@ -61,6 +62,20 @@ fieldSetting :: (V.HasEvaluation c) => ParserEnv -> Ntn -> IO (Record.FieldSetti
 fieldSetting e (N.Infix (N.Ident x sp) (N.Keyword ":=" _) body) =
   Record.FieldSetting x <$> chk e body <*> pure sp
 fieldSetting e n = unexpectedNotation e n "field setting of the form `<fieldname> := <expr>`"
+
+recordFields :: ParserEnv -> (Ntn -> IO a) -> [Ntn] -> IO [a]
+recordFields e parseField = go []
+ where
+  go _ [] = pure []
+  go seen (n : rest) = do
+    field <- parseField n
+    seen' <- case n of
+      N.Infix (N.Ident x sp) _ _ -> do
+        when (x `elem` seen) $
+          failWith e sp DuplicateDefinition ("duplicate record field" <+> dpretty x)
+        pure (x:seen)
+      _ -> pure seen
+    (field :) <$> go seen' rest
 
 ident :: ParserEnv -> Ntn -> IO Name
 ident _ (N.Ident x _) = pure x
@@ -137,10 +152,10 @@ expr e n = case n of
               <*> syn e "term in equality" rhs
           )
   N.Block "sig" Nothing ns _ -> do
-    t <- Record.formation <$> traverse (fieldDecl e) ns
+    t <- Record.formation <$> recordFields e (fieldDecl e) ns
     fromTypD e (N.span n) t
-  N.Block "struct" Nothing ns s ->
-    FromChk "struct expression" <$> (Record.intro s <$> traverse (fieldSetting e) ns)
+  N.Block "struct" Nothing ns s -> do
+    FromChk "struct expression" <$> Record.intro s <$> recordFields e (fieldSetting e) ns
   N.Int i _ -> pure $ fromSynN $ Builtin.intro $ LitInt i
   N.String s _ -> pure $ fromSynN $ Builtin.intro $ LitString s
   n -> unexpectedNotation e n "expression"

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Expr.hs
@@ -73,7 +73,7 @@ recordFields e parseField = go []
       N.Infix (N.Ident x sp) _ _ -> do
         when (x `elem` seen) $
           failWith e sp DuplicateDefinition ("duplicate record field" <+> dpretty x)
-        pure (x:seen)
+        pure (x : seen)
       _ -> pure seen
     (field :) <$> go seen' rest
 

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
@@ -43,11 +43,11 @@ argBinding e n@(N.Infix n0 (N.Keyword ":" _) n1) = do
   pure (N.span n, m, x, a)
 argBinding e n = unexpectedNotation e n "argument binding of the form `<name> : <type>`"
 
-unpackArgs :: ParserEnv -> Ntn -> IO (Name, [(Span, Mode, Name, Typ N)])
+unpackArgs :: ParserEnv -> Ntn -> IO (Name, Span, [(Span, Mode, Name, Typ N)])
 unpackArgs e (N.Group (xN :| argsN)) = do
   x <- ident e xN
   args <- mapM (argBinding e) argsN
-  pure (x, args)
+  pure (x, N.span xN, args)
 
 withArgs :: (V.HasEvaluation c) => [(Span, Mode, Name, Typ N)] -> (Typ N, Chk c) -> (Typ N, Chk c)
 withArgs args base = foldr go base args
@@ -58,23 +58,23 @@ withArgs args base = foldr go base args
     , Function.intro sp name c
     )
 
-theory :: ParserEnv -> Ntn -> IO (Name, Typ N, Chk D)
+theory :: ParserEnv -> Ntn -> IO (Name, Span, Typ N, Chk D)
 theory e n = do
   (pat_n, body_n) <- definition e n
-  (name, args) <- unpackArgs e pat_n
+  (name, nameSpan, args) <- unpackArgs e pat_n
   body <- chk e body_n
   let (ty, tm) = withArgs args (Typ $ \_ -> pure $ M.univ TheoryU, body)
-  pure $ (name, ty, tm)
+  pure (name, nameSpan, ty, tm)
 
-def :: ParserEnv -> Ntn -> IO (Name, Typ N, Chk D)
+def :: ParserEnv -> Ntn -> IO (Name, Span, Typ N, Chk D)
 def e n = do
   (head_n, body_n) <- definition e n
   (pat_n, ty_n) <- annot e head_n
-  (name, args) <- unpackArgs e pat_n
+  (name, nameSpan, args) <- unpackArgs e pat_n
   returnTyp <- typ e ty_n
   body <- chk e body_n
   let (ty, tm) = withArgs args (returnTyp, body)
-  pure (name, ty, tm)
+  pure (name, nameSpan, ty, tm)
 
 elabDefinition :: DiagnosticEnv ElaboratorCode -> Globals -> Mode -> (Name, Typ N, Chk D) -> IO (Definition Global)
 elabDefinition e g m (x, ty, tm) = do
@@ -96,37 +96,37 @@ mode e sp ms = do
 decl :: DiagnosticEnv ColnCode -> Globals -> Ntn -> IO Globals
 decl e g (N.MDecl ms "theory" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
-  (x, t, c) <- theory (contramap ParserCode e) n
+  (x, xsp, t, c) <- theory (contramap ParserCode e) n
   when (x `OMap.member` g.definitions) $
-    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
 decl e g (N.MDecl ms "def" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
-  (x, t, c) <- def (contramap ParserCode e) n
+  (x, xsp, t, c) <- def (contramap ParserCode e) n
   when (x `OMap.member` g.definitions) $
-    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
-decl e g (N.Block "realm" (Just head) body sp) = do
-  (x, r) <- realm e g head body
+decl e g (N.Block "realm" (Just head) body _) = do
+  (x, xsp, r) <- realm e g head body
   when (x `OMap.member` g.realms) $
-    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   pure $ addRealm x r g
 decl e _ n = unexpectedNotation (contramap ParserCode e) n "top-level declaration"
 
-realmHead :: ParserEnv -> Ntn -> IO (Name, Ntn)
-realmHead _ (N.Infix (N.Ident x _) (N.Keyword "@" _) n) = pure (x, n)
+realmHead :: ParserEnv -> Ntn -> IO (Name, Span, Ntn)
+realmHead _ (N.Infix (N.Ident x sp) (N.Keyword "@" _) n) = pure (x, sp, n)
 realmHead e n = unexpectedNotation e n "realm head"
 
-realm :: DiagnosticEnv ColnCode -> Globals -> Ntn -> [Ntn] -> IO (Name, Realm)
+realm :: DiagnosticEnv ColnCode -> Globals -> Ntn -> [Ntn] -> IO (Name, Span, Realm)
 realm e g head def_ns = do
-  (x, theory_n) <- realmHead (contramap ParserCode e) head
+  (x, xsp, theory_n) <- realmHead (contramap ParserCode e) head
   theory_typ <- typ (contramap ParserCode e) theory_n
   theory <- theory_typ.elab (emptyElabEnv (contramap ElaboratorCode e) g Inductive)
   let (gt, root) = layoutTop x theory.val
   defs <- realmDecls e g theory.val root.val def_ns
-  pure (x, Realm gt root.val theory.val defs)
+  pure (x, xsp, Realm gt root.val theory.val defs)
 
 elabRealmDefinition :: ElabEnv N -> Mode -> (Typ N, Chk D) -> IO (Definition Local)
 elabRealmDefinition e m (ty, tm) = do
@@ -141,9 +141,9 @@ elabRealmDefinition e m (ty, tm) = do
 realmDecl :: DiagnosticEnv ColnCode -> ElabEnv N -> Ntn -> IO (Name, Definition Local)
 realmDecl de e (N.MDecl ms "def" n sp) = do
   m <- mode (contramap ParserCode de) sp ms
-  (x, t, c) <- def (contramap ParserCode de) n
+  (x, xsp, t, c) <- def (contramap ParserCode de) n
   when (x `elem` e.scope.names) $
-    failWith (contramap ParserCode de) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+    failWith (contramap ParserCode de) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   d <- elabRealmDefinition e m (t, c)
   pure (x, d)
 realmDecl de _ n = unexpectedNotation (contramap ParserCode de) n "realm declaration"

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
@@ -93,25 +93,27 @@ mode e sp ms = do
   let msg = "unknown modifiers" <+> hsep (dpretty <$> ms)
   failWith e sp UnknownModifiers msg
 
+checkDuplicateIn :: DiagnosticEnv ColnCode -> OMap Name a -> Name -> Span -> IO ()
+checkDuplicateIn e entries x sp =
+  when (x `OMap.member` entries) $
+    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+
 decl :: DiagnosticEnv ColnCode -> Globals -> Ntn -> IO Globals
 decl e g (N.MDecl ms "theory" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
   (x, xsp, t, c) <- theory (contramap ParserCode e) n
-  when (x `OMap.member` g.definitions) $
-    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+  checkDuplicateIn e g.definitions x xsp
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
 decl e g (N.MDecl ms "def" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
   (x, xsp, t, c) <- def (contramap ParserCode e) n
-  when (x `OMap.member` g.definitions) $
-    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+  checkDuplicateIn e g.definitions x xsp
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
 decl e g (N.Block "realm" (Just head) body _) = do
   (x, xsp, r) <- realm e g head body
-  when (x `OMap.member` g.realms) $
-    failWith (contramap ParserCode e) xsp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
+  checkDuplicateIn e g.realms x xsp
   pure $ addRealm x r g
 decl e _ n = unexpectedNotation (contramap ParserCode e) n "top-level declaration"
 

--- a/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
+++ b/packages/coln-compiler/src/Coln/Frontend/Parser/Top.hs
@@ -5,6 +5,7 @@
 module Coln.Frontend.Parser.Top where
 
 import Control.Exception (try)
+import Control.Monad (when)
 import Data.Foldable
 import Data.Functor.Contravariant (contramap)
 import Data.List.NonEmpty (NonEmpty (..))
@@ -96,15 +97,21 @@ decl :: DiagnosticEnv ColnCode -> Globals -> Ntn -> IO Globals
 decl e g (N.MDecl ms "theory" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
   (x, t, c) <- theory (contramap ParserCode e) n
+  when (x `OMap.member` g.definitions) $
+    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
 decl e g (N.MDecl ms "def" n sp) = do
   m <- mode (contramap ParserCode e) sp ms
   (x, t, c) <- def (contramap ParserCode e) n
+  when (x `OMap.member` g.definitions) $
+    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   ge <- elabDefinition (contramap ElaboratorCode e) g m (x, t, c)
   pure $ addDefinition x ge g
-decl e g (N.Block "realm" (Just head) body _) = do
+decl e g (N.Block "realm" (Just head) body sp) = do
   (x, r) <- realm e g head body
+  when (x `OMap.member` g.realms) $
+    failWith (contramap ParserCode e) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   pure $ addRealm x r g
 decl e _ n = unexpectedNotation (contramap ParserCode e) n "top-level declaration"
 
@@ -135,6 +142,8 @@ realmDecl :: DiagnosticEnv ColnCode -> ElabEnv N -> Ntn -> IO (Name, Definition 
 realmDecl de e (N.MDecl ms "def" n sp) = do
   m <- mode (contramap ParserCode de) sp ms
   (x, t, c) <- def (contramap ParserCode de) n
+  when (x `elem` e.scope.names) $
+    failWith (contramap ParserCode de) sp DuplicateDefinition ("duplicate definition of" <+> dpretty x)
   d <- elabRealmDefinition e m (t, c)
   pure (x, d)
 realmDecl de _ n = unexpectedNotation (contramap ParserCode de) n "realm declaration"

--- a/packages/coln-compiler/test/golden/elaborator-errors.coln
+++ b/packages/coln-compiler/test/golden/elaborator-errors.coln
@@ -18,9 +18,9 @@ def dependent : Dependent := struct
   value := 1
 end
 
-def identity : Int -> Int := x => x
+def identity : (^c x : Int) -> Int := x => x
 
-def shadow (x : String) : Int -> Int := x => x
+def shadow (x : String) : (^c x : Int) -> Int := x => x
 
 def projectionOfNonRecord : Int := (1).missing
 

--- a/packages/coln-compiler/test/golden/elaborator-errors.output
+++ b/packages/coln-compiler/test/golden/elaborator-errors.output
@@ -21,16 +21,16 @@ global entry named dependent
 in mode: Conjunctive
 type: Dependent
 value: [A := Int, value := 1]
+global entry named identity
+in mode: Conjunctive
+type: (x : Int) -> Int
+value: x => x
+global entry named shadow
+in mode: Conjunctive
+type: (x : String) -> (x : Int) -> Int
+value: x => x => x
 
 -- messages
-
-error[E0316]: cannot use inductively bound variable in a conjunctive context
-21 | def identity : Int -> Int := x => x
-21 |                                   ^
-
-error[E0316]: cannot use inductively bound variable in a conjunctive context
-23 | def shadow (x : String) : Int -> Int := x => x
-23 |                                              ^
 
 error[E0302]: tried to project from a value that was not of a record type
 25 | def projectionOfNonRecord : Int := (1).missing

--- a/packages/coln-compiler/test/golden/modular-lattice.coln
+++ b/packages/coln-compiler/test/golden/modular-lattice.coln
@@ -24,7 +24,7 @@ theory ModularLattice := sig
     join (join a b) c = join a (join b c)
   )
   # Commutativity: a ⋁ b = b ⋁ a
-  join/associative : (a : Element) -> (b : Element) -> (
+  join/commutative : (a : Element) -> (b : Element) -> (
     join a b = join b a
   )
   # Idempotence: a ⋁ a = a

--- a/packages/coln-compiler/test/golden/shadowing-allowed.coln
+++ b/packages/coln-compiler/test/golden/shadowing-allowed.coln
@@ -26,3 +26,14 @@ realm PairRealm @ Pair
   def realm_def : Int := 38
   def def_arg (realm_def : Int) : Int := 23
 end
+
+theory Nasty := sig
+  B : Set
+  E : B -> Set
+  n : (b : B) -> (b : E b) -> Int
+end
+
+theory NastyParam (b : Int) := sig
+  E : Int -> Set
+  b : E b
+end

--- a/packages/coln-compiler/test/golden/shadowing-allowed.coln
+++ b/packages/coln-compiler/test/golden/shadowing-allowed.coln
@@ -1,0 +1,28 @@
+def parameter_shadowing (x : Int) (x : Int) : Int := x
+
+def lambda_shadowing (x : Int) : (^c y : Int) -> Int := x => x
+
+theory PiShadowing := (x : Int) -> (x : Int) -> Set
+
+theory FieldArgumentShadowing (x : Int) := sig
+  x : Int
+end
+
+def top : Int := 19
+
+def param_top_shadowing (top : Int) : Int := 34
+
+theory ParamTopTheory (top : Int) := sig
+end
+
+def Pair : Set := sig
+  x : Int
+  y : Int
+end
+
+realm PairRealm @ Pair
+  def root_arg (root : Int) : Int := 41
+
+  def realm_def : Int := 38
+  def def_arg (realm_def : Int) : Int := 23
+end

--- a/packages/coln-compiler/test/golden/shadowing-allowed.output
+++ b/packages/coln-compiler/test/golden/shadowing-allowed.output
@@ -1,0 +1,61 @@
+-- elaborated
+global entry named parameter_shadowing
+in mode: Conjunctive
+type: (x : Int) -> (x : Int) -> Int
+value: x => x => x
+global entry named lambda_shadowing
+in mode: Conjunctive
+type: (x : Int) -> (y : Int) -> Int
+value: x => x => x
+global entry named PiShadowing
+in mode: Conjunctive
+type: Theory
+value: (x : Int) -> (x : Int) -> Set
+global entry named FieldArgumentShadowing
+in mode: Conjunctive
+type: (x : Int) -> Theory
+value: x => sig
+  x : Int
+end
+global entry named top
+in mode: Conjunctive
+type: Int
+value: 19
+global entry named param_top_shadowing
+in mode: Conjunctive
+type: (top : Int) -> Int
+value: top => 34
+global entry named ParamTopTheory
+in mode: Conjunctive
+type: (top : Int) -> Theory
+value: top => sig
+end
+global entry named Pair
+in mode: Conjunctive
+type: Set
+value: sig
+  x : Int
+  y : Int
+end
+realm named PairRealm
+elaborated: realm
+  generators
+    fun [] -> Pair
+  end
+  definitions
+    def root_arg : (root : Int) -> Int := root => 41
+    def realm_def : Int := 38
+    def def_arg : (realm_def : Int) -> Int := realm_def => 23
+  end
+end
+lowered: flatrealm
+  entities
+    table ℜ := [.a.x : Int, .a.y : Int] primarykey []
+  end
+  rules
+    enforced ℜ.foreignKey a.x a.y := ℜ [.a.x ↦ a.x, .a.y ↦ a.y] ⊢ ⊤
+    monitored ℜ.total := ⊤ ⊢ ℜ []
+  end
+end
+
+-- messages

--- a/packages/coln-compiler/test/golden/shadowing-allowed.output
+++ b/packages/coln-compiler/test/golden/shadowing-allowed.output
@@ -37,6 +37,21 @@ value: sig
   x : Int
   y : Int
 end
+global entry named Nasty
+in mode: Conjunctive
+type: Theory
+value: sig
+  B : Set
+  E : B -> Set
+  n : (b : B) -> (b : E b) -> Int
+end
+global entry named NastyParam
+in mode: Conjunctive
+type: (b : Int) -> Theory
+value: b => sig
+  E : Int -> Set
+  b : E b
+end
 realm named PairRealm
 elaborated: realm
   generators

--- a/packages/coln-compiler/test/golden/shadowing-forbidden.coln
+++ b/packages/coln-compiler/test/golden/shadowing-forbidden.coln
@@ -1,0 +1,40 @@
+def Pair : Set := sig
+  x : Int
+  y : Int
+end
+
+def Pair : Set := sig
+  x : String
+  y : String
+end
+
+def ShadowField : Set := sig
+  x : Int
+  x : String
+end
+
+# Banish him to the
+realm ShadowRealm @ Pair
+end
+
+realm ShadowRealm @ Pair
+end
+
+realm ShadowRoot @ Pair
+  def root : Pair := struct
+    x := 1
+    y := 2
+  end
+end
+
+realm ShadowRealmDefinition @ Pair
+  def thing : Pair := struct
+    x := 1
+    y := 2
+  end
+
+  def thing : Pair := struct
+    x := 3
+    y := 4
+  end
+end

--- a/packages/coln-compiler/test/golden/shadowing-forbidden.output
+++ b/packages/coln-compiler/test/golden/shadowing-forbidden.output
@@ -3,15 +3,8 @@ global entry named Pair
 in mode: Conjunctive
 type: Set
 value: sig
-  x : String
-  y : String
-end
-global entry named ShadowField
-in mode: Conjunctive
-type: Set
-value: sig
   x : Int
-  x : String
+  y : Int
 end
 realm named ShadowRealm
 elaborated: realm
@@ -23,7 +16,7 @@ elaborated: realm
 end
 lowered: flatrealm
   entities
-    table ℜ := [.a.x : String, .a.y : String] primarykey []
+    table ℜ := [.a.x : Int, .a.y : Int] primarykey []
   end
   rules
     enforced ℜ.foreignKey a.x a.y := ℜ [.a.x ↦ a.x, .a.y ↦ a.y] ⊢ ⊤
@@ -33,12 +26,42 @@ end
 
 -- messages
 
-error[E0300]: expected type String, but got type Int
-25 |     x := 1
-25 |          ^
-types String and Int are not equal because unequal builtin types
+error[E0207]: duplicate definition of Pair
+6 | def Pair : Set := sig
+6 | ^^^^^^^^^^^^^^^^^^^^^
+7 |   x : String
+7 | ^^^^^^^^^^^^
+8 |   y : String
+8 | ^^^^^^^^^^^^
+9 | end
+9 | ^^^
 
-error[E0300]: expected type String, but got type Int
-32 |     x := 1
-32 |          ^
-types String and Int are not equal because unequal builtin types
+error[E0207]: duplicate record field x
+13 |   x : String
+13 |   ^
+
+error[E0207]: duplicate definition of ShadowRealm
+20 | realm ShadowRealm @ Pair
+20 | ^^^^^^^^^^^^^^^^^^^^^^^^
+21 | end
+21 | ^^^
+
+error[E0207]: duplicate definition of root
+24 |   def root : Pair := struct
+24 |   ^^^^^^^^^^^^^^^^^^^^^^^^^
+25 |     x := 1
+25 | ^^^^^^^^^^
+26 |     y := 2
+26 | ^^^^^^^^^^
+27 |   end
+27 | ^^^^^
+
+error[E0207]: duplicate definition of thing
+36 |   def thing : Pair := struct
+36 |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
+37 |     x := 3
+37 | ^^^^^^^^^^
+38 |     y := 4
+38 | ^^^^^^^^^^
+39 |   end
+39 | ^^^^^

--- a/packages/coln-compiler/test/golden/shadowing-forbidden.output
+++ b/packages/coln-compiler/test/golden/shadowing-forbidden.output
@@ -1,0 +1,44 @@
+-- elaborated
+global entry named Pair
+in mode: Conjunctive
+type: Set
+value: sig
+  x : String
+  y : String
+end
+global entry named ShadowField
+in mode: Conjunctive
+type: Set
+value: sig
+  x : Int
+  x : String
+end
+realm named ShadowRealm
+elaborated: realm
+  generators
+    fun [] -> Pair
+  end
+  definitions
+  end
+end
+lowered: flatrealm
+  entities
+    table ℜ := [.a.x : String, .a.y : String] primarykey []
+  end
+  rules
+    enforced ℜ.foreignKey a.x a.y := ℜ [.a.x ↦ a.x, .a.y ↦ a.y] ⊢ ⊤
+    monitored ℜ.total := ⊤ ⊢ ℜ []
+  end
+end
+
+-- messages
+
+error[E0300]: expected type String, but got type Int
+25 |     x := 1
+25 |          ^
+types String and Int are not equal because unequal builtin types
+
+error[E0300]: expected type String, but got type Int
+32 |     x := 1
+32 |          ^
+types String and Int are not equal because unequal builtin types

--- a/packages/coln-compiler/test/golden/shadowing-forbidden.output
+++ b/packages/coln-compiler/test/golden/shadowing-forbidden.output
@@ -26,22 +26,22 @@ end
 
 -- messages
 
-error[E0207]: duplicate definition of Pair
+error[E0208]: duplicate definition of Pair
 6 | def Pair : Set := sig
 6 |     ^^^^
 
-error[E0207]: duplicate record field x
+error[E0209]: duplicate record field x
 13 |   x : String
 13 |   ^
 
-error[E0207]: duplicate definition of ShadowRealm
+error[E0208]: duplicate definition of ShadowRealm
 20 | realm ShadowRealm @ Pair
 20 |       ^^^^^^^^^^^
 
-error[E0207]: duplicate definition of root
+error[E0208]: duplicate definition of root
 24 |   def root : Pair := struct
 24 |       ^^^^
 
-error[E0207]: duplicate definition of thing
+error[E0208]: duplicate definition of thing
 36 |   def thing : Pair := struct
 36 |       ^^^^^

--- a/packages/coln-compiler/test/golden/shadowing-forbidden.output
+++ b/packages/coln-compiler/test/golden/shadowing-forbidden.output
@@ -28,13 +28,7 @@ end
 
 error[E0207]: duplicate definition of Pair
 6 | def Pair : Set := sig
-6 | ^^^^^^^^^^^^^^^^^^^^^
-7 |   x : String
-7 | ^^^^^^^^^^^^
-8 |   y : String
-8 | ^^^^^^^^^^^^
-9 | end
-9 | ^^^
+6 |     ^^^^
 
 error[E0207]: duplicate record field x
 13 |   x : String
@@ -42,26 +36,12 @@ error[E0207]: duplicate record field x
 
 error[E0207]: duplicate definition of ShadowRealm
 20 | realm ShadowRealm @ Pair
-20 | ^^^^^^^^^^^^^^^^^^^^^^^^
-21 | end
-21 | ^^^
+20 |       ^^^^^^^^^^^
 
 error[E0207]: duplicate definition of root
 24 |   def root : Pair := struct
-24 |   ^^^^^^^^^^^^^^^^^^^^^^^^^
-25 |     x := 1
-25 | ^^^^^^^^^^
-26 |     y := 2
-26 | ^^^^^^^^^^
-27 |   end
-27 | ^^^^^
+24 |       ^^^^
 
 error[E0207]: duplicate definition of thing
 36 |   def thing : Pair := struct
-36 |   ^^^^^^^^^^^^^^^^^^^^^^^^^^
-37 |     x := 3
-37 | ^^^^^^^^^^
-38 |     y := 4
-38 | ^^^^^^^^^^
-39 |   end
-39 | ^^^^^
+36 |       ^^^^^

--- a/packages/coln-compiler/test/golden/weighted.coln
+++ b/packages/coln-compiler/test/golden/weighted.coln
@@ -8,5 +8,5 @@ theory Q (G : WeightedGraph) := sig
   y : G.V
   z : G.V
   e1 : G.E x y 1
-  e1 : G.E y z 3
+  e2 : G.E y z 3
 end


### PR DESCRIPTION
Added `golden/shadowing-allowed.coln` and `golden/shadowing-forbidden.coln` as examples of what we're allowing and what we're not. Any cases I've missed?

Fixes #147 