### PR TITLE
Allowing coln-query to run the batch engine on values beyond u64 and bool

### DIFF
--- a/packages/coln-query/src/lib.rs
+++ b/packages/coln-query/src/lib.rs
@@ -1156,17 +1156,515 @@ mod test {
         Ok(())
     }
 
-    /// The batch backend's value slice is unsigned integers and booleans.
-    /// Rows carrying strings fail loudly instead of computing something
-    /// wrong.
-    // TODO(Jan): support the remaining scalar types (strings first, via
-    // dictionary encoding) after the end-to-end slice is complete; then
-    // `test_standard_join` gets its batch twin, too.
+    /// The standard join, persons and professions with string names, on
+    /// the batch backend. After every step the full state must equal the
+    /// incremental output.
     #[test]
-    fn batch_feed_rejects_strings_for_now() -> Result<(), anyhow::Error> {
+    fn batch_standard_join_matches_incremental() -> Result<(), anyhow::Error> {
+        let plan = || {
+            vec![
+                Stmt::from(VarStmt {
+                    name: "person".to_string(),
+                    initializer: Some(Expr::from(SourceExpr::new(PersonRel::id()))),
+                }),
+                Stmt::from(VarStmt {
+                    name: "profession".to_string(),
+                    initializer: Some(Expr::from(SourceExpr::new(ProfessionRel::id()))),
+                }),
+                Stmt::from(VarStmt {
+                    name: "joined".to_string(),
+                    initializer: Some(Expr::from(EquiJoinExpr {
+                        left: Expr::from(AliasExpr {
+                            relation: Expr::from(VarExpr::new("person")),
+                            alias: "pers".to_string(),
+                        }),
+                        right: Expr::from(AliasExpr {
+                            relation: Expr::from(VarExpr::new("profession")),
+                            alias: "prof".to_string(),
+                        }),
+                        on: vec![(
+                            Expr::from(VarExpr::new("profession_id")),
+                            Expr::from(VarExpr::new("profession_id")),
+                        )],
+                        attributes: Some(
+                            [
+                                ("person_id", "pers.person_id"),
+                                ("person_name", "pers.name"),
+                                ("age", "pers.age"),
+                                ("profession_id", "prof.profession_id"),
+                                ("profession_name", "prof.name"),
+                            ]
+                            .into_iter()
+                            .map(|(name, identifier)| {
+                                (name.to_string(), Expr::from(VarExpr::new(identifier)))
+                            })
+                            .collect(),
+                        ),
+                    })),
+                }),
+                output_stmt("joined"),
+            ]
+        };
+        let schemas = || [PersonRel::schema(), ProfessionRel::schema()];
+        let mut batch = Pipeline::batch().runtime(&mut TestProgram::new(plan(), schemas()))?;
+        let mut incremental =
+            Pipeline::incremental().runtime(&mut TestProgram::new(plan(), schemas()))?;
+
+        let steps = person_profession_data()
+            .into_iter()
+            .zip(person_profession_data());
+        for ((persons, professions), (persons_again, professions_again)) in steps {
+            assert!(batch.feed(&PersonRel::id(), rows_with_weight(persons, 1))?);
+            assert!(batch.feed(&ProfessionRel::id(), rows_with_weight(professions, 1))?);
+            batch.commit()?;
+            assert!(incremental.feed(&PersonRel::id(), rows_with_weight(persons_again, 1))?);
+            assert!(
+                incremental.feed(&ProfessionRel::id(), rows_with_weight(professions_again, 1))?
+            );
+            incremental.commit()?;
+
+            let snapshot = batch.output(&SinkId::from("joined"))?;
+            assert_eq!(
+                snapshot.columns(),
+                [
+                    "person_id",
+                    "person_name",
+                    "age",
+                    "profession_id",
+                    "profession_name"
+                ]
+            );
+            let expected = zset! {
+                tuple!(0_u64, "Alice", 20_u64, 0_u64, "Engineer") => 1,
+                tuple!(2_u64, "Charlie", 40_u64, 0_u64, "Engineer") => 1,
+                tuple!(1_u64, "Bob", 30_u64, 1_u64, "Doctor") => 1,
+            };
+            assert_eq!(snapshot.to_debug_zset(), expected);
+            assert_eq!(
+                incremental
+                    .output(&SinkId::from("joined"))?
+                    .debug_view(false)
+                    .to_zset(),
+                expected
+            );
+        }
+        Ok(())
+    }
+
+    /// Every scalar type the plan knows, except null, flows through feed,
+    /// a selection on a string literal, and output unchanged, on both
+    /// backends.
+    #[test]
+    fn batch_carries_every_scalar_type() -> Result<(), anyhow::Error> {
         use crate::api::deltas::ZRow;
-        use crate::relational::relation::TupleValue;
-        use crate::scalarial::ScalarTypedValue;
+        use crate::host::expr::{BinaryExpr, Literal, LiteralExpr};
+        use crate::host::operator::Operator;
+        use crate::relational::expr::{SelectionExpr, SourceId};
+        use crate::relational::schema::{Column, EntityRef, TableSchema};
+        use crate::scalarial::ScalarType;
+
+        let schema = || {
+            TableSchema::new(
+                EntityRef::from("cells"),
+                vec![
+                    Column::new("id", ScalarType::Uint),
+                    Column::new("delta", ScalarType::Iint),
+                    Column::new("label", ScalarType::String),
+                    Column::new("flag", ScalarType::Bool),
+                    Column::new("initial", ScalarType::Char),
+                ],
+                vec![],
+            )
+        };
+        let plan = || {
+            vec![
+                Stmt::from(VarStmt {
+                    name: "cells".to_string(),
+                    initializer: Some(Expr::from(SourceExpr::new(SourceId::from("cells")))),
+                }),
+                Stmt::from(VarStmt {
+                    name: "picked".to_string(),
+                    initializer: Some(Expr::from(SelectionExpr {
+                        relation: Expr::from(VarExpr::new("cells")),
+                        condition: Expr::from(BinaryExpr {
+                            operator: Operator::Equal,
+                            left: Expr::from(VarExpr::new("label")),
+                            right: Expr::from(LiteralExpr {
+                                value: Literal::String("b".to_string()),
+                            }),
+                        }),
+                    })),
+                }),
+                output_stmt("picked"),
+            ]
+        };
+        let data = || {
+            [
+                tuple!(1_u64, -5_i64, "a", true, 'x'),
+                tuple!(2_u64, 7_i64, "b", false, 'y'),
+                tuple!(3_u64, -1_i64, "b", true, 'z'),
+            ]
+            .into_iter()
+            .map(|row| ZRow::new(1, row).expect("non-zero zweight"))
+            .collect::<Vec<_>>()
+        };
+        let expected = zset! {
+            tuple!(2_u64, 7_i64, "b", false, 'y') => 1,
+            tuple!(3_u64, -1_i64, "b", true, 'z') => 1,
+        };
+
+        let mut batch = Pipeline::batch().runtime(&mut TestProgram::new(plan(), [schema()]))?;
+        assert!(batch.feed(&SourceId::from("cells"), data())?);
+        batch.commit()?;
+        let snapshot = batch.output(&SinkId::from("picked"))?;
+        assert_eq!(
+            snapshot.columns(),
+            ["id", "delta", "label", "flag", "initial"]
+        );
+        assert_eq!(snapshot.to_debug_zset(), expected);
+
+        let mut incremental =
+            Pipeline::incremental().runtime(&mut TestProgram::new(plan(), [schema()]))?;
+        assert!(incremental.feed(&SourceId::from("cells"), data())?);
+        incremental.commit()?;
+        assert_eq!(
+            incremental
+                .output(&SinkId::from("picked"))?
+                .debug_view(false)
+                .to_zset(),
+            expected
+        );
+        Ok(())
+    }
+
+    /// Null is the one plan type the batch backend refuses: a null column
+    /// fails at build time, a null cell at feed time.
+    #[test]
+    fn batch_rejects_null() -> Result<(), anyhow::Error> {
+        use crate::api::deltas::ZRow;
+        use crate::relational::expr::SourceId;
+        use crate::relational::schema::{Column, EntityRef, TableSchema};
+        use crate::scalarial::{ScalarType, ScalarTypedValue};
+
+        let plan = || {
+            vec![
+                Stmt::from(VarStmt {
+                    name: "t".to_string(),
+                    initializer: Some(Expr::from(SourceExpr::new(SourceId::from("t")))),
+                }),
+                output_stmt("t"),
+            ]
+        };
+        let with_null_column = TableSchema::new(
+            EntityRef::from("t"),
+            vec![Column::new("n", ScalarType::Null)],
+            vec![],
+        );
+        let err = Pipeline::batch()
+            .runtime(&mut TestProgram::new(plan(), [with_null_column]))
+            .err()
+            .expect("a null column cannot be built");
+        assert!(err.to_string().contains("null"), "got: {err}");
+
+        let uint_column = TableSchema::new(
+            EntityRef::from("t"),
+            vec![Column::new("n", ScalarType::Uint)],
+            vec![],
+        );
+        let mut rt = Pipeline::batch().runtime(&mut TestProgram::new(plan(), [uint_column]))?;
+        let null_cell = ZRow::new(1, tuple!(())).expect("non-zero zweight");
+        let err = rt.feed(&SourceId::from("t"), [null_cell]).unwrap_err();
+        assert!(err.to_string().contains("null"), "got: {err}");
+        let _ = ScalarTypedValue::Null(());
+        Ok(())
+    }
+
+    /// One cell of plan type `ty` for the small integer `x`, injective on
+    /// the values these tests use (booleans get `0..2`). Not the identity
+    /// for any type, so encoding and decoding are both exercised.
+    fn typed_cell(ty: crate::scalarial::ScalarType, x: u64) -> ScalarTypedValue {
+        use crate::scalarial::ScalarType;
+        match ty {
+            ScalarType::Uint => ScalarTypedValue::Uint(u64::MAX - x),
+            ScalarType::Iint => ScalarTypedValue::Iint(x as i64 - 5),
+            ScalarType::Bool => {
+                assert!(x < 2, "boolean instances use the domain 0..2");
+                ScalarTypedValue::Bool(x == 1)
+            }
+            ScalarType::Char => {
+                ScalarTypedValue::Char(char::from_u32(0x1F600 + x as u32).expect("emoji range"))
+            }
+            ScalarType::String => ScalarTypedValue::String(format!("wert {x} ß")),
+            ScalarType::Null => unreachable!("null is not a stored type"),
+        }
+    }
+
+    const STORED_TYPES: [crate::scalarial::ScalarType; 5] = [
+        crate::scalarial::ScalarType::Uint,
+        crate::scalarial::ScalarType::Iint,
+        crate::scalarial::ScalarType::Bool,
+        crate::scalarial::ScalarType::Char,
+        crate::scalarial::ScalarType::String,
+    ];
+
+    /// The table `edge(from: ty, to: ty)`.
+    fn typed_edge_schema(
+        ty: crate::scalarial::ScalarType,
+    ) -> crate::relational::schema::TableSchema {
+        use crate::relational::schema::{Column, EntityRef, TableSchema};
+        TableSchema::new(
+            EntityRef::from("edge"),
+            vec![Column::new("from", ty), Column::new("to", ty)],
+            vec![],
+        )
+    }
+
+    fn typed_edges(
+        ty: crate::scalarial::ScalarType,
+        pairs: &[(u64, u64)],
+    ) -> Vec<crate::api::deltas::ZRow> {
+        pairs
+            .iter()
+            .map(|&(a, b)| {
+                crate::api::deltas::ZRow::new(
+                    1,
+                    TupleValue {
+                        data: vec![typed_cell(ty, a), typed_cell(ty, b)],
+                    },
+                )
+                .expect("non-zero zweight")
+            })
+            .collect()
+    }
+
+    fn typed_pairs_zset(
+        ty: crate::scalarial::ScalarType,
+        pairs: &[(u64, u64)],
+    ) -> OrdZSet<TupleValue> {
+        OrdZSet::from_keys(
+            (),
+            pairs
+                .iter()
+                .map(|&(a, b)| {
+                    ::dbsp::utils::Tup2(
+                        TupleValue {
+                            data: vec![typed_cell(ty, a), typed_cell(ty, b)],
+                        },
+                        1,
+                    )
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    fn edge_source() -> Expr {
+        use crate::relational::expr::SourceId;
+        Expr::from(SourceExpr::new(SourceId::from("edge")))
+    }
+
+    fn edge_id() -> crate::relational::expr::SourceId {
+        crate::relational::expr::SourceId::from("edge")
+    }
+
+    /// Two hops along `edge`: `two_hops(start, end)`.
+    fn two_hop_plan() -> Vec<Stmt> {
+        vec![
+            Stmt::from(VarStmt {
+                name: "edges".to_string(),
+                initializer: Some(edge_source()),
+            }),
+            Stmt::from(VarStmt {
+                name: "two_hops".to_string(),
+                initializer: Some(Expr::from(EquiJoinExpr {
+                    left: Expr::from(AliasExpr {
+                        relation: Expr::from(VarExpr::new("edges")),
+                        alias: "h1".to_string(),
+                    }),
+                    right: Expr::from(AliasExpr {
+                        relation: Expr::from(VarExpr::new("edges")),
+                        alias: "h2".to_string(),
+                    }),
+                    on: vec![(
+                        Expr::from(VarExpr::new("to")),
+                        Expr::from(VarExpr::new("from")),
+                    )],
+                    attributes: Some(vec![
+                        ("start".to_string(), Expr::from(VarExpr::new("h1.from"))),
+                        ("end".to_string(), Expr::from(VarExpr::new("h2.to"))),
+                    ]),
+                })),
+            }),
+            output_stmt("two_hops"),
+        ]
+    }
+
+    /// The transitive closure of `edge` as a fixed point, read through a
+    /// distinct so both backends report a set: the batch backend always
+    /// does, the incremental one counts derivations otherwise.
+    fn closure_plan() -> Vec<Stmt> {
+        vec![
+            Stmt::from(VarStmt {
+                name: "edges".to_string(),
+                initializer: Some(edge_source()),
+            }),
+            Stmt::from(VarStmt {
+                name: "closure".to_string(),
+                initializer: Some(Expr::from(FixedPointIterExpr {
+                    accumulator: ("cur".to_string(), Expr::from(VarExpr::new("edges"))),
+                    step: BlockStmt {
+                        stmts: vec![Stmt::from(ExprStmt {
+                            expr: Expr::from(DistinctExpr {
+                                relation: Expr::from(EquiJoinExpr {
+                                    left: Expr::from(AliasExpr {
+                                        relation: Expr::from(VarExpr::new("cur")),
+                                        alias: "walk".to_string(),
+                                    }),
+                                    right: Expr::from(AliasExpr {
+                                        relation: Expr::from(VarExpr::new("edges")),
+                                        alias: "step".to_string(),
+                                    }),
+                                    on: vec![(
+                                        Expr::from(VarExpr::new("to")),
+                                        Expr::from(VarExpr::new("from")),
+                                    )],
+                                    attributes: Some(vec![
+                                        ("from".to_string(), Expr::from(VarExpr::new("walk.from"))),
+                                        ("to".to_string(), Expr::from(VarExpr::new("step.to"))),
+                                    ]),
+                                }),
+                            }),
+                        })],
+                    },
+                })),
+            }),
+            Stmt::from(VarStmt {
+                name: "closure_set".to_string(),
+                initializer: Some(Expr::from(DistinctExpr {
+                    relation: Expr::from(VarExpr::new("closure")),
+                })),
+            }),
+            output_stmt("closure_set"),
+        ]
+    }
+
+    fn two_hops_of(pairs: &[(u64, u64)]) -> Vec<(u64, u64)> {
+        let mut out: Vec<(u64, u64)> = pairs
+            .iter()
+            .flat_map(|&(a, b)| {
+                pairs
+                    .iter()
+                    .filter(move |&&(c, _)| c == b)
+                    .map(move |&(_, d)| (a, d))
+            })
+            .collect();
+        out.sort_unstable();
+        out.dedup();
+        out
+    }
+
+    fn closure_of(pairs: &[(u64, u64)]) -> Vec<(u64, u64)> {
+        let mut closure: Vec<(u64, u64)> = pairs.to_vec();
+        loop {
+            let mut next = closure.clone();
+            next.extend(two_hops_of(&closure));
+            next.sort_unstable();
+            next.dedup();
+            if next.len() == closure.len() {
+                return closure;
+            }
+            closure = next;
+        }
+    }
+
+    /// The same two-hop plan over every stored type: the batch state and
+    /// the incremental output must both equal the expected pairs.
+    #[test]
+    fn batch_join_every_type_matches_incremental() -> Result<(), anyhow::Error> {
+        for ty in STORED_TYPES {
+            let pairs: &[(u64, u64)] = if ty == crate::scalarial::ScalarType::Bool {
+                &[(0, 1), (1, 1)]
+            } else {
+                &[(0, 1), (1, 2), (2, 3), (3, 1), (4, 4)]
+            };
+            let expected = typed_pairs_zset(ty, &two_hops_of(pairs));
+            assert!(!expected.is_empty());
+
+            let mut batch = Pipeline::batch().runtime(&mut TestProgram::new(
+                two_hop_plan(),
+                [typed_edge_schema(ty)],
+            ))?;
+            assert!(batch.feed(&edge_id(), typed_edges(ty, pairs))?);
+            batch.commit()?;
+            let snapshot = batch.output(&SinkId::from("two_hops"))?;
+            assert_eq!(snapshot.columns(), ["start", "end"]);
+            assert_eq!(snapshot.to_debug_zset(), expected, "batch over {ty}");
+
+            let mut incremental = Pipeline::incremental().runtime(&mut TestProgram::new(
+                two_hop_plan(),
+                [typed_edge_schema(ty)],
+            ))?;
+            assert!(incremental.feed(&edge_id(), typed_edges(ty, pairs))?);
+            incremental.commit()?;
+            assert_eq!(
+                incremental
+                    .output(&SinkId::from("two_hops"))?
+                    .debug_view(false)
+                    .to_zset(),
+                expected,
+                "incremental over {ty}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The same fixed point over every stored type, on both backends.
+    #[test]
+    fn batch_fixed_point_every_type_matches_incremental() -> Result<(), anyhow::Error> {
+        for ty in STORED_TYPES {
+            // A fork (0 → 2 directly and via 1) and a self loop: pairs with
+            // several derivations, which only a set semantics reports once.
+            let pairs: &[(u64, u64)] = if ty == crate::scalarial::ScalarType::Bool {
+                &[(0, 1), (1, 1)]
+            } else {
+                &[(0, 1), (1, 2), (0, 2), (2, 3), (3, 3)]
+            };
+            let expected = typed_pairs_zset(ty, &closure_of(pairs));
+
+            let mut batch = Pipeline::batch().runtime(&mut TestProgram::new(
+                closure_plan(),
+                [typed_edge_schema(ty)],
+            ))?;
+            assert!(batch.feed(&edge_id(), typed_edges(ty, pairs))?);
+            batch.commit()?;
+            assert_eq!(
+                batch.output(&SinkId::from("closure_set"))?.to_debug_zset(),
+                expected,
+                "batch over {ty}"
+            );
+
+            let mut incremental = Pipeline::incremental().runtime(&mut TestProgram::new(
+                closure_plan(),
+                [typed_edge_schema(ty)],
+            ))?;
+            assert!(incremental.feed(&edge_id(), typed_edges(ty, pairs))?);
+            incremental.commit()?;
+            assert_eq!(
+                incremental
+                    .output(&SinkId::from("closure_set"))?
+                    .debug_view(false)
+                    .to_zset(),
+                expected,
+                "incremental over {ty}"
+            );
+        }
+        Ok(())
+    }
+
+    /// A fed cell must have its column's type, and a row its schema's
+    /// arity; both mismatches fail at feed time, naming the source.
+    #[test]
+    fn batch_feed_checks_cell_types() -> Result<(), anyhow::Error> {
+        use crate::api::deltas::ZRow;
 
         let plan = vec![
             Stmt::from(VarStmt {
@@ -1177,20 +1675,15 @@ mod test {
         ];
         let mut rt =
             Pipeline::batch().runtime(&mut TestProgram::new(plan, [PersonRel::schema()]))?;
-        let alice = ZRow::new(
-            1,
-            TupleValue {
-                data: vec![
-                    ScalarTypedValue::Uint(0),
-                    ScalarTypedValue::String("Alice".to_string()),
-                    ScalarTypedValue::Uint(20),
-                    ScalarTypedValue::Uint(0),
-                ],
-            },
-        )
-        .expect("non-zero zweight");
-        let err = rt.feed(&PersonRel::id(), [alice]).unwrap_err();
-        assert!(err.to_string().contains("unsigned integer"), "got: {err}");
+
+        let wrong_type = ZRow::new(1, tuple!("zero", "Alice", 20_u64, 0_u64)).expect("non-zero");
+        let err = rt.feed(&PersonRel::id(), [wrong_type]).unwrap_err();
+        assert!(err.to_string().contains("expected uint"), "got: {err}");
+        assert!(err.to_string().contains("person"), "got: {err}");
+
+        let wrong_arity = ZRow::new(1, tuple!(0_u64, "Alice")).expect("non-zero");
+        let err = rt.feed(&PersonRel::id(), [wrong_arity]).unwrap_err();
+        assert!(err.to_string().contains("columns"), "got: {err}");
         Ok(())
     }
 

--- a/packages/coln-query/src/relational/batch/lowering.rs
+++ b/packages/coln-query/src/relational/batch/lowering.rs
@@ -11,15 +11,22 @@
 //! coln-batch's semi-naive fixpoint then computes the entire plan,
 //! including the dependencies between statements, in one run.
 //!
-//! Scope of this first slice: purely relational plans. Sources, equi
-//! joins on columns (chains are flattened into one n-ary rule body),
-//! multi-way equi joins (FLIR's native n-ary node, consumed directly),
-//! cartesian products, projections onto columns and literals, equality
-//! selections against literals, unions, distinct, and fixed points whose
-//! step is a single relational expression. Everything that needs the
-//! scalar engine (computed columns, general conditions) and the
-//! remaining operators (anti join, difference) fail with a clear error
-//! instead of a wrong answer.
+//! Types travel with the columns. A source column has the type its
+//! schema declares, a rule variable the type of the column it was created
+//! for, and a derived relation the types of its head. Unifying two
+//! columns of different types (a join, a selection against a literal of
+//! the wrong type) is a lowering error, so the engine never sees an
+//! ill-typed program.
+//!
+//! Scope of this slice: purely relational plans. Sources, equi joins on
+//! columns (chains are flattened into one n-ary rule body), multi-way
+//! equi joins (FLIR's native n-ary node, consumed directly), cartesian
+//! products, projections onto columns and literals, equality selections
+//! against literals, unions, distinct, and fixed points whose step is a
+//! single relational expression. Everything that needs the scalar engine
+//! (computed columns, general conditions) and the remaining operators
+//! (anti join, difference) fail with a clear error instead of a wrong
+//! answer.
 //!
 //! The tests at the bottom build up in difficulty and double as a guided
 //! tour of the translation.
@@ -29,9 +36,11 @@ use std::collections::HashMap;
 use anyhow::{Context, Result, bail};
 use coln_batch::query::{Atom, Term};
 use coln_batch::rule::{Program, Rule};
+use coln_batch::types::{Column, ScalarType, Schema, Value};
 
+use super::values::{batch_schema, literal_value};
 use crate::host::QueryIr;
-use crate::host::expr::{Expr, Literal};
+use crate::host::expr::Expr;
 use crate::host::operator::Operator;
 use crate::host::stmt::{Stmt, VarStmt};
 use crate::relational::catalog::SourceSchemas;
@@ -44,12 +53,12 @@ use crate::relational::expr::{
 pub struct LoweredPlan {
     /// One Datalog program covering every statement of the plan.
     pub program: Program,
-    /// Source id (schema name) to column names, in tuple order.
-    pub sources: HashMap<String, Vec<String>>,
+    /// Source id (schema name) to its schema, in tuple order.
+    pub sources: HashMap<String, Schema>,
     /// Sink id to the derived relation `output` reads.
     pub outputs: HashMap<String, String>,
-    /// Column names per relation, sources and derived alike.
-    pub schemas: HashMap<String, Vec<String>>,
+    /// Schema per relation, sources and derived alike.
+    pub schemas: HashMap<String, Schema>,
 }
 
 /// Lower a plan (its statement list) into a [`LoweredPlan`]. `sources`
@@ -59,22 +68,19 @@ pub fn lower(ir: &QueryIr, sources: &SourceSchemas) -> Result<LoweredPlan> {
     let available_sources = sources
         .iter()
         .map(|(id, schema)| {
-            let columns = schema
-                .columns()
-                .iter()
-                .map(|column| column.name().to_string())
-                .collect();
-            (id.as_str().to_string(), columns)
+            let schema = batch_schema(schema)
+                .with_context(|| format!("in the schema of source {}", id.as_str()))?;
+            Ok((id.as_str().to_string(), schema))
         })
-        .collect();
+        .collect::<Result<HashMap<_, _>>>()?;
     let mut lowerer = Lowerer {
         available_sources,
         ..Lowerer::default()
     };
     lowerer.lower_stmts(ir)?;
-    let mut schemas: HashMap<String, Vec<String>> = lowerer.sources.clone();
+    let mut schemas: HashMap<String, Schema> = lowerer.sources.clone();
     for (name, info) in &lowerer.env {
-        schemas.insert(name.clone(), info.columns.clone());
+        schemas.insert(name.clone(), info.schema.clone());
     }
     Ok(LoweredPlan {
         program: Program {
@@ -86,28 +92,28 @@ pub fn lower(ir: &QueryIr, sources: &SourceSchemas) -> Result<LoweredPlan> {
     })
 }
 
-/// What a plan variable is bound to: a relation plus its column names.
+/// What a plan variable is bound to: a relation plus its schema.
 #[derive(Clone)]
 struct RelInfo {
     relation: String,
-    columns: Vec<String>,
+    schema: Schema,
 }
 
 /// A column binding inside one rule body under construction.
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 enum Bind {
     Var(usize),
-    Lit(u64),
+    Lit(Value),
 }
 
 impl Bind {
-    fn term(self, remap: &HashMap<usize, usize>) -> Result<Term> {
+    fn term(&self, remap: &HashMap<usize, usize>) -> Result<Term> {
         match self {
             Bind::Var(v) => remap
-                .get(&v)
+                .get(v)
                 .map(|nv| Term::Var(*nv))
                 .context("head column refers to a variable that does not occur in the body"),
-            Bind::Lit(x) => Ok(Term::lit(x)),
+            Bind::Lit(value) => Ok(Term::Lit(value.clone())),
         }
     }
 }
@@ -124,43 +130,69 @@ struct Scope {
 impl Scope {
     fn resolve(&self, name: &str) -> Result<Bind> {
         match self.names.get(name) {
-            Some(Some(bind)) => Ok(*bind),
+            Some(Some(bind)) => Ok(bind.clone()),
             Some(None) => bail!("column {name} is ambiguous here, qualify it with an alias"),
             None => bail!("unknown column {name}"),
         }
     }
 
-    fn substitute(&mut self, from: usize, to: Bind) {
+    fn substitute(&mut self, from: usize, to: &Bind) {
         for (_, bind) in &mut self.columns {
             if *bind == Bind::Var(from) {
-                *bind = to;
+                *bind = to.clone();
             }
         }
         for bind in self.names.values_mut() {
             if *bind == Some(Bind::Var(from)) {
-                *bind = Some(to);
+                *bind = Some(to.clone());
             }
         }
     }
+
+    /// The columns as a schema, with their types taken from `frame`.
+    fn schema(&self, frame: &Frame) -> Schema {
+        self.columns
+            .iter()
+            .map(|(name, bind)| Column::new(name.clone(), frame.ty(bind)))
+            .collect()
+    }
 }
 
-/// One rule body under construction: a variable counter and the atoms.
+/// One rule body under construction: the variables (each with its type)
+/// and the atoms.
 #[derive(Default)]
 struct Frame {
-    next_var: usize,
+    var_types: Vec<ScalarType>,
     atoms: Vec<Atom>,
 }
 
 impl Frame {
-    fn fresh(&mut self) -> usize {
-        self.next_var += 1;
-        self.next_var - 1
+    fn fresh(&mut self, ty: ScalarType) -> usize {
+        self.var_types.push(ty);
+        self.var_types.len() - 1
     }
 
-    fn substitute(&mut self, from: usize, to: Bind) {
+    fn ty(&self, bind: &Bind) -> ScalarType {
+        match bind {
+            Bind::Var(v) => self.var_types[*v],
+            Bind::Lit(value) => value.scalar_type(),
+        }
+    }
+
+    /// Fail unless both bindings have the same type; `what` names the
+    /// construct for the message.
+    fn check_same_type(&self, left: &Bind, right: &Bind, what: &str) -> Result<()> {
+        let (l, r) = (self.ty(left), self.ty(right));
+        if l != r {
+            bail!("{what} equates a {l} column with a {r} column");
+        }
+        Ok(())
+    }
+
+    fn substitute(&mut self, from: usize, to: &Bind) {
         let to = match to {
-            Bind::Var(v) => Term::Var(v),
-            Bind::Lit(x) => Term::lit(x),
+            Bind::Var(v) => Term::Var(*v),
+            Bind::Lit(value) => Term::Lit(value.clone()),
         };
         for atom in &mut self.atoms {
             for term in &mut atom.terms {
@@ -175,10 +207,10 @@ impl Frame {
 #[derive(Default)]
 struct Lowerer {
     rules: Vec<Rule>,
-    /// All base tables the catalog offers (id, column names).
-    available_sources: HashMap<String, Vec<String>>,
+    /// All base tables the catalog offers (id, schema).
+    available_sources: HashMap<String, Schema>,
     /// The subset of `available_sources` the plan actually uses.
-    sources: HashMap<String, Vec<String>>,
+    sources: HashMap<String, Schema>,
     env: HashMap<String, RelInfo>,
     outputs: HashMap<String, String>,
 }
@@ -203,7 +235,7 @@ impl Lowerer {
             .as_ref()
             .with_context(|| format!("variable {} has no initializer", var.name))?;
 
-        let columns = match initializer {
+        let schema = match initializer {
             // Aliasing one relation variable to another.
             Expr::Var(inner) => {
                 let info = self.lookup(&inner.name)?.clone();
@@ -215,24 +247,25 @@ impl Lowerer {
                     self.lower_fixed_point(&var.name, fixed_point)?
                 }
                 RelExpr::Union(union) => {
-                    let mut columns: Option<Vec<String>> = None;
+                    let mut schema: Option<Schema> = None;
                     for branch in &union.relations {
-                        let branch_columns = self.push_rule_for(&var.name, branch)?;
-                        match &columns {
-                            None => columns = Some(branch_columns),
+                        let branch_schema = self.push_rule_for(&var.name, branch)?;
+                        match &schema {
+                            None => schema = Some(branch_schema),
                             Some(first) => {
-                                if first.len() != branch_columns.len() {
+                                if first.types() != branch_schema.types() {
                                     bail!(
-                                        "union branches for {} have arities {} and {}",
+                                        "union branches for {} have different schemas, \
+                                         {} and {}",
                                         var.name,
-                                        first.len(),
-                                        branch_columns.len()
+                                        describe(first),
+                                        describe(&branch_schema)
                                     );
                                 }
                             }
                         }
                     }
-                    columns.with_context(|| format!("union for {} is empty", var.name))?
+                    schema.with_context(|| format!("union for {} is empty", var.name))?
                 }
                 _ => self.push_rule_for(&var.name, initializer)?,
             },
@@ -246,19 +279,20 @@ impl Lowerer {
             var.name.clone(),
             RelInfo {
                 relation: var.name.clone(),
-                columns,
+                schema,
             },
         );
         Ok(())
     }
 
     /// Lower one relational expression into a single rule with the given
-    /// head relation; returns the head's column names.
-    fn push_rule_for(&mut self, head: &str, expr: &Expr) -> Result<Vec<String>> {
+    /// head relation; returns the head's schema.
+    fn push_rule_for(&mut self, head: &str, expr: &Expr) -> Result<Schema> {
         let mut frame = Frame::default();
         let scope = self.lower_rel(expr, &mut frame)?;
+        let schema = scope.schema(&frame);
         self.push_rule(head, frame, &scope)?;
-        Ok(scope.columns.iter().map(|(name, _)| name.clone()).collect())
+        Ok(schema)
     }
 
     /// A fixed point defines its accumulator as a recursive relation:
@@ -269,9 +303,9 @@ impl Lowerer {
         &mut self,
         head: &str,
         fixed_point: &FixedPointIterExpr,
-    ) -> Result<Vec<String>> {
+    ) -> Result<Schema> {
         let (accumulator, init) = (&fixed_point.accumulator.0, &fixed_point.accumulator.1);
-        let columns = self.push_rule_for(head, init)?;
+        let schema = self.push_rule_for(head, init)?;
 
         // Inside the step, the accumulator name refers to the relation
         // being defined; that reference is what makes the rule recursive.
@@ -279,7 +313,7 @@ impl Lowerer {
             accumulator.clone(),
             RelInfo {
                 relation: head.to_string(),
-                columns: columns.clone(),
+                schema: schema.clone(),
             },
         );
 
@@ -290,12 +324,12 @@ impl Lowerer {
             let Stmt::Expr(step_expr) = step else {
                 bail!("batch lowering expects the fixed point step to be an expression");
             };
-            let step_columns = self.push_rule_for(head, &step_expr.expr)?;
-            if step_columns.len() != columns.len() {
+            let step_schema = self.push_rule_for(head, &step_expr.expr)?;
+            if step_schema.types() != schema.types() {
                 bail!(
-                    "fixed point step for {head} has arity {}, its base has {}",
-                    step_columns.len(),
-                    columns.len()
+                    "fixed point step for {head} has schema {}, its base has {}",
+                    describe(&step_schema),
+                    describe(&schema)
                 );
             }
             Ok(())
@@ -310,7 +344,7 @@ impl Lowerer {
             }
         }
         result?;
-        Ok(columns)
+        Ok(schema)
     }
 
     /// An output statement names a derived relation as a sink.
@@ -350,7 +384,7 @@ impl Lowerer {
                     let inner = self.lower_rel(&alias.relation, frame)?;
                     let mut names = inner.names.clone();
                     for (name, bind) in &inner.columns {
-                        names.insert(format!("{}.{}", alias.alias, name), Some(*bind));
+                        names.insert(format!("{}.{}", alias.alias, name), Some(bind.clone()));
                     }
                     Ok(Scope {
                         columns: inner.columns,
@@ -367,7 +401,7 @@ impl Lowerer {
                         let bind = self
                             .lower_attribute(attribute, &inner)
                             .with_context(|| format!("in the projection attribute {name}"))?;
-                        columns.push((name.clone(), bind));
+                        columns.push((name.clone(), bind.clone()));
                         names.insert(name.clone(), Some(bind));
                     }
                     Ok(Scope { columns, names })
@@ -398,29 +432,31 @@ impl Lowerer {
 
     fn lower_source(&mut self, source: &SourceExpr, frame: &mut Frame) -> Result<Scope> {
         let id = source.as_id().as_str().to_string();
-        let columns = self
+        let schema = self
             .available_sources
             .get(&id)
             .with_context(|| format!("source {id} is not in the catalog"))?
             .clone();
-        self.sources.insert(id.clone(), columns.clone());
+        self.sources.insert(id.clone(), schema.clone());
         let info = RelInfo {
             relation: id,
-            columns,
+            schema,
         };
         Ok(self.scope_from_atom(&info, frame))
     }
 
-    /// Place one atom over `info`'s relation with fresh variables.
+    /// Place one atom over `info`'s relation with fresh variables, one per
+    /// column, typed like the column.
     fn scope_from_atom(&mut self, info: &RelInfo, frame: &mut Frame) -> Scope {
-        let mut columns = Vec::with_capacity(info.columns.len());
+        let arity = info.schema.arity();
+        let mut columns = Vec::with_capacity(arity);
         let mut names = HashMap::new();
-        let mut terms = Vec::with_capacity(info.columns.len());
-        for name in &info.columns {
-            let var = frame.fresh();
+        let mut terms = Vec::with_capacity(arity);
+        for column in info.schema.columns() {
+            let var = frame.fresh(column.ty);
             terms.push(Term::Var(var));
-            columns.push((name.clone(), Bind::Var(var)));
-            names.insert(name.clone(), Some(Bind::Var(var)));
+            columns.push((column.name.clone(), Bind::Var(var)));
+            names.insert(column.name.clone(), Some(Bind::Var(var)));
         }
         frame.atoms.push(Atom {
             relation: info.relation.clone(),
@@ -442,16 +478,23 @@ impl Lowerer {
         let mut left = left;
 
         for (left_expr, right_expr) in &join.on {
-            let left_bind = left.resolve(Self::column_name(left_expr)?)?;
-            let right_bind = right.resolve(Self::column_name(right_expr)?)?;
-            match (left_bind, right_bind) {
+            let left_name = Self::column_name(left_expr)?;
+            let right_name = Self::column_name(right_expr)?;
+            let left_bind = left.resolve(left_name)?;
+            let right_bind = right.resolve(right_name)?;
+            frame.check_same_type(
+                &left_bind,
+                &right_bind,
+                &format!("join condition {left_name} = {right_name}"),
+            )?;
+            match (&left_bind, &right_bind) {
                 (Bind::Var(l), _) => {
-                    frame.substitute(l, right_bind);
-                    left.substitute(l, right_bind);
+                    frame.substitute(*l, &right_bind);
+                    left.substitute(*l, &right_bind);
                 }
                 (Bind::Lit(_), Bind::Var(r)) => {
-                    frame.substitute(r, left_bind);
-                    right.substitute(r, left_bind);
+                    frame.substitute(*r, &left_bind);
+                    right.substitute(*r, &left_bind);
                 }
                 (Bind::Lit(a), Bind::Lit(b)) if a == b => {}
                 (Bind::Lit(a), Bind::Lit(b)) => {
@@ -468,7 +511,7 @@ impl Lowerer {
                     names.insert(name.clone(), None);
                 }
                 None => {
-                    names.insert(name.clone(), *bind);
+                    names.insert(name.clone(), bind.clone());
                 }
             }
         }
@@ -498,7 +541,7 @@ impl Lowerer {
 
         let mut names = merged.names;
         for (name, bind) in &columns {
-            names.insert(name.clone(), Some(*bind));
+            names.insert(name.clone(), Some(bind.clone()));
         }
         Ok(Scope { columns, names })
     }
@@ -539,18 +582,23 @@ impl Lowerer {
                     }
                     Some(kept) => {
                         carried.insert((*relation, column), None);
-                        match (kept, bind) {
+                        frame.check_same_type(
+                            &kept,
+                            &bind,
+                            &format!("join variable {}", variable.name),
+                        )?;
+                        match (&kept, &bind) {
                             (Bind::Var(l), _) => {
-                                frame.substitute(l, bind);
+                                frame.substitute(*l, &bind);
                                 for scope in &mut scopes {
-                                    scope.substitute(l, bind);
+                                    scope.substitute(*l, &bind);
                                 }
                                 bind
                             }
                             (Bind::Lit(_), Bind::Var(r)) => {
-                                frame.substitute(r, kept);
+                                frame.substitute(*r, &kept);
                                 for scope in &mut scopes {
-                                    scope.substitute(r, kept);
+                                    scope.substitute(*r, &kept);
                                 }
                                 kept
                             }
@@ -570,11 +618,13 @@ impl Lowerer {
         for (relation, scope) in scopes.iter().enumerate() {
             for (name, bind) in &scope.columns {
                 match carried.get(&(relation, name.clone())) {
-                    Some(Some(variable_name)) => columns.push((variable_name.clone(), *bind)),
+                    Some(Some(variable_name)) => {
+                        columns.push((variable_name.clone(), bind.clone()));
+                    }
                     Some(None) => {}
                     None => {
                         if columns.iter().all(|(active, _)| active != name) {
-                            columns.push((name.clone(), *bind));
+                            columns.push((name.clone(), bind.clone()));
                         }
                     }
                 }
@@ -587,12 +637,12 @@ impl Lowerer {
         for scope in &scopes {
             for (name, bind) in &scope.names {
                 if name.contains('.') {
-                    names.entry(name.clone()).or_insert(*bind);
+                    names.entry(name.clone()).or_insert(bind.clone());
                 }
             }
         }
         for (name, bind) in &columns {
-            names.insert(name.clone(), Some(*bind));
+            names.insert(name.clone(), Some(bind.clone()));
         }
         let merged = Scope {
             columns: columns.clone(),
@@ -615,7 +665,7 @@ impl Lowerer {
 
         let mut names = merged.names;
         for (name, bind) in &columns {
-            names.insert(name.clone(), Some(*bind));
+            names.insert(name.clone(), Some(bind.clone()));
         }
         Ok(Scope { columns, names })
     }
@@ -625,7 +675,7 @@ impl Lowerer {
     fn lower_attribute(&self, attribute: &Expr, scope: &Scope) -> Result<Bind> {
         match attribute {
             Expr::Var(var) => scope.resolve(&var.name),
-            Expr::Literal(literal) => Ok(Bind::Lit(Self::literal_u64(&literal.value)?)),
+            Expr::Literal(literal) => Ok(Bind::Lit(literal_value(&literal.value)?)),
             _ => bail!(
                 "computed attributes need the scalar engine and are not supported in this slice"
             ),
@@ -647,14 +697,23 @@ impl Lowerer {
             bail!("selection conditions beyond column = literal need the scalar engine");
         }
         let (column, literal) = match (&binary.left, &binary.right) {
-            (Expr::Var(var), Expr::Literal(lit)) => (&var.name, Self::literal_u64(&lit.value)?),
-            (Expr::Literal(lit), Expr::Var(var)) => (&var.name, Self::literal_u64(&lit.value)?),
+            (Expr::Var(var), Expr::Literal(lit)) => (&var.name, literal_value(&lit.value)?),
+            (Expr::Literal(lit), Expr::Var(var)) => (&var.name, literal_value(&lit.value)?),
             _ => bail!("selection conditions beyond column = literal need the scalar engine"),
         };
-        match scope.resolve(column)? {
+        let bind = scope.resolve(column)?;
+        let column_type = frame.ty(&bind);
+        if column_type != literal.scalar_type() {
+            bail!(
+                "selection compares column {column} ({column_type}) with the {} literal {literal}",
+                literal.scalar_type()
+            );
+        }
+        match bind {
             Bind::Var(v) => {
-                frame.substitute(v, Bind::Lit(literal));
-                scope.substitute(v, Bind::Lit(literal));
+                let pinned = Bind::Lit(literal);
+                frame.substitute(v, &pinned);
+                scope.substitute(v, &pinned);
             }
             Bind::Lit(existing) if existing == literal => {}
             Bind::Lit(existing) => {
@@ -718,14 +777,16 @@ impl Lowerer {
             _ => bail!("join conditions must reference columns by name"),
         }
     }
+}
 
-    fn literal_u64(literal: &Literal) -> Result<u64> {
-        match literal {
-            Literal::Uint(value) => Ok(*value),
-            Literal::Bool(value) => Ok(*value as u64),
-            _ => bail!("only unsigned integer and boolean literals are supported in this slice"),
-        }
-    }
+/// A schema for error messages: `(name: type, …)`.
+fn describe(schema: &Schema) -> String {
+    let columns: Vec<String> = schema
+        .columns()
+        .iter()
+        .map(|c| format!("{}: {}", c.name, c.ty))
+        .collect();
+    format!("({})", columns.join(", "))
 }
 
 #[cfg(test)]
@@ -741,8 +802,8 @@ mod tests {
         AliasExpr, AntiJoinExpr, CartesianProductExpr, DistinctExpr, JoinVariable, OutputExpr,
         ProjectionExpr, SelectionExpr, SinkId, SourceId, UnionExpr,
     };
-    use crate::relational::schema::{Column, EntityRef, TableSchema};
-    use crate::scalarial::ScalarType;
+    use crate::relational::schema::{Column as PlanColumn, EntityRef, TableSchema};
+    use crate::scalarial::ScalarType as PlanType;
     use coln_batch::fixpoint::{self, Exec};
     use coln_batch::generic_join;
     use coln_batch::query::Catalog;
@@ -755,25 +816,40 @@ mod tests {
         SourceId::from(name)
     }
 
-    /// One catalog for every rung: the base tables a plan may name.
+    /// One catalog for every rung: the base tables a plan may name. The
+    /// first three are plain unsigned integer tables; `person` carries
+    /// every kind of column the engine types.
     fn test_sources() -> SourceSchemas {
-        [
-            ("edge", ["from", "to"]),
-            ("r", ["a", "b"]),
-            ("s", ["c", "d"]),
+        let uint_tables = [
+            ("edge", vec!["from", "to"]),
+            ("r", vec!["a", "b"]),
+            ("s", vec!["c", "d"]),
         ]
         .into_iter()
         .map(|(name, columns)| {
             let columns = columns
                 .into_iter()
-                .map(|column| Column::new(column, ScalarType::Uint))
+                .map(|column| PlanColumn::new(column, PlanType::Uint))
                 .collect();
             (
                 SourceId::from(name),
                 TableSchema::new(EntityRef::from(name), columns, vec![]),
             )
-        })
-        .collect()
+        });
+        let person = (
+            SourceId::from("person"),
+            TableSchema::new(
+                EntityRef::from("person"),
+                vec![
+                    PlanColumn::new("id", PlanType::Uint),
+                    PlanColumn::new("name", PlanType::String),
+                    PlanColumn::new("age", PlanType::Iint),
+                    PlanColumn::new("active", PlanType::Bool),
+                ],
+                vec![],
+            ),
+        );
+        uint_tables.chain(std::iter::once(person)).collect()
     }
 
     fn lower_plan(stmts: Vec<Stmt>) -> Result<LoweredPlan> {
@@ -795,6 +871,10 @@ mod tests {
         Expr::from(LiteralExpr {
             value: Literal::Uint(value),
         })
+    }
+
+    fn literal(value: Literal) -> Expr {
+        Expr::from(LiteralExpr { value })
     }
 
     fn out(name: &str) -> Stmt {
@@ -824,6 +904,14 @@ mod tests {
             .collect()
     }
 
+    fn equals(column: &str, value: Literal) -> Expr {
+        Expr::from(BinaryExpr {
+            operator: Operator::Equal,
+            left: var(column),
+            right: literal(value),
+        })
+    }
+
     /// Run a lowered plan over hand-built relations with coln-batch's
     /// semi-naive fixpoint and the worst-case-optimal executor.
     fn run(plan: &LoweredPlan, edb: Catalog) -> Catalog {
@@ -847,6 +935,27 @@ mod tests {
         (0..relation.len()).map(|i| relation.row(i)).collect()
     }
 
+    /// The `person` table with typed rows, in a catalog of its own.
+    fn people() -> Catalog {
+        let mut edb = Catalog::new();
+        edb.insert_rows(
+            "person",
+            Schema::new([
+                Column::new("id", ScalarType::Uint),
+                Column::new("name", ScalarType::String),
+                Column::new("age", ScalarType::Iint),
+                Column::new("active", ScalarType::Bool),
+            ]),
+            vec![
+                vec![1u64.into(), "ann".into(), (-5i64).into(), true.into()],
+                vec![2u64.into(), "bob".into(), 30i64.into(), false.into()],
+                vec![3u64.into(), "ann".into(), 7i64.into(), true.into()],
+            ],
+        )
+        .unwrap();
+        edb
+    }
+
     /// Step 1: a source becomes a stored atom, a variable becomes a
     /// derived relation, and an output names what to read. The smallest
     /// possible translation: one rule that copies the source.
@@ -858,7 +967,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(plan.sources["edge"], vec!["from", "to"]);
+        assert_eq!(plan.sources["edge"].names(), vec!["from", "to"]);
         assert_eq!(plan.outputs["edges"], "edges");
         assert_eq!(plan.program.rules.len(), 1);
         let rule = &plan.program.rules[0];
@@ -894,7 +1003,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(plan.schemas["swapped"], vec!["target", "origin"]);
+        assert_eq!(plan.schemas["swapped"].names(), vec!["target", "origin"]);
 
         let result = run(&plan, {
             let mut edb = Catalog::new();
@@ -972,11 +1081,7 @@ mod tests {
                 "from_three",
                 SelectionExpr {
                     relation: Expr::from(SourceExpr::new(src("edge"))),
-                    condition: Expr::from(BinaryExpr {
-                        operator: Operator::Equal,
-                        left: var("from"),
-                        right: lit(3),
-                    }),
+                    condition: equals("from", Literal::Uint(3)),
                 },
             ),
             out("from_three"),
@@ -1133,7 +1238,7 @@ mod tests {
         // once, under its variable name.
         let rule = &plan.program.rules[1];
         assert_eq!(rule.body.len(), 3);
-        assert_eq!(plan.schemas["triangles"], vec!["x", "y", "z"]);
+        assert_eq!(plan.schemas["triangles"].names(), vec!["x", "y", "z"]);
 
         // Edges 1→2→3→1 close a triangle; 1→4 is a dead end. The three
         // result rows are the rotations of the one triangle.
@@ -1176,7 +1281,7 @@ mod tests {
         ])
         .unwrap();
 
-        assert_eq!(plan.schemas["joined"], vec!["a", "d"]);
+        assert_eq!(plan.schemas["joined"].names(), vec!["a", "d"]);
 
         let result = run(&plan, {
             let mut edb = Catalog::new();
@@ -1345,7 +1450,7 @@ mod tests {
                 attributes: vec![(
                     "sum".to_string(),
                     Expr::from(BinaryExpr {
-                        operator: Operator::Addition,
+                        operator: Operator::Less,
                         left: var("a"),
                         right: var("b"),
                     }),
@@ -1353,6 +1458,171 @@ mod tests {
             },
         )])
         .unwrap_err();
-        assert!(format!("{err:#}").contains("scalar engine"));
+        assert!(format!("{err:#}").contains("scalar engine"), "{err:#}");
+
+        let err = lower_plan(vec![let_rel("missing", SourceExpr::new(src("nope")))]).unwrap_err();
+        assert!(err.to_string().contains("not in the catalog"));
+
+        let err = lower_plan(vec![let_rel(
+            "nested",
+            ProjectionExpr {
+                relation: Expr::from(OutputExpr {
+                    relation: Expr::from(SourceExpr::new(src("r"))),
+                    id: SinkId::from("inner"),
+                    kind: OutputKind::Channel,
+                }),
+                attributes: named_columns(&[("a", "a")]),
+            },
+        )])
+        .unwrap_err();
+        assert!(err.to_string().contains("nested"));
+    }
+
+    /// Step 15: columns keep their types. A source's schema types the
+    /// rule variables, a selection may pin a string or a signed integer,
+    /// and a derived relation's schema carries the types on, so the
+    /// engine decodes real values on the way out.
+    #[test]
+    fn s15_columns_keep_their_types() {
+        let plan = lower_plan(vec![
+            let_rel(
+                "anns",
+                SelectionExpr {
+                    relation: Expr::from(SourceExpr::new(src("person"))),
+                    condition: equals("name", Literal::String("ann".into())),
+                },
+            ),
+            let_rel(
+                "young",
+                SelectionExpr {
+                    relation: var("anns"),
+                    condition: equals("age", Literal::Iint(-5)),
+                },
+            ),
+            let_rel(
+                "picked",
+                ProjectionExpr {
+                    relation: var("young"),
+                    attributes: vec![
+                        ("who".to_string(), var("name")),
+                        ("id".to_string(), var("id")),
+                        ("note".to_string(), literal(Literal::String("seen".into()))),
+                    ],
+                },
+            ),
+            out("picked"),
+        ])
+        .unwrap();
+
+        assert_eq!(
+            plan.sources["person"].types(),
+            vec![
+                ScalarType::Uint,
+                ScalarType::String,
+                ScalarType::Iint,
+                ScalarType::Bool
+            ]
+        );
+        assert_eq!(plan.schemas["picked"].names(), vec!["who", "id", "note"]);
+        assert_eq!(
+            plan.schemas["picked"].types(),
+            vec![ScalarType::String, ScalarType::Uint, ScalarType::String]
+        );
+
+        let result = run(&plan, people());
+        assert_eq!(
+            result.rows_of("picked").unwrap(),
+            vec![vec!["ann".into(), 1u64.into(), "seen".into()]]
+        );
+        // The unknown name never matches, and that is not an error.
+        let plan = lower_plan(vec![
+            let_rel(
+                "nobody",
+                SelectionExpr {
+                    relation: Expr::from(SourceExpr::new(src("person"))),
+                    condition: equals("name", Literal::String("zed".into())),
+                },
+            ),
+            out("nobody"),
+        ])
+        .unwrap();
+        assert!(run(&plan, people()).get("nobody").unwrap().is_empty());
+    }
+
+    /// Step 16: type errors are lowering errors. Joining or comparing
+    /// columns of different types is rejected before any data is read.
+    #[test]
+    fn s16_type_mismatches_fail_at_lowering() {
+        // A uint column joined with a string column.
+        let err = lower_plan(vec![let_rel(
+            "bad_join",
+            EquiJoinExpr {
+                left: Expr::from(SourceExpr::new(src("r"))),
+                right: Expr::from(SourceExpr::new(src("person"))),
+                on: vec![(var("a"), var("name"))],
+                attributes: None,
+            },
+        )])
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("uint column with a string column"),
+            "{err}"
+        );
+
+        // A string column compared with an integer literal.
+        let err = lower_plan(vec![let_rel(
+            "bad_selection",
+            SelectionExpr {
+                relation: Expr::from(SourceExpr::new(src("person"))),
+                condition: equals("name", Literal::Uint(3)),
+            },
+        )])
+        .unwrap_err();
+        assert!(
+            err.to_string().contains("(string) with the uint literal 3"),
+            "{err}"
+        );
+
+        // A multi-way join variable spanning two types.
+        let err = lower_plan(vec![let_rel(
+            "bad_multi",
+            MultiWayEquiJoinExpr::new(
+                vec![
+                    Expr::from(SourceExpr::new(src("r"))),
+                    Expr::from(SourceExpr::new(src("person"))),
+                ],
+                vec![join_variable("k", &[(0, "a"), (1, "age")])],
+                None,
+            )
+            .unwrap(),
+        )])
+        .unwrap_err();
+        assert!(err.to_string().contains("join variable k"), "{err}");
+
+        // Union branches must agree on types, not only on arity.
+        let err = lower_plan(vec![
+            let_rel(
+                "ids",
+                ProjectionExpr {
+                    relation: Expr::from(SourceExpr::new(src("person"))),
+                    attributes: named_columns(&[("v", "id")]),
+                },
+            ),
+            let_rel(
+                "names",
+                ProjectionExpr {
+                    relation: Expr::from(SourceExpr::new(src("person"))),
+                    attributes: named_columns(&[("v", "name")]),
+                },
+            ),
+            let_rel(
+                "mixed",
+                UnionExpr {
+                    relations: vec![var("ids"), var("names")],
+                },
+            ),
+        ])
+        .unwrap_err();
+        assert!(err.to_string().contains("different schemas"), "{err}");
     }
 }

--- a/packages/coln-query/src/relational/batch/mod.rs
+++ b/packages/coln-query/src/relational/batch/mod.rs
@@ -12,10 +12,12 @@
 //! [`Snapshot`]. Where the incremental backend reports deltas, this backend
 //! reports states.
 //!
-//! Value scope of this slice: unsigned integers and booleans, mapped onto
-//! the engine's u64 universe.
-// TODO(Jan): the remaining scalar types (strings first, via dictionary
-// encoding) land after the end-to-end slice is complete.
+//! Values keep their plan types end to end: unsigned and signed integers,
+//! booleans, characters and strings. The engine stores every cell as a
+//! typed key (see `coln_batch::types`); strings go through a dictionary
+//! the runtime owns, so their keys stay stable across commits. `Null` is
+//! the one plan type the backend refuses, at build time for schemas and at
+//! feed time for rows.
 //!
 //! # Interim: base tables arrive by push
 //!
@@ -40,6 +42,7 @@
 // lowering, fixpoint, and output stay as they are.
 
 mod lowering;
+mod values;
 
 use std::collections::HashMap;
 use std::num::NonZeroUsize;
@@ -49,9 +52,11 @@ use coln_batch::generic_join;
 use coln_batch::query::Catalog as BatchCatalog;
 use coln_batch::relation::Relation;
 use coln_batch::rule::Program;
+use coln_batch::types::{Dictionary, Key, Schema};
 use dbsp::{OrdZSet, utils::Tup2};
 
 use self::lowering::{LoweredPlan, lower};
+use self::values::{engine_value, pipeline_value};
 use super::{Backend, Runtime};
 use crate::{
     api::deltas::{ZRow, ZWeight},
@@ -62,7 +67,7 @@ use crate::{
         expr::{SinkId, SourceId},
         relation::TupleValue,
     },
-    scalarial::{ColumnScalarEngine, ScalarTypedValue, column::VectorizedScalarEngine},
+    scalarial::{ColumnScalarEngine, column::VectorizedScalarEngine},
 };
 
 /// The non-incremental backend: lowers the plan to a coln-batch Datalog
@@ -111,6 +116,7 @@ impl<E: ColumnScalarEngine> Backend for BatchBackend<E> {
             program,
             outputs,
             schemas,
+            dictionary: Dictionary::new(),
             inputs,
             sinks,
             results: None,
@@ -124,22 +130,27 @@ pub struct BatchRuntime {
     program: Program,
     /// Sink id to the derived relation `output` reads.
     outputs: HashMap<String, String>,
-    /// Column names per relation, sources and derived alike.
-    schemas: HashMap<String, Vec<String>>,
-    /// Per used source: the net z-weight of every row fed so far. This is
-    /// the interim snapshot store described in the module docs; the pull
-    /// API replaces it.
-    inputs: HashMap<String, HashMap<Vec<u64>, ZWeight>>,
+    /// Schema (column names and types) per relation, sources and derived
+    /// alike.
+    schemas: HashMap<String, Schema>,
+    /// String codes for every row fed so far. Stable for the life of the
+    /// runtime; every commit's catalog starts from a copy of it.
+    dictionary: Dictionary,
+    /// Per used source: the net z-weight of every row fed so far, as
+    /// keys. This is the interim snapshot store described in the module
+    /// docs; the pull API replaces it.
+    inputs: HashMap<String, HashMap<Vec<Key>, ZWeight>>,
     sinks: Vec<SinkId>,
-    /// The relations of the last commit.
+    /// The relations of the last commit, with the dictionary that decodes
+    /// them.
     results: Option<BatchCatalog>,
 }
 
 /// The full current state of a result relation, the natural output of a
 /// batch backend (the incremental backend reports deltas instead).
 ///
-/// Rows are sorted and deduplicated: results are sets. Values come back as
-/// unsigned integers, matching the value slice the backend accepts.
+/// Rows are sorted and deduplicated: results are sets. Every cell carries
+/// the type the plan gave its column.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Snapshot {
     columns: Vec<String>,
@@ -147,17 +158,21 @@ pub struct Snapshot {
 }
 
 impl Snapshot {
-    fn from_relation(columns: Vec<String>, relation: &Relation) -> Self {
-        let rows = (0..relation.len())
-            .map(|row| TupleValue {
-                data: relation
-                    .row(row)
-                    .into_iter()
-                    .map(ScalarTypedValue::Uint)
-                    .collect(),
-            })
-            .collect();
-        Self { columns, rows }
+    fn from_relation(
+        columns: Vec<String>,
+        relation: &Relation,
+        dictionary: &Dictionary,
+    ) -> Result<Self, RuntimeError> {
+        let mut rows = Vec::with_capacity(relation.len());
+        for i in 0..relation.len() {
+            let values = relation
+                .row_values(i, dictionary)
+                .map_err(|error| RuntimeError::new(format!("{error:#}")))?;
+            rows.push(TupleValue {
+                data: values.into_iter().map(pipeline_value).collect(),
+            });
+        }
+        Ok(Self { columns, rows })
     }
 
     /// The result's column names, in tuple order.
@@ -200,9 +215,10 @@ impl BatchRuntime {
     // TODO(Jan): swap for the pull API once the pipeline offers one.
     fn materialize_sources(&self) -> Result<BatchCatalog, RuntimeError> {
         let mut edb = BatchCatalog::new();
+        *edb.dictionary_mut() = self.dictionary.clone();
         for (source, staged) in &self.inputs {
-            let columns = self.schemas.get(source).cloned().unwrap_or_default();
-            let mut data: Vec<Vec<u64>> = vec![Vec::new(); columns.len()];
+            let schema = self.schemas.get(source).cloned().unwrap_or_default();
+            let mut data: Vec<Vec<Key>> = vec![Vec::new(); schema.arity()];
             for (row, weight) in staged {
                 match weight {
                     weight if *weight < 0 => {
@@ -214,15 +230,51 @@ impl BatchRuntime {
                     0 => {}
                     // Sets: duplicated insertions collapse into one row.
                     _ => {
-                        for (column, value) in data.iter_mut().zip(row) {
-                            column.push(*value);
+                        for (column, key) in data.iter_mut().zip(row) {
+                            column.push(*key);
                         }
                     }
                 }
             }
-            edb.insert(Relation::new(source.clone(), columns, data));
+            edb.insert(Relation::with_schema(source.clone(), schema, data));
         }
         Ok(edb)
+    }
+
+    /// Encode one fed row against its source's schema.
+    fn encode_row(
+        &mut self,
+        source: &SourceId,
+        row: &TupleValue,
+    ) -> Result<Vec<Key>, RuntimeError> {
+        let schema = self
+            .schemas
+            .get(source.as_str())
+            .expect("checked by the caller: the plan uses this source");
+        if row.data.len() != schema.arity() {
+            return Err(RuntimeError::new(format!(
+                "row for source '{}' has {} values, its schema has {} columns",
+                source.as_str(),
+                row.data.len(),
+                schema.arity()
+            )));
+        }
+        let mut keys = Vec::with_capacity(row.data.len());
+        for (col, cell) in row.data.iter().enumerate() {
+            let value = engine_value(cell).map_err(|error| {
+                RuntimeError::new(format!("source '{}': {error:#}", source.as_str()))
+            })?;
+            let expected = schema.column_type(col);
+            if value.scalar_type() != expected {
+                return Err(RuntimeError::new(format!(
+                    "source '{}', column {}: expected {expected}, got {value}",
+                    source.as_str(),
+                    schema.name(col)
+                )));
+            }
+            keys.push(value.to_key(&mut self.dictionary));
+        }
+        Ok(keys)
     }
 }
 
@@ -237,14 +289,14 @@ impl Runtime for BatchRuntime {
     ) -> Result<bool, Self::Error> {
         // Mirrors the incremental backend: a source the plan does not use
         // is `Ok(false)`, not an error. The caller decides what that means.
-        let arity = self.schemas.get(source.as_str()).map_or(0, Vec::len);
-        let Some(staged) = self.inputs.get_mut(source.as_str()) else {
+        if !self.inputs.contains_key(source.as_str()) {
             return Ok(false);
-        };
+        }
         for zrow in rows {
             let weight = zrow.zweight();
-            let row = convert_row(source, &zrow.into_row(), arity)?;
-            *staged.entry(row).or_insert(0) += weight;
+            let keys = self.encode_row(source, &zrow.into_row())?;
+            let staged = self.inputs.get_mut(source.as_str()).expect("checked above");
+            *staged.entry(keys).or_insert(0) += weight;
         }
         Ok(true)
     }
@@ -269,45 +321,18 @@ impl Runtime for BatchRuntime {
         };
         // The engine names rule variables generically (v0, v1, …); the
         // plan's speaking column names live in the schema table.
-        let columns = self.schemas.get(relation).cloned().unwrap_or_default();
+        let columns = self
+            .schemas
+            .get(relation)
+            .map(Schema::names)
+            .unwrap_or_default();
         let relation = results
             .get(relation)
             .map_err(|error| RuntimeError::new(format!("{error:#}")))?;
-        Ok(Snapshot::from_relation(columns, relation))
+        Snapshot::from_relation(columns, relation, results.dictionary())
     }
 
     fn list_outputs(&self) -> impl Iterator<Item = &'_ SinkId> {
         self.sinks.iter()
     }
-}
-
-/// Convert one staged row into the engine's u64 universe.
-///
-/// This slice accepts unsigned integers and booleans; everything else
-/// fails loudly instead of computing something wrong.
-// TODO(Jan): remaining scalar types after the end-to-end slice.
-fn convert_row(
-    source: &SourceId,
-    row: &TupleValue,
-    arity: usize,
-) -> Result<Vec<u64>, RuntimeError> {
-    if row.data.len() != arity {
-        return Err(RuntimeError::new(format!(
-            "row for source '{}' has {} values, its schema has {arity} columns",
-            source.as_str(),
-            row.data.len()
-        )));
-    }
-    row.data
-        .iter()
-        .map(|value| match value {
-            ScalarTypedValue::Uint(value) => Ok(*value),
-            ScalarTypedValue::Bool(value) => Ok(u64::from(*value)),
-            other => Err(RuntimeError::new(format!(
-                "source '{}': the batch backend supports unsigned integer and boolean \
-                 values for now, got {other:?}",
-                source.as_str()
-            ))),
-        })
-        .collect()
 }

--- a/packages/coln-query/src/relational/batch/values.rs
+++ b/packages/coln-query/src/relational/batch/values.rs
@@ -1,0 +1,122 @@
+// SPDX-FileCopyrightText: 2026 Coln contributors
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Conversions between the pipeline's scalar vocabulary and the batch
+//! engine's. The two agree on every type except `Null`, which the engine
+//! does not store: a schema or row carrying it is rejected at the
+//! boundary instead of being mapped to something else.
+
+use anyhow::{Result, bail};
+use coln_batch::types::{Column as BatchColumn, ScalarType as BatchType, Schema, Value};
+
+use crate::host::expr::Literal;
+use crate::relational::schema::TableSchema;
+use crate::scalarial::{ScalarType, ScalarTypedValue};
+
+/// The engine's type for a plan type.
+pub(crate) fn batch_type(ty: ScalarType) -> Result<BatchType> {
+    Ok(match ty {
+        ScalarType::Uint => BatchType::Uint,
+        ScalarType::Iint => BatchType::Iint,
+        ScalarType::Bool => BatchType::Bool,
+        ScalarType::Char => BatchType::Char,
+        ScalarType::String => BatchType::String,
+        ScalarType::Null => bail!("the batch backend does not store null values"),
+    })
+}
+
+/// The plan type for an engine type.
+pub(crate) fn plan_type(ty: BatchType) -> ScalarType {
+    match ty {
+        BatchType::Uint => ScalarType::Uint,
+        BatchType::Iint => ScalarType::Iint,
+        BatchType::Bool => ScalarType::Bool,
+        BatchType::Char => ScalarType::Char,
+        BatchType::String => ScalarType::String,
+    }
+}
+
+/// A base table's schema in the engine's vocabulary.
+pub(crate) fn batch_schema(schema: &TableSchema) -> Result<Schema> {
+    schema
+        .columns()
+        .iter()
+        .map(|column| {
+            Ok(BatchColumn::new(
+                column.name(),
+                batch_type(column.scalar_type())?,
+            ))
+        })
+        .collect()
+}
+
+/// A plan literal as an engine value.
+pub(crate) fn literal_value(literal: &Literal) -> Result<Value> {
+    Ok(match literal {
+        Literal::String(s) => Value::String(s.clone()),
+        Literal::Uint(u) => Value::Uint(*u),
+        Literal::Iint(i) => Value::Iint(*i),
+        Literal::Bool(b) => Value::Bool(*b),
+        Literal::Null(()) => bail!("the batch backend does not support null literals"),
+    })
+}
+
+/// A fed cell as an engine value.
+pub(crate) fn engine_value(value: &ScalarTypedValue) -> Result<Value> {
+    Ok(match value {
+        ScalarTypedValue::String(s) => Value::String(s.clone()),
+        ScalarTypedValue::Uint(u) => Value::Uint(*u),
+        ScalarTypedValue::Iint(i) => Value::Iint(*i),
+        ScalarTypedValue::Bool(b) => Value::Bool(*b),
+        ScalarTypedValue::Char(c) => Value::Char(*c),
+        ScalarTypedValue::Null(()) => bail!("the batch backend does not store null values"),
+    })
+}
+
+/// An engine value as a pipeline cell.
+pub(crate) fn pipeline_value(value: Value) -> ScalarTypedValue {
+    match value {
+        Value::String(s) => ScalarTypedValue::String(s),
+        Value::Uint(u) => ScalarTypedValue::Uint(u),
+        Value::Iint(i) => ScalarTypedValue::Iint(i),
+        Value::Bool(b) => ScalarTypedValue::Bool(b),
+        Value::Char(c) => ScalarTypedValue::Char(c),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_type_maps_both_ways_except_null() {
+        for ty in [
+            ScalarType::Uint,
+            ScalarType::Iint,
+            ScalarType::Bool,
+            ScalarType::Char,
+            ScalarType::String,
+        ] {
+            assert_eq!(plan_type(batch_type(ty).unwrap()), ty);
+        }
+        assert!(batch_type(ScalarType::Null).is_err());
+    }
+
+    #[test]
+    fn values_round_trip() {
+        let values = [
+            ScalarTypedValue::Uint(7),
+            ScalarTypedValue::Iint(-7),
+            ScalarTypedValue::Bool(true),
+            ScalarTypedValue::Char('x'),
+            ScalarTypedValue::String("seven".into()),
+        ];
+        for value in values {
+            assert_eq!(pipeline_value(engine_value(&value).unwrap()), value);
+        }
+        assert!(engine_value(&ScalarTypedValue::Null(())).is_err());
+        assert!(literal_value(&Literal::Null(())).is_err());
+        assert_eq!(literal_value(&Literal::Iint(-1)).unwrap(), Value::Iint(-1));
+    }
+}


### PR DESCRIPTION
## What
**This is wiring up coln-query to make use of the "new" typed batch-engine**.

Until now the batch backend in coln-query only accepted uint and bool
columns. Anything else failed at feed time. With the typed engine from
#152 in place, this PR makes the backend pass the plan's column types
through, so coln-query can run plans with signed integers, booleans,
characters and strings on the batch engine. Null is rejected.

## How

- `lowering.rs` carries each column's type from the source schemas into
  the engine program and checks joins, selections and unions against
  it. A type error fails while lowering, before any data is read.
- `mod.rs`: feed converts the plan's values into engine values, output
  converts them back. The runtime owns the string dictionary.
- `values.rs` holds the conversions between coln-query's scalar types
  and the engine's.

## Testing

`cargo test -p coln-query batch`
- The same two-hop join and the same transitive closure run over each
  of the five types on the batch and the incremental backend. The
  results must be identical.
- The standard join with string names runs on the batch backend.
- Wrong cell types, wrong row widths and null fail with a clear error.