### PR TITLE
fix(coln-query): shut down DBSP outside Tokio callers

### DIFF
--- a/packages/coln-query/src/api/mod.rs
+++ b/packages/coln-query/src/api/mod.rs
@@ -36,6 +36,11 @@ pub mod violations;
 /// and what schema to rebuild a [`TableDelta`] by.
 /// It doubles as the [`Catalog`](crate::relational::catalog::Catalog)
 /// an ad-hoc query is compiled against.
+///
+/// # Shutdown
+///
+/// Dropping a query waits for its DBSP workers to shut down. Queries can be
+/// dropped inside either current-thread or multi-thread Tokio runtimes.
 #[derive(Debug)]
 pub struct ColnQuery {
     flir_program: FlirProgram,

--- a/packages/coln-query/src/relational/incremental/mod.rs
+++ b/packages/coln-query/src/relational/incremental/mod.rs
@@ -117,7 +117,7 @@ impl<E: RowScalarEngine + Send> Backend for DbspBackend<E> {
             }
         }
         Ok(DbspRuntime {
-            handle,
+            handle: Some(handle),
             inputs,
             outputs: outputs_by_name,
             cli_outputs,
@@ -130,7 +130,7 @@ impl<E: RowScalarEngine + Send> Backend for DbspBackend<E> {
 /// [`DbspOutputDelta`]s.
 #[derive(Debug)]
 pub struct DbspRuntime {
-    handle: DbspHandle,
+    handle: Option<DbspHandle>,
     inputs: DbspInputs,
     /// Read handles for the [`OutputKind::Channel`] taps, keyed by name. These
     /// are the outputs [`output`](Runtime::output) can read.
@@ -139,6 +139,20 @@ pub struct DbspRuntime {
     /// plan order. Kept separate from `outputs`: printing drains a handle, so
     /// these are print-only and never readable via [`output`](Runtime::output).
     cli_outputs: Vec<(SinkId, DbspOutput)>,
+}
+
+impl Drop for DbspRuntime {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            // DBSP synchronously shuts down its own Tokio runtime. Its destructor
+            // must run outside a caller's async context, including current-thread
+            // runtimes where block_in_place is unavailable. Join before returning
+            // so destroying the query still releases all of its workers.
+            std::thread::spawn(move || drop(handle))
+                .join()
+                .expect("DBSP shutdown thread panicked");
+        }
+    }
 }
 
 impl Runtime for DbspRuntime {
@@ -160,7 +174,10 @@ impl Runtime for DbspRuntime {
     }
 
     fn commit(&mut self) -> Result<(), Self::Error> {
-        self.handle.transaction()?;
+        self.handle
+            .as_mut()
+            .expect("runtime is alive")
+            .transaction()?;
         // Flush CLI taps: print each flagged output's current batch for
         // debugging. This drains the handle, which is why CLI taps are not
         // readable via `output`.

--- a/packages/coln-store/tests/test_tokio_shutdown.rs
+++ b/packages/coln-store/tests/test_tokio_shutdown.rs
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+use coln_store::store::Store;
+
+#[tokio::test(flavor = "current_thread")]
+async fn store_can_be_dropped_in_a_current_thread_runtime() {
+    let store = Store::new();
+    drop(store);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn store_can_be_dropped_in_a_multi_thread_runtime() {
+    let store = Store::new();
+    drop(store);
+}


### PR DESCRIPTION
Dropping a `Store` inside Tokio panics while DBSP shuts down its own runtime, breaking the existing Subduction integration tests on the query/store branch.

Move the DBSP handle to an ordinary thread for destruction and join it before returning. Cleanup remains synchronous, with one short-lived thread per query shutdown.

Added minimal `Store::new()` tests for current-thread and multi-thread Tokio runtimes. Both new tests and both affected Subduction tests fail before the fix and pass afterward.

@incipit0 