### PR TITLE
Support empty antecedent rules in coln-query

### DIFF
--- a/packages/coln-flir-rs/tests/data/Path.json
+++ b/packages/coln-flir-rs/tests/data/Path.json
@@ -1,0 +1,4675 @@
+{
+  "entities": [
+    {
+      "path": [["Path"], ["G0"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Graphs"]]
+            }
+          }
+        ],
+        "primaryKey": []
+      }
+    },
+    {
+      "path": [["Path"], ["G1"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Graphs"]]
+            }
+          }
+        ],
+        "primaryKey": []
+      }
+    },
+    {
+      "path": [["Path"], ["Graphs"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [],
+        "primaryKey": null
+      }
+    },
+    {
+      "path": [["Path"], ["G"], ["E"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Graphs"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["c"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          }
+        ],
+        "primaryKey": null
+      }
+    },
+    {
+      "path": [["Path"], ["G"], ["V"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Graphs"]]
+            }
+          }
+        ],
+        "primaryKey": null
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["E"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["y"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["E"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["E"]]
+            }
+          }
+        ],
+        "primaryKey": [[["a"]], [["x"]], [["y"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["V"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          }
+        ],
+        "primaryKey": [[["a"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["cons"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["y"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["z"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["E"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path0"], ["t"]]
+            }
+          },
+          {
+            "path": [["c"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path0"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["a"]], [["b"]], [["x"]], [["y"]], [["z"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["empty"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path0"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["x"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["t"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          }
+        ],
+        "primaryKey": null
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["cons"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["y"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["z"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["E"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path1"], ["t"]]
+            }
+          },
+          {
+            "path": [["c"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path1"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["a"]], [["b"]], [["x"]], [["y"]], [["z"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["empty"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path1"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["x"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["t"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          }
+        ],
+        "primaryKey": null
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["cons"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["y"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["z"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["e"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["E"]]
+            }
+          },
+          {
+            "path": [["p0"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path0"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["e"]], [["p0"]], [["x"]], [["y"]], [["z"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["empty"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          }
+        ],
+        "primaryKey": [[["x"]]]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["t"]],
+      "value": {
+        "entityVariant": {
+          "tag": "table"
+        },
+        "columns": [
+          {
+            "path": [["x"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["y"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["G"], ["V"]]
+            }
+          },
+          {
+            "path": [["a"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path0"], ["t"]]
+            }
+          },
+          {
+            "path": [["b"]],
+            "type": {
+              "tag": "rowId",
+              "path": [["Path"], ["Path1"], ["t"]]
+            }
+          }
+        ],
+        "primaryKey": [[["a"]], [["x"]], [["y"]]]
+      }
+    }
+  ],
+  "rules": [
+    {
+      "path": [["Path"], ["G0"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Graphs"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["G0"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [],
+        "varTypes": [],
+        "antecedents": [],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["G1"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G1"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Graphs"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["G1"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [],
+        "varTypes": [],
+        "antecedents": [],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G1"]],
+              "rowId": null,
+              "values": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Graphs"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [],
+        "varTypes": [],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Graphs"]],
+              "rowId": null,
+              "values": []
+            }
+          }
+        ],
+        "consequents": []
+      }
+    },
+    {
+      "path": [["Path"], ["G"], ["E"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]], [["b"]], [["c"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Graphs"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": []
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["G"], ["V"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Graphs"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": []
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["E"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["a"]],
+          [["b"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["a"], ["a"]],
+          [["b"], ["a"]],
+          [["b"], ["b"]],
+          [["b"], ["c"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["E"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G1"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["V"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["V"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["E"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["a"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["a"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["E"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["V"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]], [["b"]], [["a"], ["a"]], [["b"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["V"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G1"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Hom"], ["V"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [[["a"]], [["a"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Hom"], ["V"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["cons"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["a"]],
+          [["b"]],
+          [["c"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["a"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                },
+                {
+                  "column": 5,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 5
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["cons"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["a"]],
+          [["b"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["a"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["empty"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["x"]], [["a"]], [["x"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["empty"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [[["x"]], [["x"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path0"], ["t"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]], [["b"]], [["a"], ["a"]], [["b"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["cons"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["a"]],
+          [["b"]],
+          [["c"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["a"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                },
+                {
+                  "column": 5,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 5
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["cons"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["a"]],
+          [["b"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["a"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["empty"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["x"]], [["a"]], [["x"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["empty"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [[["x"]], [["x"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["Path1"], ["t"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [[["a"]], [["b"]], [["a"], ["a"]], [["b"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["cons"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["e"]],
+          [["p0"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["e"], ["a"]],
+          [["a"], ["lhs"]],
+          [["a"], ["lhs"], ["a"]],
+          [["a"], ["rhs"]],
+          [["a"], ["rhs"], ["b"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                },
+                {
+                  "column": 5,
+                  "term": {
+                    "tag": "var",
+                    "index": 10
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 10
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 9
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 12
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 12
+                  }
+                },
+                {
+                  "column": 5,
+                  "term": {
+                    "tag": "var",
+                    "index": 11
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "eq",
+            "left": {
+              "tag": "var",
+              "index": 9
+            },
+            "right": {
+              "tag": "var",
+              "index": 11
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["cons"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["z"]],
+          [["e"]],
+          [["p0"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]],
+          [["z"], ["a"]],
+          [["e"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["E"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 6
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 7
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["E"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 8
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 4
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["cons"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 4,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["empty"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["x"], ["a"]],
+          [["a"], ["lhs"]],
+          [["a"], ["lhs"], ["a"]],
+          [["a"], ["rhs"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "eq",
+            "left": {
+              "tag": "var",
+              "index": 2
+            },
+            "right": {
+              "tag": "var",
+              "index": 4
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["empty"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [[["x"]], [["x"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["empty"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["t"], ["foreignKey"]],
+      "value": {
+        "ruleVariant": "enforced",
+        "varNames": [
+          [["x"]],
+          [["y"]],
+          [["a"]],
+          [["b"]],
+          [["x"], ["a"]],
+          [["y"], ["a"]]
+        ],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path1"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                },
+                {
+                  "column": 3,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 5
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path1"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 3
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "path": [["Path"], ["PathHom"], ["t"], ["total"]],
+      "value": {
+        "ruleVariant": "monitored",
+        "varNames": [[["x"]], [["y"]], [["a"]], [["x"], ["a"]], [["y"], ["a"]]],
+        "varTypes": [
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["G"], ["V"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Path0"], ["t"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          },
+          {
+            "tag": "rowId",
+            "path": [["Path"], ["Graphs"]]
+          }
+        ],
+        "antecedents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G0"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 0
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 3
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["G"], ["V"]],
+              "rowId": {
+                "tag": "var",
+                "index": 1
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 4
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["Path0"], ["t"]],
+              "rowId": {
+                "tag": "var",
+                "index": 2
+              },
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "consequents": [
+          {
+            "tag": "atom",
+            "atom": {
+              "entity": [["Path"], ["PathHom"], ["t"]],
+              "rowId": null,
+              "values": [
+                {
+                  "column": 0,
+                  "term": {
+                    "tag": "var",
+                    "index": 0
+                  }
+                },
+                {
+                  "column": 1,
+                  "term": {
+                    "tag": "var",
+                    "index": 1
+                  }
+                },
+                {
+                  "column": 2,
+                  "term": {
+                    "tag": "var",
+                    "index": 2
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/packages/coln-query/src/host/print.rs
+++ b/packages/coln-query/src/host/print.rs
@@ -54,9 +54,9 @@ use super::{
 };
 use crate::relational::catalog::Catalog;
 use crate::relational::expr::{
-    AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-    FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr, OutputKind, ProjectionExpr, RelExpr,
-    RelExprVisitor, SelectionExpr, SourceExpr, UnionExpr,
+    AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr, DistinctExpr,
+    EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr, OutputKind, ProjectionExpr,
+    RelExpr, RelExprVisitor, SelectionExpr, SourceExpr, UnionExpr,
 };
 use std::fmt::Write;
 
@@ -336,6 +336,13 @@ impl RelExprVisitor<(), ()> for TreePrinter<'_> {
         }
     }
 
+    fn visit_constant_expr(&mut self, expr: &ConstantExpr, ctx: ()) {
+        // Renders itself entirely: it carries its schema and its rows,
+        // so there is no catalog to consult and nothing to look up.
+        // Long constants elide their tail, see `ConstantExpr`'s `Display`.
+        emit!(self, "Constant {expr}");
+    }
+
     fn visit_output_expr(&mut self, expr: &OutputExpr, ctx: ()) {
         let kind = match expr.kind {
             OutputKind::Cli => "cli",
@@ -451,10 +458,11 @@ mod tests {
     use crate::host::QueryIr;
     use crate::program::QueryProgram;
     use crate::relational::{
-        expr::{JoinVariable, SinkId},
+        expr::{JoinVariable, Multiplicity, SinkId},
+        relation::TupleValue,
         schema::TableSchema,
     };
-    use crate::scalarial::ScalarType;
+    use crate::scalarial::{ScalarType, ScalarTypedValue};
     use crate::test_utils::{TestProgram, table_schema};
 
     fn schema(name: &str) -> TableSchema {
@@ -542,6 +550,32 @@ mod tests {
                 .contains("init: Source \"edge\" (not in catalog)"),
             "{}",
             program.to_tree()
+        );
+    }
+
+    #[test]
+    fn a_constant_renders_its_own_shape_and_rows() {
+        // The counterpart of the two tests above: this leaf needs no catalog,
+        // because the rows and the schema are in the node. Copies are shown
+        // where they are not one, so a bag is distinguishable from a set.
+        let constant = ConstantExpr::new(
+            table_schema("digits", [("d", ScalarType::Uint)], []),
+            [
+                (
+                    TupleValue::new(vec![ScalarTypedValue::Uint(1)]),
+                    Multiplicity::new(2).expect("two copies"),
+                ),
+                (
+                    TupleValue::new(vec![ScalarTypedValue::Uint(2)]),
+                    Multiplicity::ONE,
+                ),
+            ],
+        )
+        .expect("valid rows");
+        let code = QueryIr::new(vec![expr_stmt(Expr::from(constant))]);
+        assert_eq!(
+            code.to_tree(),
+            "ExprStmt\n└─ expr: Constant (d: uint) [[1]×2, [2]]"
         );
     }
 

--- a/packages/coln-query/src/host/resolver.rs
+++ b/packages/coln-query/src/host/resolver.rs
@@ -14,9 +14,9 @@ use crate::{
         variable::SCOPES_CAPACITY,
     },
     relational::expr::{
-        AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-        FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr, ProjectionExpr, RelExpr,
-        RelExprVisitorMut, SelectionExpr, SourceExpr, UnionExpr,
+        AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr, DistinctExpr,
+        EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr, ProjectionExpr,
+        RelExpr, RelExprVisitorMut, SelectionExpr, SourceExpr, UnionExpr,
     },
 };
 use std::collections::HashMap;
@@ -313,6 +313,14 @@ impl RelExprVisitorMut<VisitorResult, VisitorCtx<'_, '_>> for Resolver {
     fn visit_source_expr(&mut self, expr: &mut SourceExpr, ctx: VisitorCtx) -> VisitorResult {
         // A source is a plan leaf that names an extensional relation; it carries
         // no variables to resolve.
+        Ok(())
+    }
+
+    fn visit_constant_expr(&mut self, expr: &mut ConstantExpr, ctx: VisitorCtx) -> VisitorResult {
+        // The other plan leaf: it carries rows rather than variables, so there
+        // is nothing to resolve. Its invariants need no re-check here either,
+        // unlike a `MultiWayEquiJoinExpr`, a constant cannot be assembled
+        // except through `ConstantExpr::new`, which checks them.
         Ok(())
     }
 

--- a/packages/coln-query/src/host/walk.rs
+++ b/packages/coln-query/src/host/walk.rs
@@ -43,7 +43,7 @@
 
 use crate::{
     host::{expr::Expr, stmt::Stmt},
-    relational::expr::{EquiJoinExpr, OutputExpr, RelExpr, SourceExpr},
+    relational::expr::{ConstantExpr, EquiJoinExpr, OutputExpr, RelExpr, SourceExpr},
 };
 
 /// A borrowed pointer to a node of any of the three mutually recursive node
@@ -136,6 +136,8 @@ impl<'a> Node<'a> {
         match rel {
             // A plan leaf: it only *names* an extensional relation.
             RelExpr::Source(_) => {}
+            // The other plan leaf: its rows are data it carries, not nodes.
+            RelExpr::Constant(_) => {}
             RelExpr::Output(expr) => out.push(Node::from(&expr.relation)),
             RelExpr::Alias(expr) => out.push(Node::from(&expr.relation)),
             RelExpr::Distinct(expr) => out.push(Node::from(&expr.relation)),
@@ -239,7 +241,16 @@ impl<'a> Node<'a> {
         })
     }
 
-    /// The [`SourceExpr`] leaf this node is, if any. What a plan-wide output
+    /// The [`ConstantExpr`] leaf this node is, if any. The counterpart of
+    /// [`as_source`](Self::as_source) on the other kind of leaf.
+    pub fn as_constant(self) -> Option<&'a ConstantExpr> {
+        self.as_rel().and_then(|expr| match expr {
+            RelExpr::Constant(constant) => Some(constant.as_ref()),
+            _ => None,
+        })
+    }
+
+    /// The [`OutputExpr`] tap this node is, if any. What a plan-wide output
     /// discovery filters a [walk](Walk) on.
     pub fn as_output(self) -> Option<&'a OutputExpr> {
         self.as_rel().and_then(|expr| match expr {

--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -34,15 +34,15 @@ mod test {
         relational::{
             Runtime,
             expr::{
-                AliasExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-                FixedPointIterExpr, OutputExpr, OutputKind, ProjectionExpr, SelectionExpr, SinkId,
-                SourceExpr, UnionExpr,
+                AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr,
+                EquiJoinExpr, FixedPointIterExpr, OutputExpr, OutputKind, ProjectionExpr,
+                SelectionExpr, SinkId, SourceExpr, SourceId, UnionExpr,
             },
             incremental::dbsp::{ZWeight, zset},
             relation::TupleValue,
         },
         scalarial::ScalarTypedValue,
-        test_utils::{TestProgram, person_profession_data, rows, rows_with_weight},
+        test_utils::{TestProgram, UnitRel, person_profession_data, rows, rows_with_weight},
     };
     use ::dbsp::OrdZSet;
     use test_utils::{EdgeRel, InputRel, PersonRel, PlainRel, PredRel, ProfessionRel, SetRel};
@@ -465,6 +465,121 @@ mod test {
             err.to_string().contains("edge"),
             "expected the error to name the unknown source, got: {err}"
         );
+    }
+
+    #[test]
+    fn empty_tuple_behavior_with_dbsp() -> anyhow::Result<()> {
+        const UNIT_REL: &'static str = "unit_rel";
+        const CONS_REL_1: &'static str = "cons_rel_1";
+        const CONS_REL_2: &'static str = "cons_rel_2";
+
+        let plan = vec![
+            Stmt::from(VarStmt {
+                name: "unit".to_string(),
+                initializer: Some(Expr::from(SourceExpr::new(UNIT_REL))),
+            }),
+            Stmt::from(VarStmt {
+                name: "cons_rel_1".to_string(),
+                initializer: Some(Expr::from(SourceExpr::new(CONS_REL_1))),
+            }),
+            Stmt::from(VarStmt {
+                name: "cons_rel_2".to_string(),
+                initializer: Some(Expr::from(SourceExpr::new(CONS_REL_2))),
+            }),
+            Stmt::from(VarStmt {
+                name: "joined".to_string(),
+                initializer: Some(Expr::from(EquiJoinExpr {
+                    left: Expr::from(VarExpr::new("cons_rel_1")),
+                    right: Expr::from(VarExpr::new("cons_rel_2")),
+                    on: vec![],
+                    attributes: None,
+                })),
+            }),
+            Stmt::from(VarStmt {
+                name: "antijoin".to_string(),
+                initializer: Some(Expr::from(OutputExpr {
+                    id: SinkId::from("antijoin"),
+                    kind: OutputKind::Channel,
+                    relation: Expr::from(AntiJoinExpr {
+                        left: Expr::from(VarExpr::new("unit")),
+                        right: Expr::from(VarExpr::new("joined")),
+                        on: vec![],
+                    }),
+                })),
+            }),
+        ];
+
+        let mut rt = Pipeline::incremental().runtime(&mut TestProgram::new(
+            plan,
+            [
+                UnitRel::named_schema(UNIT_REL),
+                UnitRel::named_schema(CONS_REL_1),
+                UnitRel::named_schema(CONS_REL_2),
+            ],
+        ))?;
+
+        let unit_rel_data = [
+            vec![(UnitRel::new_unit_tuple(), 1)],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        ];
+
+        let cons_rel_1_data = [
+            vec![
+                (UnitRel::new_unit_tuple(), 1),
+                (UnitRel::new_unit_tuple(), 1),
+                (UnitRel::new_unit_tuple(), 1),
+            ], // 3 entries
+            vec![(UnitRel::new_unit_tuple(), -3)], // 0 entries
+            vec![(UnitRel::new_unit_tuple(), 1)],  // 1 entry
+            vec![],                                // 1 entry
+            vec![],                                // 1 entry
+            vec![],                                // 1 entry
+        ];
+
+        let cons_rel_2_data = [
+            vec![(UnitRel::new_unit_tuple(), 1)],  // 1 entry
+            vec![],                                // 1 entry
+            vec![(UnitRel::new_unit_tuple(), 1)],  // 2 entries
+            vec![(UnitRel::new_unit_tuple(), -3)], // -1 entries
+            vec![(UnitRel::new_unit_tuple(), 1)],  // 0 entries
+            vec![(UnitRel::new_unit_tuple(), 1)],  // 1 entry
+        ];
+
+        let expected_antijoin_output = [
+            zset! {},               // no violation
+            zset! {tuple!() => 1},  // a violation
+            zset! {tuple!() => -1}, // violation retracted
+            zset! {tuple!() => 1},  // a new violation
+            zset! {},               // still a violation
+            zset! {tuple!() => -1}, // violation retracted
+        ];
+
+        for (step, (((unit_rel_data, cons_rel_1_data), cons_rel_2_data), expected_output)) in
+            unit_rel_data
+                .into_iter()
+                .zip(cons_rel_1_data.into_iter())
+                .zip(cons_rel_2_data.into_iter())
+                .zip(expected_antijoin_output.into_iter())
+                .enumerate()
+        {
+            assert!(rt.feed(&SourceId::from(UNIT_REL), rows(unit_rel_data))?);
+            assert!(rt.feed(&SourceId::from(CONS_REL_1), rows(cons_rel_1_data))?);
+            assert!(rt.feed(&SourceId::from(CONS_REL_2), rows(cons_rel_2_data))?);
+
+            rt.commit()?;
+
+            let antijoin = rt.output(&SinkId::from("antijoin"))?;
+            print!(
+                "ANTIJOIN in {step}\n{}",
+                antijoin.debug_view(true).to_cli_table()?
+            );
+            assert_eq!(antijoin.debug_view(false).to_zset(), expected_output);
+        }
+        Ok(())
     }
 
     #[test]

--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -34,15 +34,17 @@ mod test {
         relational::{
             Runtime,
             expr::{
-                AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr,
-                EquiJoinExpr, FixedPointIterExpr, OutputExpr, OutputKind, ProjectionExpr,
-                SelectionExpr, SinkId, SourceExpr, SourceId, UnionExpr,
+                AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr,
+                DistinctExpr, EquiJoinExpr, FixedPointIterExpr, Multiplicity, OutputExpr,
+                OutputKind, ProjectionExpr, SelectionExpr, SinkId, SourceExpr, SourceId, UnionExpr,
             },
             incremental::dbsp::{ZWeight, zset},
             relation::TupleValue,
         },
-        scalarial::ScalarTypedValue,
-        test_utils::{TestProgram, UnitRel, person_profession_data, rows, rows_with_weight},
+        scalarial::{ScalarType, ScalarTypedValue},
+        test_utils::{
+            TestProgram, UnitRel, person_profession_data, rows, rows_with_weight, table_schema,
+        },
     };
     use ::dbsp::OrdZSet;
     use test_utils::{EdgeRel, InputRel, PersonRel, PlainRel, PredRel, ProfessionRel, SetRel};
@@ -467,16 +469,19 @@ mod test {
         );
     }
 
+    /// This simulates checking a rule with an empty antecedent. For the empty
+    /// antecedent, a relation containing only one unit tuple (a 0-tuple with no
+    /// fields) is used ("unit"). This unit relation behavee exactly like a
+    /// source that was fed the unit tuple once and never touched again.
     #[test]
-    fn empty_tuple_behavior_with_dbsp() -> anyhow::Result<()> {
-        const UNIT_REL: &'static str = "unit_rel";
-        const CONS_REL_1: &'static str = "cons_rel_1";
-        const CONS_REL_2: &'static str = "cons_rel_2";
+    fn empty_tuple_behavior_with_a_constant_unit_relation() -> anyhow::Result<()> {
+        const CONS_REL_1: &str = "cons_rel_1";
+        const CONS_REL_2: &str = "cons_rel_2";
 
         let plan = vec![
             Stmt::from(VarStmt {
                 name: "unit".to_string(),
-                initializer: Some(Expr::from(SourceExpr::new(UNIT_REL))),
+                initializer: Some(Expr::from(ConstantExpr::unit())),
             }),
             Stmt::from(VarStmt {
                 name: "cons_rel_1".to_string(),
@@ -512,20 +517,10 @@ mod test {
         let mut rt = Pipeline::incremental().runtime(&mut TestProgram::new(
             plan,
             [
-                UnitRel::named_schema(UNIT_REL),
                 UnitRel::named_schema(CONS_REL_1),
                 UnitRel::named_schema(CONS_REL_2),
             ],
         ))?;
-
-        let unit_rel_data = [
-            vec![(UnitRel::new_unit_tuple(), 1)],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-        ];
 
         let cons_rel_1_data = [
             vec![
@@ -558,15 +553,12 @@ mod test {
             zset! {tuple!() => -1}, // violation retracted
         ];
 
-        for (step, (((unit_rel_data, cons_rel_1_data), cons_rel_2_data), expected_output)) in
-            unit_rel_data
-                .into_iter()
-                .zip(cons_rel_1_data.into_iter())
-                .zip(cons_rel_2_data.into_iter())
-                .zip(expected_antijoin_output.into_iter())
-                .enumerate()
+        for (step, ((cons_rel_1_data, cons_rel_2_data), expected_output)) in cons_rel_1_data
+            .into_iter()
+            .zip(cons_rel_2_data)
+            .zip(expected_antijoin_output)
+            .enumerate()
         {
-            assert!(rt.feed(&SourceId::from(UNIT_REL), rows(unit_rel_data))?);
             assert!(rt.feed(&SourceId::from(CONS_REL_1), rows(cons_rel_1_data))?);
             assert!(rt.feed(&SourceId::from(CONS_REL_2), rows(cons_rel_2_data))?);
 
@@ -579,6 +571,54 @@ mod test {
             );
             assert_eq!(antijoin.debug_view(false).to_zset(), expected_output);
         }
+        Ok(())
+    }
+
+    /// This tests what "static bag" means to an incremental backend:
+    /// The multiplicities arrive as one delta in the first transaction,
+    /// and every later transaction reports no change. This is truthful to the
+    /// definition, as the relation's *contents* stay what the plan says,
+    /// so its *changes* are empty from then on.
+    ///
+    /// A plan with no sources at all, incidentally: a constant needs nothing
+    /// bound to it.
+    #[test]
+    fn a_constant_relation_delivers_its_multiplicities_once() -> anyhow::Result<()> {
+        let constant = ConstantExpr::new(
+            table_schema("digits", [("d", ScalarType::Uint)], []),
+            [
+                (tuple!(1u64), Multiplicity::new(2).expect("two copies")),
+                (tuple!(2u64), Multiplicity::ONE),
+            ],
+        )?;
+
+        let plan = vec![Stmt::from(VarStmt {
+            name: "digits".to_string(),
+            initializer: Some(Expr::from(OutputExpr {
+                id: SinkId::from("digits"),
+                kind: OutputKind::Channel,
+                relation: Expr::from(constant),
+            })),
+        })];
+
+        let mut rt = Pipeline::incremental().runtime(&mut TestProgram::new(plan, []))?;
+        rt.commit()?;
+
+        assert_eq!(
+            rt.output(&SinkId::from("digits"))?
+                .debug_view(false)
+                .to_zset(),
+            zset! {tuple!(1u64) => 2, tuple!(2u64) => 1},
+        );
+
+        rt.commit()?;
+        assert_eq!(
+            rt.output(&SinkId::from("digits"))?
+                .debug_view(false)
+                .to_zset(),
+            zset! {},
+            "a constant relation never changes, so it has no further deltas"
+        );
         Ok(())
     }
 
@@ -1107,6 +1147,86 @@ mod test {
             }),
             output_stmt("reachable"),
         ]
+    }
+
+    #[test]
+    fn constant_leaf_inside_fixed_point_step_is_bridged() -> anyhow::Result<()> {
+        // The same reachability as `source_leaf_inside_fixed_point_step_is_bridged`,
+        // with both relations carried by the plan instead of fed: the seed
+        // outside the step, the edges *only* inside it. A constant is
+        // loop-invariant, so it is wired at the root and `delta0`'d into the
+        // nested circuit exactly as a source or an outer variable is.
+        //
+        // A plan with no sources at all, hence nothing to feed before the commit.
+        let seed = ConstantExpr::set(
+            table_schema("seed", [("node", ScalarType::Uint)], []),
+            [tuple!(0_u64)],
+        )?;
+        let edges = ConstantExpr::set(
+            table_schema(
+                "edges",
+                [("from", ScalarType::Uint), ("to", ScalarType::Uint)],
+                [],
+            ),
+            [
+                tuple!(0_u64, 1_u64),
+                tuple!(1_u64, 2_u64),
+                tuple!(2_u64, 3_u64),
+            ],
+        )?;
+
+        let plan = vec![
+            Stmt::from(VarStmt {
+                name: "base".to_string(),
+                initializer: Some(Expr::from(seed)),
+            }),
+            Stmt::from(VarStmt {
+                name: "reachable".to_string(),
+                initializer: Some(Expr::from(FixedPointIterExpr {
+                    accumulator: ("reachable".to_string(), Expr::from(VarExpr::new("base"))),
+                    step: BlockStmt {
+                        stmts: vec![Stmt::from(ExprStmt {
+                            expr: Expr::from(EquiJoinExpr {
+                                left: Expr::from(AliasExpr {
+                                    relation: Expr::from(VarExpr::new("reachable")),
+                                    alias: "cur".to_string(),
+                                }),
+                                right: Expr::from(AliasExpr {
+                                    relation: Expr::from(edges),
+                                    alias: "edge".to_string(),
+                                }),
+                                on: vec![(
+                                    Expr::from(VarExpr::new("node")),
+                                    Expr::from(VarExpr::new("from")),
+                                )],
+                                attributes: Some(vec![(
+                                    "node".to_string(),
+                                    Expr::from(VarExpr::new("edge.to")),
+                                )]),
+                            }),
+                        })],
+                    },
+                })),
+            }),
+            output_stmt("reachable"),
+        ];
+
+        let mut rt = Pipeline::incremental().runtime(&mut TestProgram::new(plan, []))?;
+        rt.commit()?;
+
+        assert_eq!(
+            rt.output(&SinkId::from("reachable"))?
+                .debug_view(false)
+                .to_zset(),
+            zset! {
+                tuple!(0_u64) => 1,
+                tuple!(1_u64) => 1,
+                tuple!(2_u64) => 1,
+                tuple!(3_u64) => 1,
+            }
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/packages/coln-query/src/optimizer/rewrite.rs
+++ b/packages/coln-query/src/optimizer/rewrite.rs
@@ -68,9 +68,9 @@ use crate::{
         stmt::{BlockStmt, ExprStmt, Stmt, StmtVisitorOwn, VarStmt},
     },
     relational::expr::{
-        AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-        FixedPointIterExpr, JoinVariable, MultiWayEquiJoinExpr, OutputExpr, ProjectionExpr,
-        RelExpr, RelExprVisitorOwn, RelKind, SelectionExpr, SourceExpr, UnionExpr,
+        AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr, DistinctExpr,
+        EquiJoinExpr, FixedPointIterExpr, JoinVariable, MultiWayEquiJoinExpr, OutputExpr,
+        ProjectionExpr, RelExpr, RelExprVisitorOwn, RelKind, SelectionExpr, SourceExpr, UnionExpr,
     },
 };
 
@@ -382,6 +382,10 @@ impl ExprVisitorOwn<VisitorResult<Expr>, ()> for Rewriter<'_> {
 /// [`Rewriter::child`], on the way in.
 impl RelExprVisitorOwn<VisitorResult<Expr>, ()> for Rewriter<'_> {
     fn visit_source_expr(&mut self, expr: Box<SourceExpr>, _ctx: ()) -> VisitorResult<Expr> {
+        self.offer(expr.into(), Direction::BottomUp)
+    }
+
+    fn visit_constant_expr(&mut self, expr: Box<ConstantExpr>, _ctx: ()) -> VisitorResult<Expr> {
         self.offer(expr.into(), Direction::BottomUp)
     }
 

--- a/packages/coln-query/src/relational/batch/lowering.rs
+++ b/packages/coln-query/src/relational/batch/lowering.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result, bail};
 use coln_batch::query::{Atom, Term};
+use coln_batch::relation::Relation;
 use coln_batch::rule::{Program, Rule};
 
 use crate::host::QueryIr;
@@ -36,8 +37,11 @@ use crate::host::operator::Operator;
 use crate::host::stmt::{Stmt, VarStmt};
 use crate::relational::catalog::SourceSchemas;
 use crate::relational::expr::{
-    EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, OutputKind, RelExpr, SourceExpr,
+    ConstantExpr, EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, Multiplicity, OutputKind,
+    RelExpr, SourceExpr,
 };
+use crate::relational::relation::Tuple;
+use crate::scalarial::ScalarTypedValue;
 
 /// The result of lowering a logical plan.
 #[derive(Debug)]
@@ -46,6 +50,10 @@ pub struct LoweredPlan {
     pub program: Program,
     /// Source id (schema name) to column names, in tuple order.
     pub sources: HashMap<String, Vec<String>>,
+    /// The plan's [`ConstantExpr`] leaves, already materialized: their rows are
+    /// in the plan, so unlike a source there is nothing to wait for and the
+    /// base table can be built at lowering time.
+    pub constants: Vec<Relation>,
     /// Sink id to the derived relation `output` reads.
     pub outputs: HashMap<String, String>,
     /// Column names per relation, sources and derived alike.
@@ -76,11 +84,19 @@ pub fn lower(ir: &QueryIr, sources: &SourceSchemas) -> Result<LoweredPlan> {
     for (name, info) in &lowerer.env {
         schemas.insert(name.clone(), info.columns.clone());
     }
+    for (_, relation) in &lowerer.constants {
+        schemas.insert(relation.name.clone(), relation.col_names.clone());
+    }
     Ok(LoweredPlan {
         program: Program {
             rules: lowerer.rules,
         },
         sources: lowerer.sources,
+        constants: lowerer
+            .constants
+            .into_iter()
+            .map(|(_, relation)| relation)
+            .collect(),
         outputs: lowerer.outputs,
         schemas,
     })
@@ -179,6 +195,10 @@ struct Lowerer {
     available_sources: HashMap<String, Vec<String>>,
     /// The subset of `available_sources` the plan actually uses.
     sources: HashMap<String, Vec<String>>,
+    /// One entry per *distinct* constant the plan carries, in the order it was
+    /// first reached: the node, and the base table its rows were turned into.
+    /// Keyed by content, so two occurrences of one constant share a relation.
+    constants: Vec<(ConstantExpr, Relation)>,
     env: HashMap<String, RelInfo>,
     outputs: HashMap<String, String>,
 }
@@ -346,6 +366,7 @@ impl Lowerer {
             }
             Expr::Relational(rel) => match rel {
                 RelExpr::Source(source) => self.lower_source(source, frame),
+                RelExpr::Constant(constant) => self.lower_constant(constant, frame),
                 RelExpr::Alias(alias) => {
                     let inner = self.lower_rel(&alias.relation, frame)?;
                     let mut names = inner.names.clone();
@@ -406,6 +427,70 @@ impl Lowerer {
         self.sources.insert(id.clone(), columns.clone());
         let info = RelInfo {
             relation: id,
+            columns,
+        };
+        Ok(self.scope_from_atom(&info, frame))
+    }
+
+    /// A constant is a base table too — the plan just happens to carry its rows
+    /// instead of naming someone who feeds them, so it is materialized here and
+    /// then read exactly like a source.
+    ///
+    /// Two limits of this backend's value slice bite here, and both fail loudly
+    /// rather than computing something slightly wrong: a coln-batch relation is
+    /// a *set*, so a row held more than once has nowhere to put its copies; and
+    /// its data is column-major with the row count read off the first column,
+    /// so a relation with no columns cannot hold a row at all — which is
+    /// precisely the unit relation.
+    fn lower_constant(&mut self, constant: &ConstantExpr, frame: &mut Frame) -> Result<Scope> {
+        if let Some((_, relation)) = self
+            .constants
+            .iter()
+            .find(|(lowered, _)| lowered == constant)
+        {
+            let info = RelInfo {
+                relation: relation.name.clone(),
+                columns: relation.col_names.clone(),
+            };
+            return Ok(self.scope_from_atom(&info, frame));
+        }
+        let columns: Vec<String> = constant
+            .schema()
+            .columns()
+            .iter()
+            .map(|column| column.name().to_string())
+            .collect();
+        if columns.is_empty() && !constant.is_empty() {
+            bail!(
+                "batch lowering cannot represent the constant relation {constant}: a \
+                 coln-batch relation stores its data column by column, so one with no \
+                 columns cannot hold a row"
+            );
+        }
+        let mut cols: Vec<Vec<u64>> =
+            vec![Vec::with_capacity(constant.rows().len()); columns.len()];
+        for (row, copies) in constant.rows() {
+            if *copies != Multiplicity::ONE {
+                bail!(
+                    "batch lowering cannot represent the constant relation {constant}: \
+                     coln-batch relations are sets, so row {} cannot be held {} times",
+                    row.data_to_string(),
+                    copies.get()
+                );
+            }
+            for (column, value) in cols.iter_mut().zip(&row.data) {
+                column.push(constant_value(constant, value)?);
+            }
+        }
+        // Synthetic: nothing addresses a constant, so the name only has to be
+        // unique among the program's relations and recognisable in a rule dump.
+        // The `__` prefix is the convention that keeps it clear of a source (a
+        // catalog path) and of a derived relation (a plan variable's name).
+        let name = format!("__const{}", self.constants.len());
+        let relation = Relation::new(name.clone(), columns.clone(), cols);
+        self.constants.push((constant.clone(), relation));
+        let info = RelInfo {
+            relation: name,
             columns,
         };
         Ok(self.scope_from_atom(&info, frame))
@@ -728,6 +813,22 @@ impl Lowerer {
     }
 }
 
+/// One cell of a constant relation in the engine's u64 universe.
+///
+/// The same value slice [`convert_row`](super::convert_row) accepts on the feed
+/// path — unsigned integers and booleans — so a constant cannot smuggle a type
+/// past a restriction a fed row would have been rejected for.
+fn constant_value(constant: &ConstantExpr, value: &ScalarTypedValue) -> Result<u64> {
+    match value {
+        ScalarTypedValue::Uint(value) => Ok(*value),
+        ScalarTypedValue::Bool(value) => Ok(u64::from(*value)),
+        other => bail!(
+            "batch lowering cannot represent the constant relation {constant}: the \
+             backend supports unsigned integer and boolean values, got {other}"
+        ),
+    }
+}
+
 #[cfg(test)]
 mod tests {
     //! A guided tour of the translation, from a single source scan to a
@@ -741,8 +842,11 @@ mod tests {
         AliasExpr, AntiJoinExpr, CartesianProductExpr, DistinctExpr, JoinVariable, OutputExpr,
         ProjectionExpr, SelectionExpr, SinkId, SourceId, UnionExpr,
     };
+    use crate::relational::relation::TupleValue;
     use crate::relational::schema::{Column, EntityRef, TableSchema};
     use crate::scalarial::ScalarType;
+    use crate::test_utils::table_schema;
+    use crate::tuple;
     use coln_batch::fixpoint::{self, Exec};
     use coln_batch::generic_join;
     use coln_batch::query::Catalog;
@@ -1323,10 +1427,76 @@ mod tests {
         );
     }
 
-    /// Step 14: everything outside this slice fails loudly with a clear
+    /// Step 14: a constant is a base table the plan brought with it. Nothing
+    /// feeds it, so lowering materializes it right here and the rule body reads
+    /// it exactly as it reads a source.
+    #[test]
+    fn s14_a_constant_becomes_a_materialized_base_table() {
+        let pairs = table_schema(
+            "pairs",
+            [("a", ScalarType::Uint), ("b", ScalarType::Uint)],
+            [],
+        );
+        let constant = ConstantExpr::set(pairs, [tuple!(1u64, 2u64), tuple!(3u64, 4u64)]).unwrap();
+        let plan = lower_plan(vec![let_rel("pairs", constant), out("pairs")]).unwrap();
+
+        // One materialized table, and the body reads it under the synthetic
+        // name — nothing addresses a constant, so the name only has to be
+        // unique and recognisable.
+        assert_eq!(plan.constants.len(), 1);
+        assert_eq!(plan.constants[0].name, "__const0");
+        assert_eq!(plan.constants[0].col_names, vec!["a", "b"]);
+        assert_eq!(plan.program.rules[0].body[0].relation, "__const0");
+        assert_eq!(plan.schemas["__const0"], vec!["a", "b"]);
+
+        // The runtime hands these to the fixpoint alongside the fed sources
+        // (see `BatchRuntime::materialize_sources`), which is what this mimics.
+        let result = run(&plan, {
+            let mut edb = Catalog::new();
+            for constant in &plan.constants {
+                edb.insert(constant.clone());
+            }
+            edb
+        });
+        assert_eq!(
+            rows(result.get("pairs").unwrap()),
+            vec![vec![1, 2], vec![3, 4]]
+        );
+    }
+
+    /// Step 15: two of this backend's limits meet the plan's bag semantics, and
+    /// both say so instead of quietly dropping copies or rows.
+    #[test]
+    fn s15_a_constant_beyond_this_backends_value_slice_fails_loudly() {
+        // coln-batch relations are sets, so copies have nowhere to go.
+        let twice = ConstantExpr::set(
+            table_schema("ones", [("a", ScalarType::Uint)], []),
+            [tuple!(1u64), tuple!(1u64)],
+        )
+        .unwrap();
+        let err = lower_plan(vec![let_rel("ones", twice)]).unwrap_err();
+        assert!(format!("{err:#}").contains("sets"));
+
+        // A relation stored column by column reads its row count off the first
+        // column, so with no columns it cannot hold a row — which is exactly
+        // what the unit relation is.
+        let err = lower_plan(vec![let_rel("unit", ConstantExpr::unit())]).unwrap_err();
+        assert!(format!("{err:#}").contains("cannot hold a row"));
+
+        // Only unsigned integers and booleans map onto the u64 universe.
+        let strings = ConstantExpr::set(
+            table_schema("words", [("w", ScalarType::String)], []),
+            [TupleValue::new(vec![ScalarTypedValue::String("a".into())])],
+        )
+        .unwrap();
+        let err = lower_plan(vec![let_rel("words", strings)]).unwrap_err();
+        assert!(format!("{err:#}").contains("unsigned integer and boolean"));
+    }
+
+    /// Step 16: everything outside this slice fails loudly with a clear
     /// message instead of producing a wrong answer.
     #[test]
-    fn s14_unsupported_features_fail_loudly() {
+    fn s16_unsupported_features_fail_loudly() {
         let err = lower_plan(vec![let_rel(
             "anti",
             Expr::from(AntiJoinExpr {

--- a/packages/coln-query/src/relational/batch/mod.rs
+++ b/packages/coln-query/src/relational/batch/mod.rs
@@ -95,6 +95,7 @@ impl<E: ColumnScalarEngine> Backend for BatchBackend<E> {
         let LoweredPlan {
             program,
             sources: used_sources,
+            constants,
             outputs,
             schemas,
         } = lower(plan.as_code(), &sources)
@@ -112,6 +113,7 @@ impl<E: ColumnScalarEngine> Backend for BatchBackend<E> {
             outputs,
             schemas,
             inputs,
+            constants,
             sinks,
             results: None,
         })
@@ -130,6 +132,10 @@ pub struct BatchRuntime {
     /// the interim snapshot store described in the module docs; the pull
     /// API replaces it.
     inputs: HashMap<String, HashMap<Vec<u64>, ZWeight>>,
+    /// The base tables the plan's constants *are*. Unlike `inputs` these need
+    /// no integration and never change: the plan states them, so lowering
+    /// materialized them once (see [`LoweredPlan::constants`]).
+    constants: Vec<Relation>,
     sinks: Vec<SinkId>,
     /// The relations of the last commit.
     results: Option<BatchCatalog>,
@@ -221,6 +227,11 @@ impl BatchRuntime {
                 }
             }
             edb.insert(Relation::new(source.clone(), columns, data));
+        }
+        // A constant is a base table like any other; it just came from the plan
+        // rather than through `feed`, so there are no deltas to integrate.
+        for constant in &self.constants {
+            edb.insert(constant.clone());
         }
         Ok(edb)
     }

--- a/packages/coln-query/src/relational/expr.rs
+++ b/packages/coln-query/src/relational/expr.rs
@@ -13,8 +13,14 @@
 use crate::{
     error::SyntaxError,
     host::{expr::Expr, stmt::BlockStmt},
+    relational::{
+        relation::{Tuple, TupleValue},
+        schema::{EntityRef, TableSchema},
+    },
+    scalarial::{ScalarType, ScalarTypedValue},
 };
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
+use std::num::NonZeroU64;
 
 /// Relational-algebra operator = backend-neutral query-plan vocabulary.
 ///
@@ -26,6 +32,9 @@ pub enum RelExpr {
     /// carrying its runtime representation (no stream, no table). The backend
     /// binds the [`SourceId`] to a concrete relation at execution time.
     Source(Box<SourceExpr>),
+    /// The other leaf of the relational plan: a relation the plan *carries*
+    /// rather than names, as a fixed bag of rows. Nothing binds it.
+    Constant(Box<ConstantExpr>),
     Output(Box<OutputExpr>),
     Alias(Box<AliasExpr>),
     Distinct(Box<DistinctExpr>),
@@ -82,6 +91,7 @@ macro_rules! impl_rel_and_expr_from {
 
 impl_rel_and_expr_from! {
     (RelExpr::Source, SourceExpr),
+    (RelExpr::Constant, ConstantExpr),
     (RelExpr::Output, OutputExpr),
     (RelExpr::Alias, AliasExpr),
     (RelExpr::Distinct, DistinctExpr),
@@ -116,6 +126,7 @@ impl From<RelExpr> for Expr {
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
 pub enum RelKind {
     Source,
+    Constant,
     Output,
     Alias,
     Distinct,
@@ -134,6 +145,7 @@ impl RelKind {
     /// Every kind, for a rule that has to see the whole plan.
     pub const ALL: &'static [RelKind] = &[
         RelKind::Source,
+        RelKind::Constant,
         RelKind::Output,
         RelKind::Alias,
         RelKind::Distinct,
@@ -154,6 +166,7 @@ impl RelExpr {
     pub fn kind(&self) -> RelKind {
         match self {
             RelExpr::Source(_) => RelKind::Source,
+            RelExpr::Constant(_) => RelKind::Constant,
             RelExpr::Output(_) => RelKind::Output,
             RelExpr::Alias(_) => RelKind::Alias,
             RelExpr::Distinct(_) => RelKind::Distinct,
@@ -245,6 +258,300 @@ impl SourceExpr {
 
     pub fn as_id(&self) -> &SourceId {
         &self.id
+    }
+}
+
+/// How many copies of a row a [`ConstantExpr`] holds.
+///
+/// Unsigned and non-zero, unlike a
+/// [`ZWeight`](crate::relational::incremental::dbsp::ZWeight).
+/// A relation the plan *states* cannot hold a negative number of copies of a
+/// row, and zero copies is the absence of a row rather than an entry about it.
+/// Keeping the zweight out of the plan layer is what makes both unrepresentable
+/// instead of merely wrong.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct Multiplicity(NonZeroU64);
+
+impl Multiplicity {
+    /// A row present exactly once, which is what set-shaped data means.
+    pub const ONE: Self = Self(NonZeroU64::MIN);
+
+    /// [`None`] for zero copies; see the type's docs.
+    pub fn new(copies: u64) -> Option<Self> {
+        NonZeroU64::new(copies).map(Self)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0.get()
+    }
+
+    /// Fold two entries for the same row into one. [`None`] on overflow, which
+    /// [`ConstantExpr::new`] reports rather than wrapping around.
+    fn checked_add(self, other: Self) -> Option<Self> {
+        self.0.checked_add(other.get()).map(Self)
+    }
+}
+
+impl std::fmt::Display for Multiplicity {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "×{}", self.0)
+    }
+}
+
+/// The name [`ConstantExpr::unit`] labels its schema with. A constant is not
+/// bound by name, so this is a label for diagnostics rather than an identity.
+const UNIT_NAME: &str = "unit";
+
+/// How many rows a rendered constant shows before eliding the rest: enough to
+/// recognise which relation it is, few enough that a plan dump stays readable.
+const RENDERED_ROWS: usize = 8;
+
+/// A relation the plan carries: a fixed bag of rows, fully determined before
+/// execution. The second kind of plan leaf and [`SourceExpr`]'s counterpart —
+/// that one names rows a driver feeds, this one holds them, so nothing binds it
+/// and no [`Catalog`](crate::relational::catalog::Catalog) describes it.
+///
+/// **What "static" means for incremental computations.** It is a claim about
+/// time: the rows are there from the first commit on and are never retracted.
+/// A backend therefore emits them as *one* delta, and the integrated value is
+/// [`rows`](Self::rows) at every step. That is also what makes a constant
+/// loop-invariant inside a [`FixedPointIterExpr`] step, where it enters the
+/// iteration exactly like an outer relation does.
+///
+/// **A bag, not a set.** A row may be present several times according to its
+/// [`Multiplicity`]. Multiplicity is observable only through operators
+/// which count, e.g. a join multiplies the weights of its operands, so joining
+/// against a row held twice doubles the other side. A [`DistinctExpr`]
+/// collapses duplicates into one occurrence.
+///
+/// **Canonical form.** [`new`](Self::new) folds equal rows into one entry and
+/// orders them, so the derived [`PartialEq`] is bag equality rather than
+/// "written in the same order". That is what lets a rewrite rule recognise two
+/// occurrences of one constant as the same relation, and a plan assertion in a
+/// test not depend on the order the rows were listed in.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ConstantExpr {
+    /// What the rows *are*: named, typed columns plus the key(s) over them. The
+    /// same vocabulary a [`Catalog`](crate::relational::catalog::Catalog)
+    /// answers with for a [`SourceExpr`], so everything downstream, the type
+    /// resolver, each backend's physical schema, reuses the source path instead
+    /// of growing a second notion of what a relation looks like.
+    ///
+    /// Declared rather than inferred from the rows: the arity of a constant with
+    /// no rows is unrecoverable, and a projection above it needs names and types
+    /// either way. Its [`name`](TableSchema::name) is a diagnostic label, not an
+    /// identity anything binds against.
+    schema: TableSchema,
+    /// The rows and how many copies of each, in [canonical form](ConstantExpr).
+    rows: Vec<(TupleValue, Multiplicity)>,
+}
+
+impl ConstantExpr {
+    /// The _only_ constructor and it cannot produce a malformed constant, as
+    /// it canonicalizes the rows and then applies [`validate`](Self::validate).
+    pub fn new(
+        schema: TableSchema,
+        rows: impl IntoIterator<Item = (TupleValue, Multiplicity)>,
+    ) -> Result<Self, SyntaxError> {
+        let mut constant = Self {
+            schema,
+            rows: rows.into_iter().collect(),
+        };
+        constant.canonicalize()?;
+        constant.validate()?;
+        Ok(constant)
+    }
+
+    /// Set-shaped data: every listed row present once. Listing a row twice is
+    /// not an error — it is a bag holding two copies of it, see
+    /// [`Multiplicity`].
+    pub fn set(
+        schema: TableSchema,
+        rows: impl IntoIterator<Item = TupleValue>,
+    ) -> Result<Self, SyntaxError> {
+        Self::new(schema, rows.into_iter().map(|row| (row, Multiplicity::ONE)))
+    }
+
+    /// The relation holding exactly the *unit tuple*: no columns, one 0-tuple.
+    /// The neutral element of the join, which is what a rule with an empty
+    /// antecedent needs its body to be.
+    ///
+    /// Valid by construction: No columns to disagree with and no declared key
+    /// to violate. Hence, this skips [`validate`](Self::validate).
+    pub fn unit() -> Self {
+        Self {
+            schema: TableSchema::new(EntityRef::from(UNIT_NAME), vec![], vec![]),
+            rows: vec![(TupleValue::empty(), Multiplicity::ONE)],
+        }
+    }
+
+    /// No rows at all over `schema`: the neutral element of the union. Valid by
+    /// construction, as [`unit`](Self::unit) is.
+    pub fn empty(schema: TableSchema) -> Self {
+        Self {
+            schema,
+            rows: Vec::new(),
+        }
+    }
+
+    pub fn schema(&self) -> &TableSchema {
+        &self.schema
+    }
+
+    /// The rows, canonical: each distinct row once, with its multiplicity,
+    /// ordered.
+    pub fn rows(&self) -> &[(TupleValue, Multiplicity)] {
+        &self.rows
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    /// Whether this is [`unit`](Self::unit) _with a single copy_ of the 0-tuple:
+    /// the join's neutral element, and so the one shape a join-elimination rule
+    /// may drop. At multiplicity `m` the join would scale its other operand by
+    /// `m` instead, which is why the test is not just "no columns, one row".
+    pub fn is_unit(&self) -> bool {
+        self.schema.columns().is_empty() && self.rows == [(TupleValue::empty(), Multiplicity::ONE)]
+    }
+
+    /// Fold equal rows into one entry and put the entries in a deterministic
+    /// order, which is what makes the derived [`PartialEq`] bag equality.
+    fn canonicalize(&mut self) -> Result<(), SyntaxError> {
+        self.rows
+            .sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+        let mut canonical: Vec<(TupleValue, Multiplicity)> = Vec::with_capacity(self.rows.len());
+        for (row, copies) in std::mem::take(&mut self.rows) {
+            match canonical.last_mut() {
+                // Sorted, so equal rows are adjacent and the fold is local.
+                Some((kept, kept_copies)) if *kept == row => {
+                    *kept_copies = kept_copies.checked_add(copies).ok_or_else(|| {
+                        SyntaxError::new(format!(
+                            "the copies of row {} in a constant relation sum beyond u64",
+                            row.data_to_string()
+                        ))
+                    })?;
+                }
+                _ => canonical.push((row, copies)),
+            }
+        }
+        self.rows = canonical;
+        Ok(())
+    }
+
+    /// Checks what the fields cannot enforce on their own.
+    fn validate(&self) -> Result<(), SyntaxError> {
+        self.validate_rows().and_then(|_| self.validate_keys())
+    }
+
+    /// Every row matches the declared columns, and every multiplicity is one a
+    /// backend can carry.
+    fn validate_rows(&self) -> Result<(), SyntaxError> {
+        let columns = self.schema.columns();
+        for (row, copies) in &self.rows {
+            let arity = row.data.len();
+            if arity != columns.len() {
+                return Err(SyntaxError::new(format!(
+                    "row {} of constant relation '{}' has {arity} value(s) \
+                    but its schema declares {} column(s)",
+                    row.data_to_string(),
+                    self.schema.name(),
+                    columns.len()
+                )));
+            }
+            for (column, value) in columns.iter().zip(&row.data) {
+                let actual = value.scalar_type();
+                // A null stands in for a value of any declared type: nothing in
+                // a `Column` claims otherwise, so rejecting it here would be
+                // inventing a non-nullability the schema does not state.
+                if actual != ScalarType::Null && actual != column.scalar_type() {
+                    return Err(SyntaxError::new(format!(
+                        "row {} of constant relation '{}' holds a {actual} in column \
+                         '{}', which is declared as {}",
+                        row.data_to_string(),
+                        self.schema.name(),
+                        column.name(),
+                        column.scalar_type()
+                    )));
+                }
+            }
+            // Both backends carry a row's multiplicity as a *signed* 64 bit
+            // weight, so a count beyond `i64::MAX` has nowhere to go. Catching
+            // it here keeps the lowerings infallible on this point.
+            if copies.get() > i64::MAX as u64 {
+                return Err(SyntaxError::new(format!(
+                    "row {} of constant relation '{}' is held {} times, beyond \
+                     the signed 64 bit weight a backend carries it as",
+                    row.data_to_string(),
+                    self.schema.name(),
+                    copies.get(),
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Every declared key must actually be one: no two distinct rows may share
+    /// the same key.
+    ///
+    /// Only declared keys are claims. A schema declaring none lowers to the
+    /// empty key, which indexes every row under the same (empty) key and asserts
+    /// nothing; [`unit`](Self::unit) is that case.
+    fn validate_keys(&self) -> Result<(), SyntaxError> {
+        let key_of = |key: &[usize], row: &TupleValue| -> Vec<ScalarTypedValue> {
+            key.iter().map(|index| row.data[*index].clone()).collect()
+        };
+        for key in self.schema.primary_key_indices() {
+            // The rows are canonical, so equal rows have already been folded
+            // into one entry: two entries agreeing on a key are two *distinct*
+            // rows, which is the violation.
+            let mut seen: HashMap<Vec<ScalarTypedValue>, &TupleValue> =
+                HashMap::with_capacity(self.rows.len());
+            for (row, _) in &self.rows {
+                if let Some(previous) = seen.insert(key_of(key, row), row)
+                    && previous != row
+                {
+                    let key_columns = key
+                        .iter()
+                        .map(|index| self.schema.columns()[*index].name())
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    return Err(SyntaxError::new(format!(
+                        "rows {} and {} of constant relation '{}' agree on its declared \
+                         key ({key_columns}), so that key does not determine a row",
+                        previous.data_to_string(),
+                        row.data_to_string(),
+                        self.schema.name()
+                    )));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// The shape and the rows, as `(a: uint) key(a) [[1]×2, [2]]`. Long constants
+/// are elided after [`RENDERED_ROWS`] rows: this renders into plan dumps and
+/// diagnostics, where the point is to recognise the relation, not to read it
+/// out.
+impl std::fmt::Display for ConstantExpr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} [", self.schema.shape())?;
+        for (position, (row, copies)) in self.rows.iter().take(RENDERED_ROWS).enumerate() {
+            if position > 0 {
+                f.write_str(", ")?;
+            }
+            f.write_str(&row.data_to_string())?;
+            // A `×1` on every row would drown out the ones that carry copies.
+            if *copies != Multiplicity::ONE {
+                write!(f, "{copies}")?;
+            }
+        }
+        match self.rows.len().saturating_sub(RENDERED_ROWS) {
+            0 => f.write_str("]"),
+            elided => write!(f, ", … {elided} more]"),
+        }
     }
 }
 
@@ -615,6 +922,7 @@ pub trait RelExprVisitor<T, C> {
     fn visit_rel(&mut self, expr: &RelExpr, ctx: C) -> T {
         match expr {
             RelExpr::Source(expr) => self.visit_source_expr(expr, ctx),
+            RelExpr::Constant(expr) => self.visit_constant_expr(expr, ctx),
             RelExpr::Output(expr) => self.visit_output_expr(expr, ctx),
             RelExpr::Alias(expr) => self.visit_alias_expr(expr, ctx),
             RelExpr::Distinct(expr) => self.visit_distinct_expr(expr, ctx),
@@ -630,6 +938,7 @@ pub trait RelExprVisitor<T, C> {
         }
     }
     fn visit_source_expr(&mut self, expr: &SourceExpr, ctx: C) -> T;
+    fn visit_constant_expr(&mut self, expr: &ConstantExpr, ctx: C) -> T;
     fn visit_output_expr(&mut self, expr: &OutputExpr, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: &AliasExpr, ctx: C) -> T;
     fn visit_distinct_expr(&mut self, expr: &DistinctExpr, ctx: C) -> T;
@@ -649,6 +958,7 @@ pub trait RelExprVisitorMut<T, C> {
     fn visit_rel(&mut self, expr: &mut RelExpr, ctx: C) -> T {
         match expr {
             RelExpr::Source(expr) => self.visit_source_expr(expr, ctx),
+            RelExpr::Constant(expr) => self.visit_constant_expr(expr, ctx),
             RelExpr::Output(expr) => self.visit_output_expr(expr, ctx),
             RelExpr::Alias(expr) => self.visit_alias_expr(expr, ctx),
             RelExpr::Distinct(expr) => self.visit_distinct_expr(expr, ctx),
@@ -664,6 +974,7 @@ pub trait RelExprVisitorMut<T, C> {
         }
     }
     fn visit_source_expr(&mut self, expr: &mut SourceExpr, ctx: C) -> T;
+    fn visit_constant_expr(&mut self, expr: &mut ConstantExpr, ctx: C) -> T;
     fn visit_output_expr(&mut self, expr: &mut OutputExpr, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: &mut AliasExpr, ctx: C) -> T;
     fn visit_distinct_expr(&mut self, expr: &mut DistinctExpr, ctx: C) -> T;
@@ -686,6 +997,7 @@ pub trait RelExprVisitorOwn<T, C> {
     fn visit_rel(&mut self, expr: RelExpr, ctx: C) -> T {
         match expr {
             RelExpr::Source(expr) => self.visit_source_expr(expr, ctx),
+            RelExpr::Constant(expr) => self.visit_constant_expr(expr, ctx),
             RelExpr::Output(expr) => self.visit_output_expr(expr, ctx),
             RelExpr::Alias(expr) => self.visit_alias_expr(expr, ctx),
             RelExpr::Distinct(expr) => self.visit_distinct_expr(expr, ctx),
@@ -701,6 +1013,7 @@ pub trait RelExprVisitorOwn<T, C> {
         }
     }
     fn visit_source_expr(&mut self, expr: Box<SourceExpr>, ctx: C) -> T;
+    fn visit_constant_expr(&mut self, expr: Box<ConstantExpr>, ctx: C) -> T;
     fn visit_output_expr(&mut self, expr: Box<OutputExpr>, ctx: C) -> T;
     fn visit_alias_expr(&mut self, expr: Box<AliasExpr>, ctx: C) -> T;
     fn visit_distinct_expr(&mut self, expr: Box<DistinctExpr>, ctx: C) -> T;
@@ -719,6 +1032,8 @@ pub trait RelExprVisitorOwn<T, C> {
 mod tests {
     use super::*;
     use crate::host::expr::VarExpr;
+    use crate::test_utils::table_schema;
+    use crate::tuple;
 
     /// A stand-in relation operand. [`MultiWayEquiJoinExpr::validate`] only ever
     /// counts these, so their content is irrelevant.
@@ -736,6 +1051,144 @@ mod tests {
                 .map(|relation| (*relation, Expr::from(VarExpr::new(name))))
                 .collect(),
         }
+    }
+
+    /// A two-column schema, keyed on `key`.
+    fn keyed_schema(key: &[&str]) -> TableSchema {
+        table_schema(
+            "pairs",
+            [("a", ScalarType::Uint), ("b", ScalarType::Bool)],
+            key.iter().copied(),
+        )
+    }
+
+    fn copies(count: u64) -> Multiplicity {
+        Multiplicity::new(count).expect("a positive number of copies")
+    }
+
+    #[test]
+    fn folds_repeated_rows_into_one_entry_with_their_multiplicity() {
+        // The bag semantics of the node: listing a row twice is not an error and
+        // not a duplicate entry, it is two copies of one row. That is what makes
+        // a `Multiplicity` the only place a count lives.
+        let constant = ConstantExpr::set(
+            keyed_schema(&[]),
+            [tuple!(1u64, true), tuple!(2u64, false), tuple!(1u64, true)],
+        )
+        .expect("repeated rows are a bag, not a violation");
+        assert_eq!(
+            constant.rows(),
+            [
+                (tuple!(1u64, true), copies(2)),
+                (tuple!(2u64, false), Multiplicity::ONE),
+            ]
+        );
+    }
+
+    #[test]
+    fn equality_is_bag_equality_rather_than_listing_order() {
+        // What the canonical form buys: a rewrite rule recognising two
+        // occurrences of one constant, and a plan assertion that does not depend
+        // on the order a producer happened to emit the rows in.
+        let schema = keyed_schema(&[]);
+        let one = ConstantExpr::set(schema.clone(), [tuple!(1u64, true), tuple!(2u64, false)])
+            .expect("valid rows");
+        let other = ConstantExpr::set(schema, [tuple!(2u64, false), tuple!(1u64, true)])
+            .expect("valid rows");
+        assert_eq!(one, other);
+    }
+
+    #[test]
+    fn rejects_a_row_whose_arity_disagrees_with_the_schema() {
+        let error = ConstantExpr::set(keyed_schema(&[]), [tuple!(1u64)])
+            .expect_err("a one-value row does not fit a two-column schema");
+        assert!(error.to_string().contains("column"));
+    }
+
+    #[test]
+    fn rejects_a_cell_whose_type_disagrees_with_its_column() {
+        let error = ConstantExpr::set(keyed_schema(&[]), [tuple!(1u64, 2u64)])
+            .expect_err("a uint does not fit a bool column");
+        assert!(error.to_string().contains("bool"));
+    }
+
+    #[test]
+    fn accepts_a_null_in_a_column_of_any_type() {
+        // Nothing in a `Column` states non-nullability, so rejecting this would
+        // be inventing a constraint the schema does not carry.
+        ConstantExpr::set(
+            keyed_schema(&["a"]),
+            [TupleValue::new(vec![
+                ScalarTypedValue::Uint(1),
+                ScalarTypedValue::Null(()),
+            ])],
+        )
+        .expect("a null stands in for a value of the declared type");
+    }
+
+    #[test]
+    fn rejects_two_distinct_rows_agreeing_on_a_declared_key() {
+        // The invariant no backend can enforce: an `OrdIndexedZSet` is an index,
+        // so a key holding several distinct values is legal there. A constant's
+        // rows are in hand, so the claim is decidable here.
+        let error = ConstantExpr::set(
+            keyed_schema(&["a"]),
+            [tuple!(1u64, true), tuple!(1u64, false)],
+        )
+        .expect_err("a declared key must determine the row");
+        assert!(error.to_string().contains("key"));
+    }
+
+    #[test]
+    fn copies_of_one_row_do_not_violate_a_declared_key() {
+        // Two *entries* under one key are a violation; two *copies* of one row
+        // are the multiplicity of that row, which the fold has already
+        // collapsed into a single entry by the time the key is checked.
+        let constant = ConstantExpr::set(
+            keyed_schema(&["a"]),
+            [tuple!(1u64, true), tuple!(1u64, true)],
+        )
+        .expect("copies of one row agree on the key trivially");
+        assert_eq!(constant.rows(), [(tuple!(1u64, true), copies(2))]);
+    }
+
+    #[test]
+    fn an_undeclared_key_claims_nothing() {
+        // Without a declared key the relation lowers to the empty key, which
+        // indexes every row under the same key and asserts nothing — so rows
+        // that would violate a key on `a` are fine here.
+        ConstantExpr::set(keyed_schema(&[]), [tuple!(1u64, true), tuple!(1u64, false)])
+            .expect("no declared key, no claim to violate");
+    }
+
+    #[test]
+    fn the_unit_relation_holds_exactly_one_copy_of_the_unit_tuple() {
+        let unit = ConstantExpr::unit();
+        assert!(unit.schema().columns().is_empty());
+        assert_eq!(unit.rows(), [(TupleValue::empty(), Multiplicity::ONE)]);
+        assert!(unit.is_unit());
+    }
+
+    #[test]
+    fn the_unit_tuple_held_twice_is_not_the_joins_neutral_element() {
+        // A join against it would scale its other operand by two, so a
+        // join-elimination rule must not fire on it. Hence `is_unit` tests the
+        // multiplicity, not just the shape.
+        let twice = ConstantExpr::new(
+            table_schema("unit", [], []),
+            [(TupleValue::empty(), copies(2))],
+        )
+        .expect("a bag may hold the unit tuple twice");
+        assert!(!twice.is_unit());
+    }
+
+    #[test]
+    fn an_empty_constant_keeps_the_arity_its_schema_declares() {
+        // Why the schema is declared rather than inferred: there is no row here
+        // to read an arity off.
+        let empty = ConstantExpr::empty(keyed_schema(&["a"]));
+        assert!(empty.is_empty());
+        assert_eq!(empty.schema().columns().len(), 2);
     }
 
     #[test]

--- a/packages/coln-query/src/relational/incremental/dbsp/wrapper.rs
+++ b/packages/coln-query/src/relational/incremental/dbsp/wrapper.rs
@@ -10,12 +10,12 @@ use crate::utils::cli_table::{
     ChainedHeader, CliReport, CliTableHeader, TableDisplay, ToCliReport, ToCliTableIterExt,
     ZWeightedHeader,
 };
+use dbsp::{
+    Circuit, IndexedZSetHandle, IndexedZSetReader, OrdIndexedZSet, OutputHandle, Stream,
+    operator::ConstantGenerator, typed_batch::SpineSnapshot, utils::Tup2,
+};
 pub use dbsp::{
     DBSPHandle as DbspHandle, Error as DbspError, NestedCircuit, RootCircuit, Runtime, ZWeight,
-};
-use dbsp::{
-    IndexedZSetHandle, IndexedZSetReader, OrdIndexedZSet, OutputHandle, Stream,
-    typed_batch::SpineSnapshot, utils::Tup2,
 };
 #[allow(unused_imports, reason = "For testing purposes")]
 pub use dbsp::{OrdZSet, indexed_zset, zset, zset_set};
@@ -31,6 +31,68 @@ pub fn new_ord_indexed_stream(
     circuit: &mut RootCircuit,
 ) -> (OrdIndexedRootStream, OrdIndexedStreamInputHandle) {
     circuit.add_input_indexed_zset::<TupleKey, TupleValue>()
+}
+
+/// Wires a relation the plan itself carries, a
+/// [`ConstantExpr`](crate::relational::expr::ConstantExpr), into a root stream.
+/// There is no handle because there is nobody to feed it.
+///
+/// `rows` are the relation's *contents*, but a root stream carries *changes*.
+/// The constant is therefore emitted as one delta in the circuit's first step
+/// and as nothing afterwards, which is what `differentiate` over a stream that
+/// is constantly `rows` computes (`rows - z⁻¹(rows)`). Its integrated value is
+/// `rows` at every step, which is exactly the claim the plan node makes.
+///
+/// [`ConstantGenerator`] is also what keeps the rows from being multiplied by
+/// the worker count, as it emits them on worker 0 only, and the operators that
+/// need the data partitioned shard it themselves. A hand-rolled
+/// [`Generator`](::dbsp::operator::Generator) would emit a full copy per worker.
+pub fn new_constant_stream(
+    circuit: &RootCircuit,
+    schema: &StreamSchema,
+    rows: impl IntoIterator<Item = (TupleValue, ZWeight)>,
+) -> OrdIndexedRootStream {
+    let key_indices = key_indices(schema);
+    let tuples = rows
+        .into_iter()
+        .map(|(row, weight)| Tup2(Tup2(key_of(&key_indices, &row), row), weight))
+        .collect();
+    let batch = OrdIndexedZSet::<TupleKey, TupleValue>::from_tuples((), tuples);
+    circuit
+        .add_source(ConstantGenerator::new(batch))
+        .differentiate()
+}
+
+/// Where the key columns of `schema` sit in its rows.
+///
+/// A relation's key is not data of its own: it is a projection of the row (see
+/// [`StreamSchema`]), which is what makes "the key determines the row" hold by
+/// construction rather than by anyone's discipline.
+fn key_indices(schema: &StreamSchema) -> Vec<usize> {
+    let tuple_names: Vec<String> = schema
+        .tuple
+        .field_names(ColumnSelector::Visible, &None)
+        .collect();
+    schema
+        .key
+        .field_names(ColumnSelector::Visible, &None)
+        .map(|key_field| {
+            tuple_names
+                .iter()
+                .position(|name| *name == key_field)
+                .expect("key field must appear in the tuple schema")
+        })
+        .collect()
+}
+
+/// The key of one row, as [`key_indices`] located it.
+fn key_of(key_indices: &[usize], row: &TupleValue) -> TupleKey {
+    TupleKey {
+        data: key_indices
+            .iter()
+            .map(|index| row.data[*index].clone())
+            .collect(),
+    }
 }
 
 pub type OrdIndexedStreamInputHandle = IndexedZSetHandle<TupleKey, TupleValue>;
@@ -282,33 +344,15 @@ impl DbspInput {
     }
     /// Feed a batch of value tuples (with z-weights) into this input. The tuple
     /// key is derived from the value by picking the schema's key fields, so
-    /// callers only supply the value — matching the neutral `Runtime::feed`.
+    /// callers only supply the value, matching the neutral `Runtime::feed`.
     pub fn feed(&self, rows: impl IntoIterator<Item = ZRow>) {
-        let tuple_names: Vec<String> = self
-            .schema
-            .tuple
-            .field_names(ColumnSelector::Visible, &None)
-            .collect();
-        let key_indices: Vec<usize> = self
-            .schema
-            .key
-            .field_names(ColumnSelector::Visible, &None)
-            .map(|key_field| {
-                tuple_names
-                    .iter()
-                    .position(|name| *name == key_field)
-                    .expect("key field must appear in the tuple schema")
-            })
-            .collect();
+        let key_indices = key_indices(&self.schema);
         let mut batch = rows
             .into_iter()
             .map(|row_delta| {
                 let zweight = row_delta.zweight();
                 let row = row_delta.into_row();
-                let key = TupleKey {
-                    data: key_indices.iter().map(|&i| row.data[i].clone()).collect(),
-                };
-                Tup2(key, Tup2(row, zweight))
+                Tup2(key_of(&key_indices, &row), Tup2(row, zweight))
             })
             .collect();
         self.handle.append(&mut batch);

--- a/packages/coln-query/src/relational/incremental/interpreter.rs
+++ b/packages/coln-query/src/relational/incremental/interpreter.rs
@@ -11,8 +11,8 @@ use super::operators::{
 use super::schema::{DbspTupleContext, SchemaTuple, StreamSchema, TupleKey};
 use crate::relational::expr::MultiWayEquiJoinExpr;
 use crate::relational::incremental::dbsp::{
-    AsDbspRelation, DbspInput, DbspRelation, OrdIndexedStreamInputHandle, new_ord_indexed_stream,
-    new_relation,
+    AsDbspRelation, DbspInput, DbspRelation, OrdIndexedStreamInputHandle, ZWeight,
+    new_constant_stream, new_ord_indexed_stream, new_relation,
 };
 use crate::relational::schema::TableSchema;
 use crate::{
@@ -25,9 +25,9 @@ use crate::{
     },
     relational::catalog::SourceSchemas,
     relational::expr::{
-        AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr, EquiJoinExpr,
-        FixedPointIterExpr, OutputExpr, OutputKind, ProjectionExpr, RelExpr, RelExprVisitor,
-        SelectionExpr, SinkId, SourceExpr, SourceId, UnionExpr,
+        AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr, DistinctExpr,
+        EquiJoinExpr, FixedPointIterExpr, OutputExpr, OutputKind, ProjectionExpr, RelExpr,
+        RelExprVisitor, SelectionExpr, SinkId, SourceExpr, SourceId, UnionExpr,
     },
     relational::incremental::dbsp::{
         DbspError, DbspInputs, DbspOutput, NestedCircuit, OrdIndexedNestedStream, RootCircuit,
@@ -58,6 +58,41 @@ impl Source {
         Source {
             schema: StreamSchema::from(table),
             handle,
+            stream: StreamWrapper::from(stream),
+        }
+    }
+}
+
+/// The position of a constant in [`DbspInterpreter::constants`]. Assigned by
+/// content, so two occurrences of the same constant share one index — and with
+/// it one wired stream.
+type ConstantIdx = usize;
+
+/// Every _distinct_ [`ConstantExpr`] of the plan, in the order a pre-order walk
+/// first reached it, with the root stream its rows were wired into.
+type Constants = Vec<(ConstantExpr, Constant)>;
+
+/// Unlike [`Source`], it does not carry a handle for inputting data.
+struct Constant {
+    schema: StreamSchema,
+    stream: StreamWrapper,
+}
+
+impl Constant {
+    /// Wire a constant's rows into a root stream. Unlike [`Source::new`] there
+    /// is no handle: the rows are in the plan, so nothing feeds this relation
+    /// and `feed` must not be able to reach it. See [`new_constant_stream`]
+    /// for how a bag of rows becomes a delta.
+    fn new(expr: &ConstantExpr, root_circuit: &RootCircuit) -> Self {
+        let schema = StreamSchema::from(expr.schema());
+        let rows = expr.rows().iter().map(|(row, copies)| {
+            let weight = ZWeight::try_from(copies.get())
+                .expect("ConstantExpr::validate rejects a multiplicity beyond i64::MAX");
+            (row.clone(), weight)
+        });
+        let stream = new_constant_stream(root_circuit, &schema, rows);
+        Constant {
+            schema,
             stream: StreamWrapper::from(stream),
         }
     }
@@ -94,6 +129,9 @@ enum ImportKey {
     Var(VariableSlot),
     /// A [`SourceExpr`] leaf, keyed by source name.
     Source(SourceId),
+    /// A [`ConstantExpr`] leaf, keyed by its position among the plan's
+    /// constants which is a content-derived identity, see [`ConstantIdx`].
+    Constant(ConstantIdx),
 }
 
 /// State that only exists while walking a [`FixedPointIterExpr`] step body,
@@ -116,8 +154,12 @@ pub struct DbspInterpreter<E: RowScalarEngine = TreeWalk> {
     engine: E,
     /// Every input stream the plan needs, keyed by the [`SourceId`] its
     /// [`SourceExpr`] leaves name it by. Wired once in [`new`](Self::new) from
-    /// the schemas the pipeline resolved, so a leaf is *bound* here.
+    /// the schemas the pipeline resolved, so a leaf is _bound_ here.
     sources: Sources,
+    /// Every constant the plan carries, wired in [`new`](Self::new) alongside
+    /// the sources and for the same reason. Looked up by content, so any plan
+    /// referring to the same constant `N` times still builds just one stream.
+    constants: Constants,
     /// Output read handles collected while walking the plan, one per
     /// [`OutputExpr`] tap, in plan order. The backend drains these after
     /// interpretation to wire the runtime's named outputs.
@@ -131,29 +173,53 @@ pub struct DbspInterpreter<E: RowScalarEngine = TreeWalk> {
 }
 
 impl<E: RowScalarEngine> DbspInterpreter<E> {
-    /// Wires one root input stream per source the plan names, up front.
+    /// Wires one root stream per relation leaf of the plan, up front: an input
+    /// per source it names, and a constant per bag of rows it carries.
     ///
-    /// Eagerly rather than on first visit, because DBSP refuses a root input
-    /// once a nested circuit is under construction: wiring everything before
-    /// interpretation starts is what lets a [`FixedPointIterExpr`] step body
-    /// reach a source at all, without a pre-pass hoisting that body's sources
-    /// out by hand. `sources` came from a walk of this same plan, so the set is
-    /// the same one lazy wiring would have reached.
+    /// Eagerly rather than on first visit, because adding a root node once a
+    /// nested circuit is under construction is not safe: DBSP hands out an input
+    /// handle through `&mut RootCircuit`, which the nested circuit's constructor
+    /// closure has already borrowed, and a node added to the parent from inside
+    /// that closure lands at a position its assigned id no longer matches.
+    /// Wiring everything before interpretation starts is what lets a
+    /// [`FixedPointIterExpr`] step body reach a source or a constant at all,
+    /// without a pre-pass hoisting that body's leaves out by hand. Both
+    /// arguments came from a walk of this same plan, so the sets are the ones
+    /// lazy wiring would have reached.
     ///
-    /// Sorted by [`SourceId`], so that circuit construction does not inherit the
-    /// iteration order of a [`HashMap`].
-    pub fn new(root_circuit: RootCircuit, engine: E, sources: SourceSchemas) -> Self {
-        let mut root_circuit = root_circuit;
-        let mut wired = Sources::with_capacity(sources.len());
+    /// Sources are sorted by [`SourceId`], so that circuit construction does not
+    /// inherit the iteration order of a [`HashMap`]; `constants` arrive in plan
+    /// order, which is deterministic already.
+    pub fn new(
+        mut root_circuit: RootCircuit,
+        engine: E,
+        sources: SourceSchemas,
+        constants: Vec<ConstantExpr>,
+    ) -> Self {
+        let mut wired_sources = Sources::with_capacity(sources.len());
         let mut sources: Vec<_> = sources.into_iter().collect();
         sources.sort_by(|(left, _), (right, _)| left.as_str().cmp(right.as_str()));
         for (id, table) in sources {
-            wired.insert(id, Source::new(&table, &mut root_circuit));
+            wired_sources.insert(id, Source::new(&table, &mut root_circuit));
         }
+
+        let mut wired_constants = Constants::with_capacity(constants.len());
+        for expr in constants {
+            // Two occurrences of the same constant are the same relation (the
+            // node's `PartialEq` is bag equality), so they share one stream.
+            // This is where they are deduped.
+            if wired_constants.iter().any(|(wired, _)| *wired == expr) {
+                continue;
+            }
+            let constant = Constant::new(&expr, &root_circuit);
+            wired_constants.push((expr, constant));
+        }
+
         Self {
             root_circuit,
             engine,
-            sources: wired,
+            sources: wired_sources,
+            constants: wired_constants,
             sinks: Vec::new(),
             step: None,
         }
@@ -250,9 +316,10 @@ impl<E: RowScalarEngine> RelExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>>
 {
     fn visit_source_expr(&mut self, expr: &SourceExpr, ctx: VisitorCtx) -> ExprVisitorResult {
         // Every source the plan names was wired in `new`, so this only binds the
-        // leaf to its stream. Exactly one stream per source, however many leaves name
-        // it. Snapshot stream and schema to drop the borrow on `sources` before
-        // any `&mut self` call below.
+        // leaf to its stream. Exactly one stream per source, however many leaves
+        // name it.
+        // We snapshot the stream and schema to drop the borrow on `sources`
+        // before any `&mut self` call below.
         let (schema, root_stream) = {
             let source = self.sources.get(&expr.id).ok_or_else(|| {
                 BuildError::new(format!(
@@ -266,6 +333,35 @@ impl<E: RowScalarEngine> RelExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>>
         // `delta0`'d into the nested circuit, just like an outer variable.
         let relation = if self.step.is_some() {
             self.bridge_import(ImportKey::Source(expr.id.clone()), schema, &root_stream)
+        } else {
+            new_relation(schema, root_stream)
+        };
+        Ok(Value::Relation(relation))
+    }
+
+    fn visit_constant_expr(&mut self, expr: &ConstantExpr, ctx: VisitorCtx) -> ExprVisitorResult {
+        // Every constant the plan carries was wired in `new`, so this only binds
+        // the leaf to its respective stream, similar to `visit_source_expr`.
+        // We snapshot the stream and schema to drop the borrow on `constants`
+        // before any `&mut self` call below.
+        let (index, schema, root_stream) = {
+            let index = self
+                .constants
+                .iter()
+                .position(|(wired, _)| wired == expr)
+                .ok_or_else(|| {
+                    BuildError::new(format!(
+                        "the constant relation {expr} is not among the wired constants"
+                    ))
+                })?;
+            let (_, constant) = &self.constants[index];
+            (index, constant.schema.clone(), constant.stream.clone())
+        };
+        // Inside a fixed-point step the constant is an outer relation and must
+        // be `delta0`'d into the nested circuit, just like a source. Being
+        // loop-invariant, it enters at the first iteration and never changes.
+        let relation = if self.step.is_some() {
+            self.bridge_import(ImportKey::Constant(index), schema, &root_stream)
         } else {
             new_relation(schema, root_stream)
         };
@@ -602,10 +698,12 @@ impl<E: RowScalarEngine> RelExprVisitor<ExprVisitorResult, VisitorCtx<'_, '_>>
             (accumulator.stream().clone(), accumulator.schema().clone())
         };
 
-        // A source referenced inside the step needs no special handling: DBSP
-        // forbids adding a root input once a nested circuit is under
-        // construction, but `new` wired every one of them before interpretation
-        // began. Inside the step each is `delta0`'d like any outer relation.
+        // A source or constant referenced inside the step needs no special
+        // handling: Adding a root node once a nested circuit is under
+        // construction is not safe with DBSP (see `new`), but `new` wired
+        // every relation leaf of the plan before interpretation began and thus,
+        // has already been constructed at this point. Inside the step each
+        // relation leaf is `delta0`'d like any outer relation.
 
         // DBSP does not allow outputting a stream attached to a child circuit.
         pre_order(&expr.step.stmts)

--- a/packages/coln-query/src/relational/incremental/mod.rs
+++ b/packages/coln-query/src/relational/incremental/mod.rs
@@ -11,11 +11,14 @@ use crate::error::{BuildError, LoweringError, RuntimeError};
 use crate::relational::incremental::dbsp::DbspOutputDelta;
 use crate::{
     host::{
-        HostInterpreter, InterpreterContext, QueryIr, resolver::ResolvedCode, variable::Environment,
+        HostInterpreter, InterpreterContext, QueryIr,
+        resolver::ResolvedCode,
+        variable::Environment,
+        walk::{Node, pre_order},
     },
     relational::{
         catalog::SourceSchemas,
-        expr::{OutputKind, SinkId, SourceId},
+        expr::{ConstantExpr, OutputKind, SinkId, SourceId},
     },
     scalarial::{RowScalarEngine, TreeWalk},
 };
@@ -74,6 +77,14 @@ impl<E: RowScalarEngine + Send> Backend for DbspBackend<E> {
         sources: SourceSchemas,
     ) -> Result<DbspRuntime, Self::Error> {
         let engine = self.scalar_engine;
+        // Both kinds of relation leaf have to be wired before the plan is
+        // walked (see `DbspInterpreter::new`). A source names itself, so
+        // `sources` already lists them; a constant carries its rows, so the
+        // plan is the only place to find one.
+        let constants: Vec<ConstantExpr> = pre_order(plan.as_code())
+            .filter_map(Node::as_constant)
+            .cloned()
+            .collect();
         let (handle, (inputs, outputs)) =
             CircuitRuntime::init_circuit(threads, move |root_circuit| {
                 // The plan is already resolved, so we interpret directly (no
@@ -82,8 +93,12 @@ impl<E: RowScalarEngine + Send> Backend for DbspBackend<E> {
                 // DBSP requires because it runs it once per worker thread.
                 let mut environment = Environment::default();
                 let mut ctx = InterpreterContext::new(&mut environment);
-                let mut interpreter =
-                    DbspInterpreter::new(root_circuit.clone(), engine.clone(), sources.clone());
+                let mut interpreter = DbspInterpreter::new(
+                    root_circuit.clone(),
+                    engine.clone(),
+                    sources.clone(),
+                    constants.clone(),
+                );
                 // Walk the plan for its side effects: each `SourceExpr` leaf
                 // wires a fresh input stream (deduplicated by name) and each
                 // `OutputExpr` tap wires an output read handle. The plan's final

--- a/packages/coln-query/src/relational/relation.rs
+++ b/packages/coln-query/src/relational/relation.rs
@@ -14,8 +14,9 @@ use std::{
 };
 
 pub trait Tuple: FromIterator<ScalarTypedValue> {
+    /// The empty tuple is also called the _unit tuple_.
     fn empty() -> Self {
-        Self::from_iter(vec![])
+        Self::from_iter(std::iter::empty())
     }
     fn data_at(&self, index: usize) -> &ScalarTypedValue;
     /// Iterates over _all_ stored fields of the tuple,

--- a/packages/coln-query/src/relational/schema.rs
+++ b/packages/coln-query/src/relational/schema.rs
@@ -145,6 +145,15 @@ impl TableSchema {
             })
         })
     }
+    /// The (compound) primary key(s) as indexes into [`columns`](Self::columns).
+    ///
+    /// The positional counterpart of [`primary_keys`](Self::primary_keys): a
+    /// consumer that has to *project a row* onto a key — checking that the key
+    /// determines the row, deriving the key of a tuple — needs the positions,
+    /// not the columns they name.
+    pub fn primary_key_indices(&self) -> impl Iterator<Item = &[usize]> {
+        self.primary_keys.iter().map(Vec::as_slice)
+    }
     /// Everything but the name: the typed columns and the key(s) over them, as
     /// `(a: uint, b: iint) key(a)`. What a plan printer wants, since a source
     /// leaf has already named the relation by the time its schema is rendered.

--- a/packages/coln-query/src/scalarial/scalar.rs
+++ b/packages/coln-query/src/scalarial/scalar.rs
@@ -55,6 +55,19 @@ macro_rules! expect_data {
 }
 
 impl ScalarTypedValue {
+    /// Which [`ScalarType`] this value is of. The value side of the same
+    /// distinction the type side spells out, so a consumer holding data and a
+    /// schema can check one against the other.
+    pub fn scalar_type(&self) -> ScalarType {
+        match self {
+            ScalarTypedValue::String(_) => ScalarType::String,
+            ScalarTypedValue::Uint(_) => ScalarType::Uint,
+            ScalarTypedValue::Iint(_) => ScalarType::Iint,
+            ScalarTypedValue::Bool(_) => ScalarType::Bool,
+            ScalarTypedValue::Char(_) => ScalarType::Char,
+            ScalarTypedValue::Null(()) => ScalarType::Null,
+        }
+    }
     pub fn unwrap_into_string(&self) -> String {
         expect_data!(self, ScalarTypedValue::String).clone()
     }

--- a/packages/coln-query/src/test_utils.rs
+++ b/packages/coln-query/src/test_utils.rs
@@ -14,6 +14,7 @@ use crate::{
         catalog::{Catalog, SourceSchemas},
         expr::SourceId,
         incremental::{dbsp::ZWeight, schema::TupleKey},
+        relation::Tuple,
         schema::{Column, EntityRef, TableSchema},
     },
     scalarial::{ScalarType, ScalarTypedValue},
@@ -608,6 +609,39 @@ pub fn person_profession_data() -> [(Vec<PersonRel>, Vec<ProfessionRel>); 1] {
             },
         ],
     )]
+}
+
+/// Contains only unit tuples, that is, 0-tuples or tuples with zero fields.
+/// Think of it as Rust's `()` unit type but applied to tuples.
+#[derive(Copy, Clone, Debug)]
+pub struct UnitRel {}
+
+impl UnitRel {
+    pub fn new_unit_tuple() -> Self {
+        Self {}
+    }
+    pub fn named_schema(name: &'static str) -> TableSchema {
+        table_schema(name, [], [])
+    }
+}
+
+impl InputRel for UnitRel {
+    fn schema() -> TableSchema {
+        // Zero columns and zero keys.
+        table_schema("unit", [], [])
+    }
+}
+
+impl From<UnitRel> for TupleKey {
+    fn from(fact: UnitRel) -> Self {
+        TupleKey::empty()
+    }
+}
+
+impl From<UnitRel> for TupleValue {
+    fn from(fact: UnitRel) -> Self {
+        TupleValue::empty()
+    }
 }
 
 #[derive(Copy, Clone, Debug)]

--- a/packages/coln-query/src/typing/type_resolver.rs
+++ b/packages/coln-query/src/typing/type_resolver.rs
@@ -18,9 +18,9 @@ use crate::{
     relational::{
         catalog::Catalog,
         expr::{
-            AliasExpr, AntiJoinExpr, CartesianProductExpr, DifferenceExpr, DistinctExpr,
-            EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr, ProjectionExpr,
-            RelExpr, RelExprVisitor, SelectionExpr, SourceExpr, UnionExpr,
+            AliasExpr, AntiJoinExpr, CartesianProductExpr, ConstantExpr, DifferenceExpr,
+            DistinctExpr, EquiJoinExpr, FixedPointIterExpr, MultiWayEquiJoinExpr, OutputExpr,
+            ProjectionExpr, RelExpr, RelExprVisitor, SelectionExpr, SourceExpr, UnionExpr,
         },
         relation::RelationType,
     },
@@ -310,6 +310,11 @@ impl RelExprVisitor<VisitorResult, VisitorCtx<'_, '_>> for TypeResolver<'_> {
             ))
         })?;
         Ok(ExprType::Relation(RelationType::from(schema.as_ref())))
+    }
+
+    fn visit_constant_expr(&mut self, expr: &ConstantExpr, ctx: VisitorCtx) -> VisitorResult {
+        // The leaf carries its own schema, so no catalog is consulted.
+        Ok(ExprType::Relation(RelationType::from(expr.schema())))
     }
 
     fn visit_output_expr(&mut self, expr: &OutputExpr, ctx: VisitorCtx) -> VisitorResult {


### PR DESCRIPTION
# Empty Antecedent Rules

## Issue

Rules can have an empty `consequents`, in which case they assert nothing and can
be ignored. However, rules can also have an empty `antecedents`, in which case
they demand the consequents to evaluate to true. That means the conjunctive
query defined by the `consequents` must be non-empty.

## Solution

### Antijoin Approach

> $antijoin(R, S)$

Whenever there is an `Atom` with no variable binding at all (neither row id nor
values) the FLIR expects a 0-tuple (a tuple with 0 fields; the _unit_ tuple
hereafter). We can translate that into projecting away all columns of the
`Atom`'s underlying relation $S$. This results in as many unit tuples as there
are rows in $S$ (let's say $n$ rows). $n$ is usually zero or one row because
rules of this kind often operate on `Atom`s (in the consequent) which contain at
most one row.

For the antijoin approach to work the left input relation $R$ (given by the
empty antecedent) must somehow come into existence, as there is no table to
provide it. The obvious candidate is a relation consisting of only the unit
tuple, as any quantification over the unit tuple is true by definition (its a
neutral element). An empty antecedent then signals such a "neutral relation".
Such a "unit relation" can now be constructed using the new `ConstantExpr` leaf.

The upside of this approach is that it aligns nicely with non-empty antecedent
rules and requires no special treatment except for the creation of a neutral
relation.

A downside of this rule checking is that for consequents with more than one
`Atom` we cannot tell the user _which_ `Atom`s are non-empty.

### The Counting Approach

Another query shape ensuring that every consequent's atom's underlying relation
is non-empty, is to count its entries with a `count()` aggregation.

The upside is that we can tell which base table violates the non-emptiness
assertion. The downside is it requires aggregation (which isn't a thing yet in
coln-query's IR; but we want to have it at some point anyways). Furthermore, an
empty antecedent rule with $n$ consequent atoms turns into $n$ queries which all
need checking if their output is $> 0$.
