### PR TITLE
Make values Iterable

### DIFF
--- a/packages/coln-js-runtime/src/ts/ColnSet.ts
+++ b/packages/coln-js-runtime/src/ts/ColnSet.ts
@@ -6,7 +6,7 @@ import { Value, RowView  } from "#wasm-bodge/bindings";
 
 export interface View {
   has(x: Value): boolean;
-  values(): Iterator<RowView>;
+  values(): IterableIterator<RowView>;
 }
 
 export interface Transaction extends View {

--- a/packages/coln-js-runtime/src/ts/RowIdSet.ts
+++ b/packages/coln-js-runtime/src/ts/RowIdSet.ts
@@ -26,7 +26,7 @@ export class View implements ColnSet.View {
     return row !== undefined && tupleEqual(row.values, this.params);
   }
 
-  values(): Iterator<RowView> {
+  values(): IterableIterator<RowView> {
     const rows = this.store.scanTable(this.path);
 
     return rows.filter((row) => tupleEqual(row.values, this.params)).values();

--- a/packages/coln-js-runtime/tests/basic-ir/prop.test.ts
+++ b/packages/coln-js-runtime/tests/basic-ir/prop.test.ts
@@ -22,6 +22,7 @@ test("prop", () => {
   const view = realm.commit();
 
   assert.equal(view.V.has(value), true);
+  assert.equal([...view.V.values()].length, 1);
 });
 
 test("prop canonicalizes proofs", { expectFailure: true }, () => {


### PR DESCRIPTION
Changes `ColnSet.View.values()` to return `IterableIterator<RowView>` instead of just `Iterator`

This is a change of type only, and matches the existing runtime implementation, with a test to confirm